### PR TITLE
Add sidebar with "exclude words" toggle and master enable switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Project conventions for Claude
+
+## Versioning
+- Bump at least the patch version (`x.y.Z`) on every commit.
+- Keep these three in sync on each bump:
+  - `chrome-extension/manifest.json` `version` field
+  - `chrome-extension/content.js` header `Version:` comment
+  - `chrome-extension/background.js` header `Version:` comment
+
+## Authorship
+- Commit author/committer: `ArieFisher <ariefisher1@gmail.com>`.
+- Never list Claude as author or contributor.
+- Never include "claude" in branch names; use `feature/<short-name>` etc.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.0
+ * Version: 1.3.1
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.2
+ * Version: 1.3.3
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.1
+ * Version: 1.3.2
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -6,6 +6,8 @@
  * Copyright (c) 2026 Arie Fisher
  */
 
+let sidebarTabId = null;
+
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     id: "dr-action",
@@ -37,12 +39,49 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
     } catch (e) {
       console.warn("Dynamic Rounding: failed to open side panel", e);
     }
+    sidebarTabId = tab.id;
     chrome.tabs.sendMessage(tab.id, { action: "SIDEBAR_OPENED" });
   }
 });
 
-chrome.runtime.onMessage.addListener((request) => {
+function closeSidebarIfOpen() {
+  chrome.runtime.sendMessage({ action: "CLOSE_SIDEBAR" }).catch(() => {});
+  sidebarTabId = null;
+}
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (tabId === sidebarTabId && changeInfo.status === "loading") {
+    closeSidebarIfOpen();
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabId === sidebarTabId) {
+    closeSidebarIfOpen();
+  }
+});
+
+chrome.tabs.onActivated.addListener((activeInfo) => {
+  if (sidebarTabId !== null && activeInfo.tabId !== sidebarTabId) {
+    closeSidebarIfOpen();
+  }
+});
+
+chrome.runtime.onMessage.addListener((request, sender) => {
   if (request.action === "UPDATE_MENU_LABEL") {
     chrome.contextMenus.update("dr-action", { title: request.title });
+    return;
+  }
+
+  if (request.action === "PAGE_UNLOADED") {
+    if (sender.tab && sender.tab.id === sidebarTabId) {
+      closeSidebarIfOpen();
+    }
+    return;
+  }
+
+  if (request.action === "SIDEBAR_CLOSED") {
+    sidebarTabId = null;
+    return;
   }
 });

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,5 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.1.0
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher
@@ -12,15 +11,36 @@ chrome.runtime.onInstalled.addListener(() => {
     title: "Round table dynamically",
     contexts: ["all"]
   });
+  chrome.contextMenus.create({
+    id: "dr-action-sidebar",
+    title: "Round table dynamically (with options)...",
+    contexts: ["all"]
+  });
 });
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
+if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
+  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+}
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (info.menuItemId === "dr-action") {
     chrome.tabs.sendMessage(tab.id, { action: "MENU_CLICKED" });
+    return;
+  }
+
+  if (info.menuItemId === "dr-action-sidebar") {
+    try {
+      if (chrome.sidePanel && chrome.sidePanel.open) {
+        await chrome.sidePanel.open({ tabId: tab.id });
+      }
+    } catch (e) {
+      console.warn("Dynamic Rounding: failed to open side panel", e);
+    }
+    chrome.tabs.sendMessage(tab.id, { action: "SIDEBAR_OPENED" });
   }
 });
 
-chrome.runtime.onMessage.addListener((request, sender) => {
+chrome.runtime.onMessage.addListener((request) => {
   if (request.action === "UPDATE_MENU_LABEL") {
     chrome.contextMenus.update("dr-action", { title: request.title });
   }

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,5 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
+ * Version: 1.3.0
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.3
+ * Version: 1.3.4
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.4
+ * Version: 1.3.5
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.0
+ * Version: 1.3.1
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -9,15 +9,23 @@
 // Constants
 const CLEAN_REGEX = /[$€£¥,\s%]/g;
 const PARENS_REGEX = /^\((.+)\)$/;
+const NUMBER_IN_TEXT_REGEX = /-?\d[\d,]*(?:\.\d+)?/;
 const DEFAULT_OFFSET_TOP = -0.5;
 const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
 
+const DEFAULT_SIDEBAR_OPTIONS = { excludeWords: true };
+
 let lastRightClickedElement = null;
+let lastRightClickedTable = null;
 
 document.addEventListener('contextmenu', (event) => {
   lastRightClickedElement = event.target;
+  const table = event.target.closest && event.target.closest('table');
+  if (table) {
+    lastRightClickedTable = table;
+  }
 }, true);
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -37,55 +45,137 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         console.warn("Dynamic Rounding: No table found at right-click location.");
       }
     }
+    return;
+  }
+
+  if (request.action === 'SIDEBAR_OPENED') {
+    if (lastRightClickedTable) {
+      applySidebarRounding(lastRightClickedTable, DEFAULT_SIDEBAR_OPTIONS);
+    } else {
+      console.warn("Dynamic Rounding: No table targeted. Right-click a table cell first.");
+    }
+    return;
+  }
+
+  if (request.action === 'APPLY_SIDEBAR_SETTINGS') {
+    if (lastRightClickedTable) {
+      applySidebarRounding(lastRightClickedTable, request.settings || DEFAULT_SIDEBAR_OPTIONS);
+    }
+    return;
   }
 });
 
-function roundTable(table) {
+function applySidebarRounding(table, options) {
+  resetTable(table);
+  roundTable(table, options);
+}
+
+function resetTable(table) {
+  const roundedCells = table.querySelectorAll('.dr-ext-rounded');
+  const showingOriginal = table.dataset.drShowingOriginal === 'true';
+  for (const cell of roundedCells) {
+    const original = cell.dataset.originalValue;
+    const rounded = cell.dataset.roundedValue;
+    if (original && rounded) {
+      const shown = showingOriginal ? original : rounded;
+      replaceTextPreservingHTML(cell, shown, original);
+    }
+    cell.classList.remove('dr-ext-rounded');
+    delete cell.dataset.originalValue;
+    delete cell.dataset.roundedValue;
+    cell.removeAttribute('title');
+  }
+  delete table.dataset.drShowingOriginal;
+}
+
+function roundTable(table, options) {
+  const opts = Object.assign({}, DEFAULT_SIDEBAR_OPTIONS, options || {});
   const rows = Array.from(table.rows);
   const data = [];
   const cellsMap = [];
+  const cellInfo = [];
 
   for (let r = 0; r < rows.length; r++) {
     const cells = Array.from(rows[r].cells);
     const rowData = [];
     const rowCells = [];
+    const rowInfo = [];
     for (let c = 0; c < cells.length; c++) {
       const cell = cells[c];
       const text = cell.innerText || cell.textContent;
       rowData.push(text);
       rowCells.push(cell);
+
+      const num = toNumber(text);
+      if (num !== null) {
+        rowInfo.push({ mode: 'pure', num });
+      } else if (!opts.excludeWords) {
+        const extracted = extractNumberInText(text);
+        if (extracted) {
+          rowInfo.push({ mode: 'extracted', num: extracted.num, numStr: extracted.numStr, index: extracted.index });
+        } else {
+          rowInfo.push({ mode: 'skip', num: null });
+        }
+      } else {
+        rowInfo.push({ mode: 'skip', num: null });
+      }
     }
     data.push(rowData);
     cellsMap.push(rowCells);
+    cellInfo.push(rowInfo);
   }
 
-  // Use dataset mode for the whole table
-  const roundedData = datasetMode(data, DEFAULT_OFFSET_TOP, DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP);
+  const numericRange = cellInfo.map(row => row.map(info => info.num));
+  const max_mag = findMaxMagnitude(numericRange);
 
   for (let r = 0; r < data.length; r++) {
     for (let c = 0; c < data[r].length; c++) {
+      const info = cellInfo[r][c];
+      if (info.mode === 'skip') continue;
+
+      const roundedValue = roundCellSetAware(info.num, info.num, max_mag, DEFAULT_OFFSET_TOP, DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP);
+      if (roundedValue === info.num) continue;
+
       const originalValue = data[r][c];
-      const roundedValue = roundedData[r][c];
       const cell = cellsMap[r][c];
+      let formattedValue;
 
-      const num = toNumber(originalValue);
-      if (num !== null && num !== roundedValue) {
-        // Format the rounded value back to the original format
-        const formattedValue = restoreFormatting(roundedValue, originalValue);
-        
-        // Replace text while preserving HTML elements (for font, size, etc)
-        replaceTextPreservingHTML(cell, originalValue, formattedValue);
-
-        // Tooltip for original value
-        cell.title = `Original: ${originalValue}`;
-
-        // Prepare for future toggles
-        cell.classList.add('dr-ext-rounded');
-        cell.dataset.originalValue = originalValue;
-        cell.dataset.roundedValue = formattedValue;
+      if (info.mode === 'pure') {
+        formattedValue = restoreFormatting(roundedValue, originalValue);
+      } else {
+        const formattedNum = formatExtractedNumber(roundedValue, info.numStr);
+        formattedValue = originalValue.substring(0, info.index) + formattedNum + originalValue.substring(info.index + info.numStr.length);
       }
+
+      replaceTextPreservingHTML(cell, originalValue, formattedValue);
+      cell.title = `Original: ${originalValue}`;
+      cell.classList.add('dr-ext-rounded');
+      cell.dataset.originalValue = originalValue;
+      cell.dataset.roundedValue = formattedValue;
     }
   }
+}
+
+function extractNumberInText(text) {
+  if (typeof text !== 'string') return null;
+  const match = text.match(NUMBER_IN_TEXT_REGEX);
+  if (!match) return null;
+  const numStr = match[0];
+  const num = toNumber(numStr);
+  if (num === null || num === 0) return null;
+  return { numStr, num, index: match.index };
+}
+
+function formatExtractedNumber(rounded, originalNumStr) {
+  const hasCommas = originalNumStr.includes(',');
+  const decMatch = originalNumStr.match(/\.(\d+)/);
+  let decimals = decMatch ? decMatch[1].length : 0;
+  if (Math.abs(rounded) >= 10) decimals = 0;
+  return rounded.toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: Math.max(decimals, 10),
+    useGrouping: hasCommas
+  });
 }
 
 function toggleOriginalValues(table) {

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.1.0
+ * Version: 1.3.0
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.2
+ * Version: 1.3.3
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.1
+ * Version: 1.3.2
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher
@@ -78,6 +78,9 @@ function applySidebarRounding(table, options) {
   resetTable(table);
   roundTable(table, options);
   flashTargetedTable(table);
+  if (table.querySelector('.dr-ext-rounded')) {
+    chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
+  }
 }
 
 let highlightStyleInjected = false;

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.4
+ * Version: 1.3.5
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher
@@ -16,7 +16,7 @@ const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
 
-const DEFAULT_SIDEBAR_OPTIONS = { excludeWords: true };
+const DEFAULT_SIDEBAR_OPTIONS = { enabled: true, excludeWords: true };
 
 let lastRightClickedElement = null;
 let lastRightClickedTable = null;
@@ -75,13 +75,18 @@ window.addEventListener('pagehide', () => {
 });
 
 function applySidebarRounding(table, options) {
+  const opts = Object.assign({}, DEFAULT_SIDEBAR_OPTIONS, options || {});
   ensureHighlightStyleInjected();
   resetTable(table);
-  roundTable(table, options);
-  flashTargetedTable(table);
-  if (table.querySelector('.dr-ext-rounded')) {
-    chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
+  if (opts.enabled !== false) {
+    roundTable(table, opts);
+    if (table.querySelector('.dr-ext-rounded')) {
+      chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
+    }
+  } else {
+    chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Round table dynamically' });
   }
+  flashTargetedTable(table);
 }
 
 let highlightStyleInjected = false;

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -42,7 +42,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: label });
         }
       } else {
-        console.warn("Dynamic Rounding: No table found at right-click location.");
+        console.debug("Dynamic Rounding: No table found at right-click location.");
       }
     }
     return;
@@ -52,7 +52,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (lastRightClickedTable) {
       applySidebarRounding(lastRightClickedTable, DEFAULT_SIDEBAR_OPTIONS);
     } else {
-      console.warn("Dynamic Rounding: No table targeted. Right-click a table cell first.");
+      console.debug("Dynamic Rounding: No table targeted. Right-click a table cell first.");
     }
     return;
   }
@@ -65,9 +65,43 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
+window.addEventListener('pagehide', () => {
+  try {
+    chrome.runtime.sendMessage({ action: 'PAGE_UNLOADED' });
+  } catch (e) {
+    // extension context may already be gone
+  }
+});
+
 function applySidebarRounding(table, options) {
+  ensureHighlightStyleInjected();
   resetTable(table);
   roundTable(table, options);
+  flashTargetedTable(table);
+}
+
+let highlightStyleInjected = false;
+function ensureHighlightStyleInjected() {
+  if (highlightStyleInjected) return;
+  const style = document.createElement('style');
+  style.textContent = `
+    @keyframes drExtTargetFlash {
+      0%   { outline: 2px solid rgba(66, 133, 244, 0.95); outline-offset: 2px; }
+      100% { outline: 2px solid rgba(66, 133, 244, 0);    outline-offset: 2px; }
+    }
+    .dr-ext-target-flash {
+      animation: drExtTargetFlash 1s ease-out;
+    }
+  `;
+  (document.head || document.documentElement).appendChild(style);
+  highlightStyleInjected = true;
+}
+
+function flashTargetedTable(table) {
+  table.classList.remove('dr-ext-target-flash');
+  // Force reflow so the animation restarts when re-added.
+  void table.offsetWidth;
+  table.classList.add('dr-ext-target-flash');
 }
 
 function resetTable(table) {

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.3
+ * Version: 1.3.4
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher
@@ -10,6 +10,7 @@
 const CLEAN_REGEX = /[$€£¥,\s%]/g;
 const PARENS_REGEX = /^\((.+)\)$/;
 const NUMBER_IN_TEXT_REGEX = /-?\d[\d,]*(?:\.\d+)?/;
+const NUMBER_IN_TEXT_REGEX_GLOBAL = /-?\d[\d,]*(?:\.\d+)?/g;
 const DEFAULT_OFFSET_TOP = -0.5;
 const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
@@ -147,14 +148,14 @@ function roundTable(table, options) {
       if (num !== null) {
         rowInfo.push({ mode: 'pure', num });
       } else if (!opts.excludeWords) {
-        const extracted = extractNumberInText(text);
-        if (extracted) {
-          rowInfo.push({ mode: 'extracted', num: extracted.num, numStr: extracted.numStr, index: extracted.index });
+        const matches = extractNumbersInText(text);
+        if (matches.length > 0) {
+          rowInfo.push({ mode: 'extracted', matches });
         } else {
-          rowInfo.push({ mode: 'skip', num: null });
+          rowInfo.push({ mode: 'skip' });
         }
       } else {
-        rowInfo.push({ mode: 'skip', num: null });
+        rowInfo.push({ mode: 'skip' });
       }
     }
     data.push(rowData);
@@ -162,26 +163,43 @@ function roundTable(table, options) {
     cellInfo.push(rowInfo);
   }
 
-  const numericRange = cellInfo.map(row => row.map(info => info.num));
-  const max_mag = findMaxMagnitude(numericRange);
+  const allNums = [];
+  for (const row of cellInfo) {
+    for (const info of row) {
+      if (info.mode === 'pure') allNums.push(info.num);
+      else if (info.mode === 'extracted') {
+        for (const m of info.matches) allNums.push(m.num);
+      }
+    }
+  }
+  const max_mag = findMaxMagnitude([allNums]);
 
   for (let r = 0; r < data.length; r++) {
     for (let c = 0; c < data[r].length; c++) {
       const info = cellInfo[r][c];
       if (info.mode === 'skip') continue;
 
-      const roundedValue = roundCellSetAware(info.num, info.num, max_mag, DEFAULT_OFFSET_TOP, DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP);
-      if (roundedValue === info.num) continue;
-
       const originalValue = data[r][c];
       const cell = cellsMap[r][c];
       let formattedValue;
 
       if (info.mode === 'pure') {
+        const roundedValue = roundCellSetAware(info.num, info.num, max_mag, DEFAULT_OFFSET_TOP, DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP);
+        if (roundedValue === info.num) continue;
         formattedValue = restoreFormatting(roundedValue, originalValue);
       } else {
-        const formattedNum = formatExtractedNumber(roundedValue, info.numStr);
-        formattedValue = originalValue.substring(0, info.index) + formattedNum + originalValue.substring(info.index + info.numStr.length);
+        // Round each match individually, splice back from right-to-left so earlier indices remain valid.
+        let changed = false;
+        formattedValue = originalValue;
+        for (let i = info.matches.length - 1; i >= 0; i--) {
+          const m = info.matches[i];
+          const rounded = roundCellSetAware(m.num, m.num, max_mag, DEFAULT_OFFSET_TOP, DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP);
+          if (rounded === m.num) continue;
+          const newNum = formatExtractedNumber(rounded, m.numStr);
+          formattedValue = formattedValue.substring(0, m.index) + newNum + formattedValue.substring(m.index + m.numStr.length);
+          changed = true;
+        }
+        if (!changed) continue;
       }
 
       replaceTextPreservingHTML(cell, originalValue, formattedValue);
@@ -201,6 +219,20 @@ function extractNumberInText(text) {
   const num = toNumber(numStr);
   if (num === null || num === 0) return null;
   return { numStr, num, index: match.index };
+}
+
+function extractNumbersInText(text) {
+  if (typeof text !== 'string') return [];
+  const matches = [];
+  const re = new RegExp(NUMBER_IN_TEXT_REGEX_GLOBAL.source, 'g');
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const num = toNumber(m[0]);
+    if (num !== null && num !== 0) {
+      matches.push({ numStr: m[0], num, index: m.index });
+    }
+  }
+  return matches;
 }
 
 function formatExtractedNumber(rounded, originalNumStr) {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
-  "permissions": ["contextMenus", "activeTab", "scripting"],
+  "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {
     "service_worker": "background.js"
   },
@@ -13,5 +13,8 @@
       "js": ["content.js"]
     }
   ],
+  "side_panel": {
+    "default_path": "sidebar.html"
+  },
   "action": {}
 }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -16,8 +16,63 @@
       font-weight: 600;
       margin: 0 0 16px 0;
     }
+    .master-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 8px 0 16px;
+      border-bottom: 1px solid #e8eaed;
+      margin-bottom: 16px;
+    }
+    .master-row .label {
+      font-weight: 500;
+    }
+    /* iOS-style toggle */
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 36px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      background-color: #bdc1c6;
+      border-radius: 20px;
+      transition: background-color 0.15s;
+    }
+    .slider::before {
+      content: "";
+      position: absolute;
+      height: 16px;
+      width: 16px;
+      left: 2px;
+      top: 2px;
+      background-color: white;
+      border-radius: 50%;
+      transition: transform 0.15s;
+    }
+    .switch input:checked + .slider {
+      background-color: #1a73e8;
+    }
+    .switch input:checked + .slider::before {
+      transform: translateX(16px);
+    }
     .section {
       margin-bottom: 20px;
+      transition: opacity 0.15s;
+    }
+    .section.disabled {
+      opacity: 0.4;
+      pointer-events: none;
     }
     .section-title {
       font-size: 12px;
@@ -48,8 +103,16 @@
 <body>
   <h1>Dynamic Rounding</h1>
 
-  <div class="section">
-    <div class="section-title">Exclude cells that also contain</div>
+  <div class="master-row">
+    <span class="label">Apply dynamic rounding</span>
+    <label class="switch">
+      <input type="checkbox" id="enabled" checked>
+      <span class="slider"></span>
+    </label>
+  </div>
+
+  <div class="section" id="optionsSection">
+    <div class="section-title">Exclude cells also containing:</div>
     <label class="checkbox-row">
       <input type="checkbox" id="excludeWords" checked>
       <span>words</span>

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Dynamic Rounding</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-size: 14px;
+      margin: 0;
+      padding: 16px;
+      color: #202124;
+    }
+    h1 {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0 0 16px 0;
+    }
+    .section {
+      margin-bottom: 20px;
+    }
+    .section-title {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #5f6368;
+      margin-bottom: 8px;
+    }
+    label.checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+      cursor: pointer;
+    }
+    label.checkbox-row input {
+      margin: 0;
+    }
+    .status {
+      font-size: 12px;
+      color: #5f6368;
+      margin-top: 12px;
+      min-height: 1em;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dynamic Rounding</h1>
+
+  <div class="section">
+    <div class="section-title">Exclude cells that also contain</div>
+    <label class="checkbox-row">
+      <input type="checkbox" id="excludeWords" checked>
+      <span>words</span>
+    </label>
+  </div>
+
+  <div class="status" id="status"></div>
+
+  <script src="sidebar.js"></script>
+</body>
+</html>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -1,0 +1,35 @@
+/**
+ * DynamicRounding Chrome Extension - Sidebar
+ * https://github.com/ArieFisher/dynamic-rounding
+ * MIT License
+ * Copyright (c) 2026 Arie Fisher
+ */
+
+const excludeWordsEl = document.getElementById('excludeWords');
+const statusEl = document.getElementById('status');
+
+function currentSettings() {
+  return {
+    excludeWords: excludeWordsEl.checked
+  };
+}
+
+function sendToActiveTab(message) {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (!tabs[0]) {
+      statusEl.textContent = 'No active tab.';
+      return;
+    }
+    chrome.tabs.sendMessage(tabs[0].id, message, () => {
+      if (chrome.runtime.lastError) {
+        statusEl.textContent = 'Right-click a table first, then reopen the sidebar.';
+      } else {
+        statusEl.textContent = '';
+      }
+    });
+  });
+}
+
+excludeWordsEl.addEventListener('change', () => {
+  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+});

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -33,3 +33,24 @@ function sendToActiveTab(message) {
 excludeWordsEl.addEventListener('change', () => {
   sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
 });
+
+// Also re-flash + re-apply when the user clicks anywhere in the sidebar body,
+// so they get a visual confirmation of which table is targeted.
+document.body.addEventListener('click', (e) => {
+  if (e.target === excludeWordsEl) return; // change handler already fires
+  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+});
+
+chrome.runtime.onMessage.addListener((request) => {
+  if (request.action === 'CLOSE_SIDEBAR') {
+    window.close();
+  }
+});
+
+window.addEventListener('unload', () => {
+  try {
+    chrome.runtime.sendMessage({ action: 'SIDEBAR_CLOSED' });
+  } catch (e) {
+    // extension context may already be gone
+  }
+});

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -5,13 +5,20 @@
  * Copyright (c) 2026 Arie Fisher
  */
 
+const enabledEl = document.getElementById('enabled');
 const excludeWordsEl = document.getElementById('excludeWords');
+const optionsSection = document.getElementById('optionsSection');
 const statusEl = document.getElementById('status');
 
 function currentSettings() {
   return {
+    enabled: enabledEl.checked,
     excludeWords: excludeWordsEl.checked
   };
+}
+
+function updateDisabledState() {
+  optionsSection.classList.toggle('disabled', !enabledEl.checked);
 }
 
 function sendToActiveTab(message) {
@@ -30,14 +37,17 @@ function sendToActiveTab(message) {
   });
 }
 
+enabledEl.addEventListener('change', () => {
+  updateDisabledState();
+  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+});
+
 excludeWordsEl.addEventListener('change', () => {
   sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
 });
 
-// Also re-flash + re-apply when the user clicks anywhere in the sidebar body,
-// so they get a visual confirmation of which table is targeted.
 document.body.addEventListener('click', (e) => {
-  if (e.target === excludeWordsEl) return; // change handler already fires
+  if (e.target === enabledEl || e.target === excludeWordsEl) return;
   sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
 });
 
@@ -54,3 +64,5 @@ window.addEventListener('unload', () => {
     // extension context may already be gone
   }
 });
+
+updateDisabledState();

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -17,6 +17,7 @@ global.chrome = {
   }
 };
 global.document = { addEventListener: () => {} };
+global.window = { addEventListener: () => {} };
 global.NodeFilter = { SHOW_TEXT: 4 };
 
 const code = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -71,6 +71,30 @@ eq('extract: non-string input',
   extractNumberInText(null),
   null);
 
+// --- extractNumbersInText (multi-match) ---
+
+eq('extractAll: range with en-dash',
+  extractNumbersInText('₹615.71–623.33 crore'),
+  [
+    { numStr: '615.71', num: 615.71, index: 1 },
+    { numStr: '623.33', num: 623.33, index: 8 }
+  ]);
+
+eq('extractAll: two-number sentence',
+  extractNumbersInText('between 1,200 and 3,400 units'),
+  [
+    { numStr: '1,200', num: 1200, index: 8 },
+    { numStr: '3,400', num: 3400, index: 18 }
+  ]);
+
+eq('extractAll: single number still returns one-element array',
+  extractNumbersInText('286k'),
+  [{ numStr: '286', num: 286, index: 0 }]);
+
+eq('extractAll: no digits returns empty array',
+  extractNumbersInText('N/A'),
+  []);
+
 // --- formatExtractedNumber ---
 
 eq('format: large number gets commas matching original',
@@ -130,6 +154,26 @@ eq('toNumber: pure text -> null', toNumber('N/A'), null);
 
   eq('e2e: full table output', out,
     ['8,500,000', '300', '8,500,000 USD', '300k']);
+})();
+
+// --- Range cell: every number in the cell must round ---
+(function rangeCell() {
+  const text = '₹615.71–623.33 crore';
+  const matches = extractNumbersInText(text);
+  const allNums = matches.map(m => m.num);
+  const maxMag = findMaxMagnitude([allNums]);
+
+  let out = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    const rounded = roundCellSetAware(m.num, m.num, maxMag, -0.5, -0.5, 1);
+    if (rounded === m.num) continue;
+    const newNum = formatExtractedNumber(rounded, m.numStr);
+    out = out.substring(0, m.index) + newNum + out.substring(m.index + m.numStr.length);
+  }
+
+  eq('range cell: both numbers in "₹615.71–623.33 crore" round',
+    out, '₹600–600 crore');
 })();
 
 // --- excludeWords=true path: extracted cells skipped, pure cells still round ---

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1,0 +1,166 @@
+/**
+ * Test suite for chrome-extension content.js pure helpers.
+ * Run: node tests.js
+ *
+ * Stubs out browser globals so we can eval content.js in Node and exercise
+ * the pure functions (extractNumberInText, formatExtractedNumber, toNumber,
+ * roundCellSetAware, findMaxMagnitude, restoreFormatting).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+global.chrome = {
+  runtime: {
+    onMessage: { addListener: () => {} },
+    sendMessage: () => {}
+  }
+};
+global.document = { addEventListener: () => {} };
+global.NodeFilter = { SHOW_TEXT: 4 };
+
+const code = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+eval(code);
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function eq(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    passed++;
+  } else {
+    failed++;
+    failures.push({ name, actual, expected });
+  }
+}
+
+// --- extractNumberInText ---
+
+eq('extract: plain comma number',
+  extractNumberInText('8,584,629'),
+  { numStr: '8,584,629', num: 8584629, index: 0 });
+
+eq('extract: number with trailing word (USD)',
+  extractNumberInText('8,584,629 USD'),
+  { numStr: '8,584,629', num: 8584629, index: 0 });
+
+eq('extract: number with trailing k',
+  extractNumberInText('286k'),
+  { numStr: '286', num: 286, index: 0 });
+
+eq('extract: non-numeric returns null',
+  extractNumberInText('N/A'),
+  null);
+
+eq('extract: number embedded mid-string',
+  extractNumberInText('approx 1,234 (close)'),
+  { numStr: '1,234', num: 1234, index: 7 });
+
+eq('extract: decimal with suffix',
+  extractNumberInText('1.5 hours'),
+  { numStr: '1.5', num: 1.5, index: 0 });
+
+eq('extract: empty string',
+  extractNumberInText(''),
+  null);
+
+eq('extract: non-string input',
+  extractNumberInText(null),
+  null);
+
+// --- formatExtractedNumber ---
+
+eq('format: large number gets commas matching original',
+  formatExtractedNumber(8500000, '8,584,629'),
+  '8,500,000');
+
+eq('format: small int no commas',
+  formatExtractedNumber(300, '286'),
+  '300');
+
+eq('format: decimal padding preserved when |x|<10',
+  formatExtractedNumber(1.5, '1.234'),
+  '1.500');
+
+eq('format: |x|>=10 drops decimals even if original had them',
+  formatExtractedNumber(1500, '1.234'),
+  '1500');
+
+// --- toNumber sanity (covered indirectly but pin behavior) ---
+
+eq('toNumber: plain integer string', toNumber('286'), 286);
+eq('toNumber: comma number', toNumber('8,584,629'), 8584629);
+eq('toNumber: currency stripped', toNumber('$1,234.56'), 1234.56);
+eq('toNumber: parens treated as negative', toNumber('(500)'), -500);
+eq('toNumber: trailing word -> null', toNumber('286k'), null);
+eq('toNumber: pure text -> null', toNumber('N/A'), null);
+
+// --- End-to-end magnitude + rounding parity with example table ---
+// Original | excludeWords=false expected
+// 8,584,629           -> 8,500,000
+// 286                 -> 300
+// 8,584,629 USD       -> 8,500,000 USD
+// 286k                -> 300k
+
+(function endToEnd() {
+  const cells = ['8,584,629', '286', '8,584,629 USD', '286k'];
+  const infos = cells.map(text => {
+    const num = toNumber(text);
+    if (num !== null) return { mode: 'pure', num, text };
+    const ex = extractNumberInText(text);
+    if (ex) return { mode: 'extracted', num: ex.num, numStr: ex.numStr, index: ex.index, text };
+    return { mode: 'skip', num: null, text };
+  });
+
+  const numericRange = [infos.map(i => i.num)];
+  const maxMag = findMaxMagnitude(numericRange);
+  eq('e2e: max magnitude across mixed cells', maxMag, 6);
+
+  const out = infos.map(info => {
+    if (info.mode === 'skip') return info.text;
+    const rounded = roundCellSetAware(info.num, info.num, maxMag, -0.5, -0.5, 1);
+    if (rounded === info.num) return info.text;
+    if (info.mode === 'pure') return restoreFormatting(rounded, info.text);
+    const num = formatExtractedNumber(rounded, info.numStr);
+    return info.text.substring(0, info.index) + num + info.text.substring(info.index + info.numStr.length);
+  });
+
+  eq('e2e: full table output', out,
+    ['8,500,000', '300', '8,500,000 USD', '300k']);
+})();
+
+// --- excludeWords=true path: extracted cells skipped, pure cells still round ---
+(function excludeWordsOn() {
+  const cells = ['8,584,629', '286', '8,584,629 USD', '286k'];
+  const infos = cells.map(text => {
+    const num = toNumber(text);
+    if (num !== null) return { mode: 'pure', num, text };
+    return { mode: 'skip', num: null, text };
+  });
+
+  const numericRange = [infos.map(i => i.num)];
+  const maxMag = findMaxMagnitude(numericRange);
+
+  const out = infos.map(info => {
+    if (info.mode === 'skip') return info.text;
+    const rounded = roundCellSetAware(info.num, info.num, maxMag, -0.5, -0.5, 1);
+    return info.mode === 'pure' ? restoreFormatting(rounded, info.text) : info.text;
+  });
+
+  eq('excludeWords=true: only pure-numeric cells round',
+    out, ['8,500,000', '300', '8,584,629 USD', '286k']);
+})();
+
+// --- Report ---
+console.log(`Passed: ${passed}`);
+console.log(`Failed: ${failed}`);
+if (failed > 0) {
+  for (const f of failures) {
+    console.log(`\n  ${f.name}`);
+    console.log(`    expected: ${JSON.stringify(f.expected)}`);
+    console.log(`    actual:   ${JSON.stringify(f.actual)}`);
+  }
+  process.exit(1);
+}

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -198,6 +198,88 @@ eq('toNumber: pure text -> null', toNumber('N/A'), null);
     out, ['8,500,000', '300', '8,584,629 USD', '286k']);
 })();
 
+// --- Additional extractNumbersInText cases ---
+
+eq('extractAll: three numbers in a sentence',
+  extractNumbersInText('grew from 10 to 200 in 3,000 days').map(m => m.num),
+  [10, 200, 3000]);
+
+eq('extractAll: decimal followed by integer',
+  extractNumbersInText('avg 4.5, peak 9'),
+  [
+    { numStr: '4.5', num: 4.5, index: 4 },
+    { numStr: '9', num: 9, index: 14 }
+  ]);
+
+eq('extractAll: indices are correct for splicing',
+  extractNumbersInText('a 100 b 200 c').map(m => ({ s: m.numStr, i: m.index })),
+  [{ s: '100', i: 2 }, { s: '200', i: 8 }]);
+
+eq('extractAll: zero is excluded',
+  extractNumbersInText('range 0 to 500').map(m => m.num),
+  [500]);
+
+// --- Range cell with mixed magnitudes ---
+(function rangeMixedMagnitudes() {
+  const text = '50–5,000 range';
+  const matches = extractNumbersInText(text);
+  const allNums = matches.map(m => m.num);
+  const maxMag = findMaxMagnitude([allNums]);
+
+  let out = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    const rounded = roundCellSetAware(m.num, m.num, maxMag, -0.5, -0.5, 1);
+    if (rounded === m.num) continue;
+    const newNum = formatExtractedNumber(rounded, m.numStr);
+    out = out.substring(0, m.index) + newNum + out.substring(m.index + m.numStr.length);
+  }
+
+  // maxMag = 3 (from 5000). 50 is magnitude 1, far from top -> uses offset_other (=top, both -0.5),
+  // so 50 rounds toward base = 10^1 * 0.5 = 5 -> 50.
+  // 5000 stays as 5,000.
+  eq('range cell: low end keeps its precision when far below top magnitude',
+    out, '50–5,000 range');
+})();
+
+// --- Splice safety: rounding doesn't affect later match indices because we go right-to-left ---
+(function spliceSafety() {
+  // Numbers that change length when rounded: 8,584,629 (9 chars) -> 8,500,000 (9 chars, same).
+  // Pick one that changes length: 286 (3) -> 300 (3) same. Use 9,876 -> 10,000 (length grows).
+  const text = '9,876 then 1,234';
+  const matches = extractNumbersInText(text);
+  const allNums = matches.map(m => m.num);
+  const maxMag = findMaxMagnitude([allNums]);
+
+  let out = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    const rounded = roundCellSetAware(m.num, m.num, maxMag, -0.5, -0.5, 1);
+    if (rounded === m.num) continue;
+    const newNum = formatExtractedNumber(rounded, m.numStr);
+    out = out.substring(0, m.index) + newNum + out.substring(m.index + m.numStr.length);
+  }
+
+  // Both magnitude 3. base = 500. 9876/500=19.75->20*500=10,000. 1234/500=2.47->2*500=1,000.
+  eq('splice safety: right-to-left replacement handles length-changing rounds',
+    out, '10,000 then 1,000');
+})();
+
+// --- Parens-negative survives toNumber ---
+eq('toNumber: parens with comma', toNumber('(1,234)'), -1234);
+eq('toNumber: empty string returns null', toNumber(''), null);
+eq('toNumber: whitespace only returns null', toNumber('   '), null);
+
+// --- restoreFormatting roundtrips for common shapes ---
+eq('restoreFormatting: pure integer keeps commas',
+  restoreFormatting(8500000, '8,584,629'), '8,500,000');
+eq('restoreFormatting: currency prefix preserved',
+  restoreFormatting(8500000, '$8,584,629'), '$8,500,000');
+eq('restoreFormatting: percent suffix preserved',
+  restoreFormatting(12, '12.34%'), '12%');
+eq('restoreFormatting: parens-negative preserved',
+  restoreFormatting(-500, '(523)'), '(500)');
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Adds a second context menu entry — **"Round table dynamically (with options)..."** — that opens a Chrome side panel with live controls. The original right-click "Round table dynamically" action is unchanged.

### Sidebar controls
- **Apply dynamic rounding** master toggle (default on). Off restores originals + greys out options; on re-applies with current settings.
- **Exclude cells also containing: words** checkbox (default on). When unchecked, cells with mixed numeric/text content (e.g. `"8,584,629 USD"`, `"286k"`, `"₹615.71–623.33 crore"`) have every numeric portion extracted, rounded in dataset context, and spliced back.

### Other behavior
- Side panel auto-closes on page reload, tab navigation, tab close, tab switch.
- Targeted table briefly outlines blue (1s fade) on sidebar open / settings change / sidebar click — confirms target when a page has multiple tables.
- Context menu first item flips to "Show original values" after sidebar rounding, and back when master toggle is off.
- Downgraded benign "no table at right-click" `console.warn` → `console.debug`.

### Tests
- New `chrome-extension/tests.js` (Node, stubs browser globals + eval's content.js): **39 tests**.
- Covers extraction (single + multi-match with indices), splice safety for length-changing rounds, `formatExtractedNumber`, `restoreFormatting` roundtrips, range cells like `"₹615.71–623.33 crore"`, and end-to-end parity for both `excludeWords` paths.
- Run: `node chrome-extension/tests.js`

### Version
Bumped to `1.3.5` across manifest + content/background header comments.

## Test plan

- [ ] `node chrome-extension/tests.js` reports 39/0
- [ ] Right-click → "Round table dynamically" still works as before
- [ ] Right-click → "Round table dynamically (with options)..." opens side panel and rounds immediately
- [ ] Uncheck **words** → `"286k"` → `"300k"`, `"8,584,629 USD"` → `"8,500,000 USD"`
- [ ] Toggle master off → originals restored, options greyed
- [ ] Toggle master on → rounding re-applies
- [ ] Reload page → sidebar closes
- [ ] Switch tabs → sidebar closes