### PR TITLE
Pulse a faint blue-and-white border around the operated range

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -48,6 +48,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (lastRightClickedElement) {
       const table = lastRightClickedElement.closest('table');
       if (table) {
+        ensureHighlightStyleInjected();
         if (!table.querySelector('.dr-ext-rounded')) {
           roundTable(table);
           chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
@@ -56,6 +57,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           const label = table.dataset.drShowingOriginal === 'true' ? 'Show rounded values' : 'Show original values';
           chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: label });
         }
+        // Context menu has no range expression → whole-table pulse (ranges null).
+        flashRangePulse(table, null);
       } else {
         console.debug("Dynamic Rounding: No table found at right-click location.");
       }
@@ -100,7 +103,8 @@ function applySidebarRounding(table, options) {
   } else {
     chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Round table dynamically' });
   }
-  flashTargetedTable(table);
+  const rangeParse = parseRangeExpr(opts.rangeExpr);
+  flashRangePulse(table, rangeParse.error ? null : rangeParse.ranges);
 }
 
 let highlightStyleInjected = false;
@@ -115,6 +119,22 @@ function ensureHighlightStyleInjected() {
     .dr-ext-target-flash {
       animation: drExtTargetFlash 1s ease-out;
     }
+    @keyframes drExtRangePulse {
+      0%   { border-color: rgba(255,255,255,0.0);  box-shadow: 0 0 0 2px rgba(66,133,244,0.0); }
+      25%  { border-color: rgba(255,255,255,0.55); box-shadow: 0 0 0 2px rgba(66,133,244,0.6); }
+      50%  { border-color: rgba(255,255,255,0.0);  box-shadow: 0 0 0 2px rgba(66,133,244,0.0); }
+      75%  { border-color: rgba(255,255,255,0.55); box-shadow: 0 0 0 2px rgba(66,133,244,0.6); }
+      100% { border-color: rgba(255,255,255,0.0);  box-shadow: 0 0 0 2px rgba(66,133,244,0.0); }
+    }
+    .dr-ext-range-pulse {
+      position: absolute;
+      pointer-events: none;
+      z-index: 2147483647;
+      border: 2px solid rgba(255,255,255,0.0);
+      border-radius: 2px;
+      box-sizing: border-box;
+      animation: drExtRangePulse 0.6s ease-in-out 2;
+    }
   `;
   (document.head || document.documentElement).appendChild(style);
   highlightStyleInjected = true;
@@ -125,6 +145,73 @@ function flashTargetedTable(table) {
   // Force reflow so the animation restarts when re-added.
   void table.offsetWidth;
   table.classList.add('dr-ext-target-flash');
+}
+
+/**
+ * Pulse a faint blue-and-white border around the operated-on region.
+ * - If ranges is null (whole-table mode), delegates to the existing table outline flash.
+ * - If ranges is an array, overlays an absolutely-positioned div sized to the bounding
+ *   rect of all targeted cells, then removes itself after the animation ends (~1.2s).
+ *   The div is appended to document.body so it never wraps or alters td elements.
+ */
+function flashRangePulse(table, ranges) {
+  if (!ranges) {
+    // Whole-table mode: reuse the existing outline flash.
+    flashTargetedTable(table);
+    return;
+  }
+
+  // Collect all cells that fall within any of the provided ranges.
+  const rows = Array.from(table.rows);
+  const matchedCells = [];
+  for (let r = 0; r < rows.length; r++) {
+    const cells = Array.from(rows[r].cells);
+    for (let c = 0; c < cells.length; c++) {
+      if (isInRanges(r, c, ranges)) {
+        matchedCells.push(cells[c]);
+      }
+    }
+  }
+
+  if (matchedCells.length === 0) {
+    // No cells matched (e.g. range outside table bounds) — fall back to whole-table flash.
+    flashTargetedTable(table);
+    return;
+  }
+
+  // Compute the union bounding rect of all matched cells relative to the viewport.
+  let top = Infinity, left = Infinity, bottom = -Infinity, right = -Infinity;
+  for (const cell of matchedCells) {
+    const rect = cell.getBoundingClientRect();
+    if (rect.top    < top)    top    = rect.top;
+    if (rect.left   < left)   left   = rect.left;
+    if (rect.bottom > bottom) bottom = rect.bottom;
+    if (rect.right  > right)  right  = rect.right;
+  }
+
+  // Convert to absolute page coordinates so the overlay stays put on scrollable pages.
+  const scrollX = window.scrollX || window.pageXOffset || 0;
+  const scrollY = window.scrollY || window.pageYOffset || 0;
+  const absTop    = top    + scrollY;
+  const absLeft   = left   + scrollX;
+  const absWidth  = right  - left;
+  const absHeight = bottom - top;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'dr-ext-range-pulse';
+  overlay.style.top    = absTop    + 'px';
+  overlay.style.left   = absLeft   + 'px';
+  overlay.style.width  = absWidth  + 'px';
+  overlay.style.height = absHeight + 'px';
+
+  // Self-cleanup: remove after animation ends or after max 1.5s safety timeout.
+  const cleanup = () => {
+    if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+  };
+  overlay.addEventListener('animationend', cleanup);
+  setTimeout(cleanup, 1500);
+
+  (document.body || document.documentElement).appendChild(overlay);
 }
 
 function resetTable(table) {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -834,6 +834,91 @@ function withCreateTreeWalker(fn) {
     bgSource.includes('sidePanel.open'), true);
 })();
 
+// --- Sprint range-pulse-border: animation parameters and dispatch ---
+
+// CSS string: capture style.textContent from ensureHighlightStyleInjected().
+// We patch document.createElement to intercept the style element before injection.
+(function rangePulseCssParams() {
+  // Reset the module-level guard so we can trigger injection fresh.
+  highlightStyleInjected = false;
+
+  let capturedCss = null;
+  const origCreate = document.createElement;
+  document.createElement = (tag) => {
+    const el = { textContent: null };
+    if (tag === 'style') {
+      Object.defineProperty(el, 'textContent', {
+        set(v) { capturedCss = v; },
+        get() { return capturedCss; }
+      });
+    }
+    return el;
+  };
+  // Stub appendChild so the injection doesn't throw (document.head is undefined in stub).
+  const origHead = document.head;
+  const origDocEl = document.documentElement;
+  document.documentElement = { appendChild: () => {} };
+
+  ensureHighlightStyleInjected();
+
+  // Restore stubs.
+  document.createElement = origCreate;
+  document.documentElement = origDocEl;
+  // Re-set guard so later paths don't re-inject against the real (absent) DOM.
+  highlightStyleInjected = true;
+
+  eq('rangePulse CSS: animation duration is 0.6s',
+    capturedCss !== null && capturedCss.includes('0.6s'), true);
+
+  // The animation shorthand for .dr-ext-range-pulse should end with iteration-count 2.
+  const animLine = capturedCss && (capturedCss.match(/animation:\s*drExtRangePulse[^;]+;/) || [])[0];
+  eq('rangePulse CSS: iteration count is 2 (two cycles = ~1.2s total)',
+    !!(animLine && /\s2\s*;$/.test(animLine.trim())), true);
+
+  eq('rangePulse CSS: .dr-ext-target-flash class still present (no regression)',
+    capturedCss !== null && capturedCss.includes('dr-ext-target-flash'), true);
+})();
+
+// Dispatch: flashRangePulse(table, null) must delegate to flashTargetedTable,
+// which adds 'dr-ext-target-flash' to table.classList.
+(function rangePulseNullRangesDispatch() {
+  const classes = new Set();
+  const mockTable = {
+    classList: {
+      remove(cls) { classes.delete(cls); },
+      add(cls) { classes.add(cls); }
+    },
+    offsetWidth: 0,   // accessed via void table.offsetWidth in flashTargetedTable
+    rows: []
+  };
+
+  flashRangePulse(mockTable, null);
+
+  eq('rangePulse dispatch: null ranges adds dr-ext-target-flash (whole-table path)',
+    classes.has('dr-ext-target-flash'), true);
+})();
+
+// Dispatch: flashRangePulse(table, ranges) with zero matching cells falls back
+// to flashTargetedTable (same class added).
+(function rangePulseEmptyCellsFallback() {
+  const classes = new Set();
+  const mockTable = {
+    classList: {
+      remove(cls) { classes.delete(cls); },
+      add(cls) { classes.add(cls); }
+    },
+    offsetWidth: 0,
+    rows: []  // no rows => no cells => matchedCells.length === 0 => fallback
+  };
+
+  // A valid non-null ranges array that can't match anything in an empty table.
+  const ranges = [{ colMin: 0, colMax: 2, rowMin: 0, rowMax: 5 }];
+  flashRangePulse(mockTable, ranges);
+
+  eq('rangePulse dispatch: non-null ranges with no matching cells falls back to whole-table flash',
+    classes.has('dr-ext-target-flash'), true);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);


### PR DESCRIPTION
Plan: `plan/chrome-ext-ux-polish:docs/sprint-plans/chrome-ext-ux-polish.md`

## Acceptance criteria

- [x] Triggering rounding from the context menu pulses a blue-and-white border around the whole table when no range is set.
- [x] Triggering rounding from the sidebar with a range like `B2:D5` pulses the border around only those cells.
- [x] Re-applying the original values triggers the same pulse on the same range.
- [x] Pulse is faint (opacity ≤ 0.6), ~1.2s total, 2 cycles.
- [x] `node chrome-extension/tests.js` passes (149/149); `node js/tests.js` not regressed.

## Reviewer notes

- Overlay strategy: absolutely-positioned `<div class="dr-ext-range-pulse">` appended to `document.body`, sized to the union `getBoundingClientRect` of targeted cells. No `<td>` mutation. Self-removes on `animationend` plus a 1.5s safety timeout.
- Whole-table pulse delegates to the existing `flashTargetedTable` / `dr-ext-target-flash` path from commit `6302830`.
- Keep manifest at **1.8.0** (minor) — main will still be at 1.7.x when this lands.
- Follow-up at merge time: `flashRangePulse`'s cell iteration walks `row.cells` directly. After `first-col-is-a` lands, apply the same `<th>`-skip / `dataCol` pattern here. Tiny diff