### PR TITLE
feat: offset_other dynamically matches offset_top

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -55,7 +55,7 @@ Rounds a range/list. Applies different offsets to top magnitude(s) vs others.
 | Parameter | Default |
 |-----------|---------|
 | offset_top | -0.5 |
-| offset_other | -0.5 |
+| offset_other | matches offset_top |
 | num_top | 1 |
 
 

--- a/js/README.md
+++ b/js/README.md
@@ -54,7 +54,7 @@ Rounds an entire range with dataset-aware behavior: larger numbers retain more d
 | 459,321 | 450,000 |
 | 6,543 | 6,500 |
 
-Defaults: `offset_top = -0.5`, `offset_other = -0.5`, `num_top = 1`
+Defaults: `offset_top = -0.5`, `offset_other = matches offset_top`, `num_top = 1`
 
 ---
 
@@ -105,7 +105,7 @@ Offset is an order-of-magnitude adjustment. Negative = finer precision, positive
 |-----------|---------|-------------|
 | range | required | Range for rounding and/or magnitude detection |
 | offset_top | -0.5 | Offset for top magnitude(s) |
-| offset_other | -0.5 | Offset for other magnitudes |
+| offset_other | matches offset_top | Offset for other magnitudes |
 | num_top | 1 | How many top orders get offset_top |
 
 ---

--- a/js/round_dynamic.js
+++ b/js/round_dynamic.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding - Dynamic rounding for readable data sets
- * Version: 0.2.6
+ * Version: 0.2.7
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  */
@@ -11,7 +11,6 @@ const PARENS_REGEX = /^\((.+)\)$/;
 
 // parameters' default values
 const DEFAULT_OFFSET_TOP = -0.5; // in all modes, by default, round to the nearest half order of magnitude
-const DEFAULT_OFFSET_OTHER = -0.5; // in dataset-aware modes, by default round numbers that are not in the top orders of magnitude to their nearest half order of magnitude
 const DEFAULT_NUM_TOP = 1; // in dataset-aware modes, by default, round numbers that are in the top 1 order of magnitude to DEFAULT_OFFSET_TOP
 
 // Internal constants
@@ -26,7 +25,7 @@ const EPSILON = 1e-9; // used to handle floating point inaccuracies
  *
  * @param {number|Array} values The value or range of values to round.
  * @param {number} offset_top The OoM offset for the single value, or, the numbers in the largest order of magnitude of a dataset (default -0.5).
- * @param {number} offset_other The OoM offset for other magnitudes in a dataset (default -0.5).
+ * @param {number} offset_other The OoM offset for other magnitudes in a dataset (defaults to matching offset_top).
  * @param {number} num_top How many top orders of magnitude get offset_top (default 1).
  * @return Simplified data.
  * @customfunction
@@ -66,7 +65,7 @@ function singleValueMode(value, offset) {
  */
 function datasetMode(range, offset_top, offset_other, num_top) {
   offset_top = (offset_top === undefined || offset_top === "") ? DEFAULT_OFFSET_TOP : offset_top;
-  offset_other = (offset_other === undefined || offset_other === "") ? DEFAULT_OFFSET_OTHER : offset_other;
+  offset_other = (offset_other === undefined || offset_other === "") ? offset_top : offset_other;
   num_top = (num_top === undefined || num_top === "") ? DEFAULT_NUM_TOP : num_top;
   validateOffset(offset_top, "offset_top");
   validateOffset(offset_other, "offset_other");

--- a/js/tests.js
+++ b/js/tests.js
@@ -172,6 +172,22 @@ testArray('GCP defaults', ROUND_DYNAMIC(gcpData), [
     [45]         // mag 1, offset=-0.5
 ]);
 
+// offset_top=-1, offset_other falls back to offset_top=-1
+testArray('GCP offset_other fallback', ROUND_DYNAMIC(gcpData, -1), [
+    [4400000],
+    [3900000],
+    [1000000],
+    [980000],
+    [820000],
+    [84000],
+    [42000],
+    [22000],
+    [1500],
+    [1100],
+    [67],
+    [43]
+]);
+
 // offset_top=-1, offset_other=0, num_top=1
 // Mag 6 gets offset=-1 (base=100k), others get offset=0
 testArray('GCP offset_top=-1', ROUND_DYNAMIC(gcpData, -1, 0, 1), [

--- a/python/README.md
+++ b/python/README.md
@@ -72,7 +72,7 @@ round_dynamic_series(s)  # → [1000.0, -500.0, 4500000.0]
 **Dataset mode** (when `data` is a list):
 - `data`: List of numbers to round
 - `offset_top`: OoM adjustment for top magnitude(s) (default: -0.5)
-- `offset_other`: OoM adjustment for other magnitudes (default: -0.5)
+- `offset_other`: OoM adjustment for other magnitudes (defaults to matching `offset_top`)
 - `num_top`: How many top orders get `offset_top` (default: 1)
 - `enforce_numeric`: If `True`, raises `ValueError` for non-numeric values in list
 

--- a/python/dynamic_rounding/__init__.py
+++ b/python/dynamic_rounding/__init__.py
@@ -1,6 +1,6 @@
 """
 DynamicRounding - Dynamic rounding for readable data
-Version: 0.1.3
+Version: 0.1.4
 https://github.com/ArieFisher/dynamic-rounding
 MIT License
 """
@@ -8,7 +8,7 @@ MIT License
 import math
 from typing import Union, List, Optional, Any
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Constants
 DEFAULT_OFFSET = -0.5
@@ -97,7 +97,7 @@ def _dataset_mode(
     if offset_top is None:
         offset_top = DEFAULT_OFFSET
     if offset_other is None:
-        offset_other = -0.5
+        offset_other = offset_top
     
     _validate_offset(offset_top, "offset_top")
     _validate_offset(offset_other, "offset_other")

--- a/python/dynamic_rounding/pandas.py
+++ b/python/dynamic_rounding/pandas.py
@@ -161,7 +161,7 @@ def _dataset_mode_series(
     if offset_top is None:
         offset_top = DEFAULT_OFFSET
     if offset_other is None:
-        offset_other = -0.5
+        offset_other = offset_top
     
     _validate_offset(offset_top, "offset_top")
     _validate_offset(offset_other, "offset_other")

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -112,12 +112,13 @@ class TestDatasetMode:
     def test_default_offsets(self):
         result = round_dynamic([4428910, 983321, 42109])
         assert result[0] == 4500000  # top magnitude: offset_top=-0.5
-        assert result[1] == 1000000  # other: offset_other=0
-        assert result[2] == 40000    # other: offset_other=0
+        assert result[1] == 1000000  # other: offset_other=-0.5
+        assert result[2] == 40000    # other: offset_other=-0.5
     
     def test_custom_offset_top(self):
         result = round_dynamic([4428910, 983321], offset_top=-1)
-        assert result[0] == 4400000  # finer precision
+        assert result[0] == 4400000  # top: offset_top=-1
+        assert result[1] == 980000   # other: falls back to offset_top=-1
     
     def test_custom_offset_other(self):
         result = round_dynamic([4428910, 983321], offset_top=-0.5, offset_other=-1)

--- a/python/tests/test_pandas.py
+++ b/python/tests/test_pandas.py
@@ -126,11 +126,13 @@ class TestDatasetModeSeries:
         s = pd.Series([4428910, 983321])
         result = round_dynamic_series(s, offset_top=-1)
         assert result[0] == 4400000
+        assert result[1] == 980000
     
     def test_triggers_on_offset_other(self):
         # Just providing offset_other should trigger dataset mode
         s = pd.Series([4428910, 983321])
         result = round_dynamic_series(s, offset_other=-1)
+        assert result[0] == 4500000
         assert result[1] == 980000
     
     def test_num_top(self):


### PR DESCRIPTION
Updates the offset_other fallback to match offset_top instead of a hardcoded constant.