### PR TITLE
Fix for Chrome plugin not working on negative numbers

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -179,6 +179,7 @@ function toNumber(value) {
   }
   if (typeof value === "string" && value.trim() !== "") {
     let cleaned = value.trim()
+      .replace(/[‐-―−﹘﹣－]/g, "-")
       .replace(CLEAN_REGEX, "")
       .replace(PARENS_REGEX, "-$1");
     const parsed = Number(cleaned);


### PR DESCRIPTION
Many websites use Unicode dash characters (en dash, em dash, U+2212 minus sign, fullwidth hyphen, etc.) instead of ASCII hyphen-minus. JavaScript's Number() does not recognize these.  So toNumber() returned null for values like '−3.70%', causing those cells to be silently skipped.

Normalizes the full range of Unicode dash characters to ASCII '-' before parsing: U+2010–U+2015, U+2212, U+FE58, U+FE63, U+FF0D.