### PR TITLE
browser extension UX: user can customize which column types to apply rounding to (exclude dates, times, first column, percent, currency)

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.6
+ * Version: 1.4.0
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,6 +1,6 @@
 /**
  * DynamicRounding Chrome Extension
- * Version: 1.3.6
+ * Version: 1.4.0
  * https://github.com/ArieFisher/dynamic-rounding
  * MIT License
  * Copyright (c) 2026 Arie Fisher
@@ -16,7 +16,15 @@ const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
 
-const DEFAULT_SIDEBAR_OPTIONS = { enabled: true, excludeWords: true };
+const DEFAULT_SIDEBAR_OPTIONS = {
+  enabled: true,
+  excludeWords: true,
+  excludeDates: true,
+  excludeTimes: true,
+  excludeFirstColumn: true,
+  excludePercent: false,
+  excludeCurrency: false
+};
 
 let lastRightClickedElement = null;
 let lastRightClickedTable = null;
@@ -149,18 +157,22 @@ function roundTable(table, options) {
       rowData.push(text);
       rowCells.push(cell);
 
-      const num = toNumber(text);
-      if (num !== null) {
-        rowInfo.push({ mode: 'pure', num });
-      } else if (!opts.excludeWords) {
-        const matches = extractNumbersInText(text);
-        if (matches.length > 0) {
-          rowInfo.push({ mode: 'extracted', matches });
+      if (getExclusionReason(text, c, opts)) {
+        rowInfo.push({ mode: 'skip' });
+      } else {
+        const num = toNumber(text);
+        if (num !== null) {
+          rowInfo.push({ mode: 'pure', num });
+        } else if (!opts.excludeWords) {
+          const matches = extractNumbersInText(text);
+          if (matches.length > 0) {
+            rowInfo.push({ mode: 'extracted', matches });
+          } else {
+            rowInfo.push({ mode: 'skip' });
+          }
         } else {
           rowInfo.push({ mode: 'skip' });
         }
-      } else {
-        rowInfo.push({ mode: 'skip' });
       }
     }
     data.push(rowData);
@@ -214,6 +226,47 @@ function roundTable(table, options) {
       cell.dataset.roundedValue = formattedValue;
     }
   }
+}
+
+function getExclusionReason(text, columnIndex, options) {
+  if (options.excludeFirstColumn && columnIndex === 0) return 'firstColumn';
+  if (typeof text !== 'string') return null;
+  const t = text.trim();
+  if (options.excludeDates && isDateLike(t)) return 'dates';
+  if (options.excludeTimes && isTimeLike(t)) return 'times';
+  if (options.excludePercent && /%/.test(t)) return 'percent';
+  if (options.excludeCurrency && /[$€£¥₹]/.test(t)) return 'currency';
+  return null;
+}
+
+function isYearValue(text) {
+  if (!/^\d{4}$/.test(text)) return false;
+  const n = parseInt(text, 10);
+  return n >= 1900 && n <= 2099;
+}
+
+const MONTH_NAMES = '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\\.?';
+const DATE_REGEXES = [
+  /^\d{4}-\d{2}-\d{2}$/,                              // 2024-03-14
+  /^\d{1,2}\/\d{1,2}\/\d{2,4}$/,                      // 3/14/2024
+  /^\d{1,2}-\d{1,2}-\d{2,4}$/,                        // 3-14-2024
+  new RegExp(`^${MONTH_NAMES}\\s+\\d{1,2},?\\s+\\d{4}$`, 'i'),  // March 14, 2024
+  new RegExp(`^\\d{1,2}\\s+${MONTH_NAMES}\\s+\\d{4}$`, 'i'),    // 14 March 2024
+  new RegExp(`^${MONTH_NAMES}\\s+\\d{4}$`, 'i'),               // March 2024
+  new RegExp(`^\\d{1,2}\\s+${MONTH_NAMES}$`, 'i')              // 14 March
+];
+
+function isDateLike(text) {
+  if (isYearValue(text)) return true;
+  for (const re of DATE_REGEXES) {
+    if (re.test(text)) return true;
+  }
+  return false;
+}
+
+function isTimeLike(text) {
+  // HH:MM or HH:MM:SS, optional AM/PM
+  return /^\d{1,2}:\d{2}(:\d{2})?(\s*[ap]\.?m\.?)?$/i.test(text);
 }
 
 function extractNumberInText(text) {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -117,6 +117,26 @@
       <input type="checkbox" id="excludeWords" checked>
       <span>words</span>
     </label>
+    <label class="checkbox-row">
+      <input type="checkbox" id="excludeDates" checked>
+      <span>dates</span>
+    </label>
+    <label class="checkbox-row">
+      <input type="checkbox" id="excludeTimes" checked>
+      <span>times</span>
+    </label>
+    <label class="checkbox-row">
+      <input type="checkbox" id="excludeFirstColumn" checked>
+      <span>first column</span>
+    </label>
+    <label class="checkbox-row">
+      <input type="checkbox" id="excludePercent">
+      <span>percentages</span>
+    </label>
+    <label class="checkbox-row">
+      <input type="checkbox" id="excludeCurrency">
+      <span>currencies</span>
+    </label>
   </div>
 
   <div class="status" id="status"></div>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -6,15 +6,25 @@
  */
 
 const enabledEl = document.getElementById('enabled');
-const excludeWordsEl = document.getElementById('excludeWords');
 const optionsSection = document.getElementById('optionsSection');
 const statusEl = document.getElementById('status');
 
+const CHECKBOX_TO_SETTING = {
+  excludeWords: 'excludeWords',
+  excludeDates: 'excludeDates',
+  excludeTimes: 'excludeTimes',
+  excludeFirstColumn: 'excludeFirstColumn',
+  excludePercent: 'excludePercent',
+  excludeCurrency: 'excludeCurrency'
+};
+
 function currentSettings() {
-  return {
-    enabled: enabledEl.checked,
-    excludeWords: excludeWordsEl.checked
-  };
+  const settings = { enabled: enabledEl.checked };
+  for (const id in CHECKBOX_TO_SETTING) {
+    const el = document.getElementById(id);
+    if (el) settings[CHECKBOX_TO_SETTING[id]] = el.checked;
+  }
+  return settings;
 }
 
 function updateDisabledState() {
@@ -37,18 +47,23 @@ function sendToActiveTab(message) {
   });
 }
 
+function applyNow() {
+  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+}
+
 enabledEl.addEventListener('change', () => {
   updateDisabledState();
-  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+  applyNow();
 });
 
-excludeWordsEl.addEventListener('change', () => {
-  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
-});
+for (const id in CHECKBOX_TO_SETTING) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('change', applyNow);
+}
 
 document.body.addEventListener('click', (e) => {
-  if (e.target === enabledEl || e.target === excludeWordsEl) return;
-  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+  if (e.target.matches('input[type="checkbox"]')) return;
+  applyNow();
 });
 
 chrome.runtime.onMessage.addListener((request) => {

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -280,6 +280,87 @@ eq('restoreFormatting: percent suffix preserved',
 eq('restoreFormatting: parens-negative preserved',
   restoreFormatting(-500, '(523)'), '(500)');
 
+// --- Sprint A: exclusion checkboxes ---
+
+eq('isYearValue: 2018 -> true', isYearValue('2018'), true);
+eq('isYearValue: 1899 -> false', isYearValue('1899'), false);
+eq('isYearValue: 2100 -> false', isYearValue('2100'), false);
+eq('isYearValue: 12 -> false', isYearValue('12'), false);
+eq('isYearValue: 20181 -> false', isYearValue('20181'), false);
+
+eq('isDateLike: bare 4-digit year', isDateLike('2018'), true);
+eq('isDateLike: ISO date', isDateLike('2024-03-14'), true);
+eq('isDateLike: US slash date', isDateLike('3/14/2024'), true);
+eq('isDateLike: dash date', isDateLike('3-14-2024'), true);
+eq('isDateLike: "March 14, 2024"', isDateLike('March 14, 2024'), true);
+eq('isDateLike: "14 March 2024"', isDateLike('14 March 2024'), true);
+eq('isDateLike: "Mar 2024"', isDateLike('Mar 2024'), true);
+eq('isDateLike: "Sept 2024"', isDateLike('Sept 2024'), true);
+eq('isDateLike: plain number not a year -> false', isDateLike('1234'), false);
+eq('isDateLike: random text -> false', isDateLike('hello'), false);
+eq('isDateLike: empty -> false', isDateLike(''), false);
+
+eq('isTimeLike: 14:30 -> true', isTimeLike('14:30'), true);
+eq('isTimeLike: 14:30:45 -> true', isTimeLike('14:30:45'), true);
+eq('isTimeLike: 2:30 PM -> true', isTimeLike('2:30 PM'), true);
+eq('isTimeLike: 2:30pm -> true', isTimeLike('2:30pm'), true);
+eq('isTimeLike: 2:3 -> false (single-digit minutes)', isTimeLike('2:3'), false);
+eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
+
+(function exclusionFirstColumn() {
+  const opts = Object.assign({}, {
+    excludeWords: true, excludeDates: false, excludeTimes: false,
+    excludeFirstColumn: true, excludePercent: false, excludeCurrency: false
+  });
+  eq('exclude: first column with flag on', getExclusionReason('anything', 0, opts), 'firstColumn');
+  eq('exclude: non-first column ignores flag', getExclusionReason('anything', 1, opts), null);
+})();
+
+(function exclusionDates() {
+  const opts = { excludeDates: true };
+  eq('exclude: year cell when excludeDates=true',
+    getExclusionReason('2018', 1, opts), 'dates');
+  eq('exclude: non-date cell when excludeDates=true',
+    getExclusionReason('1,234', 1, opts), null);
+  eq('exclude: year cell when excludeDates=false',
+    getExclusionReason('2018', 1, { excludeDates: false }), null);
+})();
+
+(function exclusionTimes() {
+  eq('exclude: time cell when excludeTimes=true',
+    getExclusionReason('14:30', 1, { excludeTimes: true }), 'times');
+})();
+
+(function exclusionPercent() {
+  eq('exclude: percent off by default',
+    getExclusionReason('45%', 1, {}), null);
+  eq('exclude: percent on',
+    getExclusionReason('45%', 1, { excludePercent: true }), 'percent');
+})();
+
+(function exclusionCurrency() {
+  eq('exclude: currency off by default',
+    getExclusionReason('$1,234', 1, {}), null);
+  eq('exclude: currency on',
+    getExclusionReason('$1,234', 1, { excludeCurrency: true }), 'currency');
+  eq('exclude: euro on',
+    getExclusionReason('€1,234', 1, { excludeCurrency: true }), 'currency');
+  eq('exclude: rupee on',
+    getExclusionReason('₹615', 1, { excludeCurrency: true }), 'currency');
+})();
+
+// First-match-wins priority: firstColumn beats dates beats times beats percent beats currency
+(function exclusionPriority() {
+  const opts = {
+    excludeFirstColumn: true, excludeDates: true, excludeTimes: true,
+    excludePercent: true, excludeCurrency: true
+  };
+  eq('priority: first column wins even when value is a date',
+    getExclusionReason('2018', 0, opts), 'firstColumn');
+  eq('priority: dates beats percent for a year value',
+    getExclusionReason('2018', 1, opts), 'dates');
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Adds 5 new exclusion checkboxes — dates (ON), times (ON), first column (ON), percentages (OFF), currencies (OFF) — and fixes the Wikipedia year-column "2018 -> 2,000" bug for both the sidebar AND the original right-click flow.

Detection helpers (`isDateLike`, `isTimeLike`, `isYearValue`) are anchored to the full trimmed cell text, so "12:34" inside prose isn't misidentified.

### Tests
75 (+36 new). Each helper, each flag on/off, exclusion priority.

### Version
1.3.6 -> 1.4.0.

### Review
Subagent: APPROVE WITH NITS, no blockers.

## Test plan
- [ ] `node chrome-extension/tests.js` -> 75/0
- [ ] Wikipedia list_of_highest-grossing_films: Year column stays "2018", Peak column stays "12"
- [ ] Right-click "Round table dynamically" also fixed
- [ ] Uncheck "dates" -> year column rounds
- [ ] Check "percentages" -> percent cells skipped