### PR TITLE
Add GitHub Actions workflow to run test suites on push/PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run ROUND_DYNAMIC (Google Sheets) tests
+        run: node js/tests.js
+      - name: Run chrome extension tests
+        run: node chrome-extension/tests.js

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.5
+ * Version: 1.3.6
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.5
+ * Version: 1.3.6
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs both test suites on every push to `main`, every PR targeting `main`, and on manual dispatch.

`.github/workflows/tests.yml`:
- `node js/tests.js` — ROUND_DYNAMIC Google Sheets function tests (94 cases)
- `node chrome-extension/tests.js` — chrome extension helper tests (39 cases)

Uses `ubuntu-latest` with Node 20. Zero install steps since both suites are dependency-free.

Also bumps version to `1.3.6` across manifest + content/background header comments.

## Test plan

- [ ] Workflow appears under the **Actions** tab after this PR is opened
- [ ] PR check `Tests / test` passes
- [ ] After merge, push to `main` triggers another green run