### PR TITLE
chrome extension: User can toggle simplified / original values

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -14,18 +14,14 @@ chrome.runtime.onInstalled.addListener(() => {
   });
 });
 
-chrome.contextMenus.onShown.addListener((info, tab) => {
-  if (!info.menuIds.includes("dr-action")) return;
-  chrome.tabs.sendMessage(tab.id, { action: "GET_MENU_LABEL" }, (response) => {
-    if (response && response.title) {
-      chrome.contextMenus.update("dr-action", { title: response.title });
-      chrome.contextMenus.refresh();
-    }
-  });
-});
-
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "dr-action") {
     chrome.tabs.sendMessage(tab.id, { action: "MENU_CLICKED" });
+  }
+});
+
+chrome.runtime.onMessage.addListener((request, sender) => {
+  if (request.action === "UPDATE_MENU_LABEL") {
+    chrome.contextMenus.update("dr-action", { title: request.title });
   }
 });

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -8,27 +8,20 @@
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
-    id: "round-table",
+    id: "dr-action",
     title: "Round table dynamically",
-    contexts: ["all"]
-  });
-  chrome.contextMenus.create({
-    id: "show-original",
-    title: "Show original values",
     contexts: ["all"]
   });
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
-  if (info.menuItemId === "round-table") {
-    chrome.tabs.sendMessage(tab.id, { action: "ROUND_TABLE" });
-  } else if (info.menuItemId === "show-original") {
-    chrome.tabs.sendMessage(tab.id, { action: "TOGGLE_ORIGINAL" });
+  if (info.menuItemId === "dr-action") {
+    chrome.tabs.sendMessage(tab.id, { action: "MENU_CLICKED" });
   }
 });
 
 chrome.runtime.onMessage.addListener((request, sender) => {
-  if (request.action === "UPDATE_TOGGLE_LABEL") {
-    chrome.contextMenus.update("show-original", { title: request.title });
+  if (request.action === "UPDATE_MENU_LABEL") {
+    chrome.contextMenus.update("dr-action", { title: request.title });
   }
 });

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -12,10 +12,23 @@ chrome.runtime.onInstalled.addListener(() => {
     title: "Round table dynamically",
     contexts: ["all"]
   });
+  chrome.contextMenus.create({
+    id: "show-original",
+    title: "Show original values",
+    contexts: ["all"]
+  });
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "round-table") {
     chrome.tabs.sendMessage(tab.id, { action: "ROUND_TABLE" });
+  } else if (info.menuItemId === "show-original") {
+    chrome.tabs.sendMessage(tab.id, { action: "TOGGLE_ORIGINAL" });
+  }
+});
+
+chrome.runtime.onMessage.addListener((request, sender) => {
+  if (request.action === "UPDATE_TOGGLE_LABEL") {
+    chrome.contextMenus.update("show-original", { title: request.title });
   }
 });

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -14,14 +14,18 @@ chrome.runtime.onInstalled.addListener(() => {
   });
 });
 
+chrome.contextMenus.onShown.addListener((info, tab) => {
+  if (!info.menuIds.includes("dr-action")) return;
+  chrome.tabs.sendMessage(tab.id, { action: "GET_MENU_LABEL" }, (response) => {
+    if (response && response.title) {
+      chrome.contextMenus.update("dr-action", { title: response.title });
+      chrome.contextMenus.refresh();
+    }
+  });
+});
+
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "dr-action") {
     chrome.tabs.sendMessage(tab.id, { action: "MENU_CLICKED" });
-  }
-});
-
-chrome.runtime.onMessage.addListener((request, sender) => {
-  if (request.action === "UPDATE_MENU_LABEL") {
-    chrome.contextMenus.update("dr-action", { title: request.title });
   }
 });

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -30,6 +30,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         console.warn("Dynamic Rounding: No table found at right-click location.");
       }
     }
+  } else if (request.action === 'TOGGLE_ORIGINAL') {
+    if (lastRightClickedElement) {
+      const table = lastRightClickedElement.closest('table');
+      if (table) {
+        toggleOriginalValues(table);
+      }
+    }
   }
 });
 
@@ -68,16 +75,45 @@ function roundTable(table) {
         
         // Replace text while preserving HTML elements (for font, size, etc)
         replaceTextPreservingHTML(cell, originalValue, formattedValue);
-        
+
         // Tooltip for original value
         cell.title = `Original: ${originalValue}`;
-        
+
         // Prepare for future toggles
         cell.classList.add('dr-ext-rounded');
         cell.dataset.originalValue = originalValue;
+        cell.dataset.roundedValue = formattedValue;
       }
     }
   }
+}
+
+function toggleOriginalValues(table) {
+  const roundedCells = table.querySelectorAll('.dr-ext-rounded');
+  if (roundedCells.length === 0) return;
+
+  const showingOriginal = table.dataset.drShowingOriginal === 'true';
+
+  for (const cell of roundedCells) {
+    const original = cell.dataset.originalValue;
+    const rounded = cell.dataset.roundedValue;
+    if (!original || !rounded) continue;
+
+    if (showingOriginal) {
+      replaceTextPreservingHTML(cell, original, rounded);
+      cell.title = `Original: ${original}`;
+    } else {
+      replaceTextPreservingHTML(cell, rounded, original);
+      cell.title = `Rounded: ${rounded}`;
+    }
+  }
+
+  table.dataset.drShowingOriginal = showingOriginal ? 'false' : 'true';
+
+  chrome.runtime.sendMessage({
+    action: 'UPDATE_TOGGLE_LABEL',
+    title: showingOriginal ? 'Show original values' : 'Show rounded values'
+  });
 }
 
 // --- Core Algorithm Inlined ---

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -15,35 +15,31 @@ const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
 
 let lastRightClickedElement = null;
-let pendingAction = 'ROUND_TABLE';
 
 document.addEventListener('contextmenu', (event) => {
   lastRightClickedElement = event.target;
-
-  const table = event.target.closest('table');
-  let label, action;
-
-  if (!table || !table.querySelector('.dr-ext-rounded')) {
-    label = 'Round table dynamically';
-    action = 'ROUND_TABLE';
-  } else if (table.dataset.drShowingOriginal === 'true') {
-    label = 'Show rounded values';
-    action = 'TOGGLE_ORIGINAL';
-  } else {
-    label = 'Show original values';
-    action = 'TOGGLE_ORIGINAL';
-  }
-
-  pendingAction = action;
-  chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: label });
 }, true);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === 'GET_MENU_LABEL') {
+    const table = lastRightClickedElement && lastRightClickedElement.closest('table');
+    let title;
+    if (!table || !table.querySelector('.dr-ext-rounded')) {
+      title = 'Round table dynamically';
+    } else if (table.dataset.drShowingOriginal === 'true') {
+      title = 'Show rounded values';
+    } else {
+      title = 'Show original values';
+    }
+    sendResponse({ title });
+    return true;
+  }
+
   if (request.action === 'MENU_CLICKED') {
     if (lastRightClickedElement) {
       const table = lastRightClickedElement.closest('table');
       if (table) {
-        if (pendingAction === 'ROUND_TABLE') {
+        if (!table.querySelector('.dr-ext-rounded')) {
           roundTable(table);
         } else {
           toggleOriginalValues(table);

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -21,28 +21,17 @@ document.addEventListener('contextmenu', (event) => {
 }, true);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === 'GET_MENU_LABEL') {
-    const table = lastRightClickedElement && lastRightClickedElement.closest('table');
-    let title;
-    if (!table || !table.querySelector('.dr-ext-rounded')) {
-      title = 'Round table dynamically';
-    } else if (table.dataset.drShowingOriginal === 'true') {
-      title = 'Show rounded values';
-    } else {
-      title = 'Show original values';
-    }
-    sendResponse({ title });
-    return true;
-  }
-
   if (request.action === 'MENU_CLICKED') {
     if (lastRightClickedElement) {
       const table = lastRightClickedElement.closest('table');
       if (table) {
         if (!table.querySelector('.dr-ext-rounded')) {
           roundTable(table);
+          chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
         } else {
           toggleOriginalValues(table);
+          const label = table.dataset.drShowingOriginal === 'true' ? 'Show rounded values' : 'Show original values';
+          chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: label });
         }
       } else {
         console.warn("Dynamic Rounding: No table found at right-click location.");

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -15,26 +15,41 @@ const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
 
 let lastRightClickedElement = null;
+let pendingAction = 'ROUND_TABLE';
 
 document.addEventListener('contextmenu', (event) => {
   lastRightClickedElement = event.target;
+
+  const table = event.target.closest('table');
+  let label, action;
+
+  if (!table || !table.querySelector('.dr-ext-rounded')) {
+    label = 'Round table dynamically';
+    action = 'ROUND_TABLE';
+  } else if (table.dataset.drShowingOriginal === 'true') {
+    label = 'Show rounded values';
+    action = 'TOGGLE_ORIGINAL';
+  } else {
+    label = 'Show original values';
+    action = 'TOGGLE_ORIGINAL';
+  }
+
+  pendingAction = action;
+  chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: label });
 }, true);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === 'ROUND_TABLE') {
+  if (request.action === 'MENU_CLICKED') {
     if (lastRightClickedElement) {
       const table = lastRightClickedElement.closest('table');
       if (table) {
-        roundTable(table);
+        if (pendingAction === 'ROUND_TABLE') {
+          roundTable(table);
+        } else {
+          toggleOriginalValues(table);
+        }
       } else {
         console.warn("Dynamic Rounding: No table found at right-click location.");
-      }
-    }
-  } else if (request.action === 'TOGGLE_ORIGINAL') {
-    if (lastRightClickedElement) {
-      const table = lastRightClickedElement.closest('table');
-      if (table) {
-        toggleOriginalValues(table);
       }
     }
   }
@@ -109,11 +124,6 @@ function toggleOriginalValues(table) {
   }
 
   table.dataset.drShowingOriginal = showingOriginal ? 'false' : 'true';
-
-  chrome.runtime.sendMessage({
-    action: 'UPDATE_TOGGLE_LABEL',
-    title: showingOriginal ? 'Show original values' : 'Show rounded values'
-  });
 }
 
 // --- Core Algorithm Inlined ---

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting"],
   "background": {


### PR DESCRIPTION
## What
A toggle in the right-click menu lets users switch between simplified 
(rounded) and original values.

The menu item label now updates dynamically based on table state, flipping between `Round table dynamically` and `Show original values`.


## How
- Stores the formatted rounded value in `data-rounded-value` on each
  modified cell at rounding time (alongside the existing `data-original-value`)
- `toggleOriginalValues()` swaps the displayed text and tooltip using
  the existing `replaceTextPreservingHTML` infrastructure
- After each action, sends `UPDATE_MENU_LABEL` to background.js so the
  label is correct on the next right-click (updating on the contextmenu
  event is too late — Chrome renders the menu before the message arrives)

## Version
1.1.1 → 1.2.0