### PR TITLE
Reorganize sidebar layout, copy, and exclusion groupings; add 'first row' exclusion

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -11,7 +11,7 @@ let sidebarTabId = null;
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     id: "dr-action",
-    title: "Round table dynamically",
+    title: "Toggle readable data",
     contexts: ["all"]
   });
   chrome.contextMenus.create({

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -18,12 +18,13 @@ const EPSILON = 1e-9;
 
 const DEFAULT_SIDEBAR_OPTIONS = {
   enabled: true,
-  excludeWords: true,
+  includeWords: false,
+  includeCurrency: false,
+  includePercent: false,
+  excludeFirstRow: false,
+  excludeFirstColumn: true,
   excludeDates: true,
   excludeTimes: true,
-  excludeFirstColumn: true,
-  excludePercent: false,
-  excludeCurrency: false,
   dateGranularity: 'year',     // year | decade | century
   timeGranularity: 'minute',   // minute | hour
   offsetTop: null,             // null = use DEFAULT_OFFSET_TOP
@@ -51,11 +52,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         ensureHighlightStyleInjected();
         if (!table.querySelector('.dr-ext-rounded')) {
           roundTable(table);
-          chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
+          chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' });
         } else {
           toggleOriginalValues(table);
-          const label = table.dataset.drShowingOriginal === 'true' ? 'Show rounded values' : 'Show original values';
-          chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: label });
+          chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' });
         }
         // Context menu has no range expression → whole-table pulse (ranges null).
         flashRangePulse(table, null);
@@ -98,10 +98,10 @@ function applySidebarRounding(table, options) {
   if (opts.enabled !== false) {
     roundTable(table, opts);
     if (table.querySelector('.dr-ext-rounded')) {
-      chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Show original values' });
+      chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' });
     }
   } else {
-    chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Round table dynamically' });
+    chrome.runtime.sendMessage({ action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' });
   }
   const rangeParse = parseRangeExpr(opts.rangeExpr);
   flashRangePulse(table, rangeParse.error ? null : rangeParse.ranges);
@@ -267,7 +267,7 @@ function roundTable(table, options) {
       const trimmed = typeof text === 'string' ? text.trim() : '';
       if (!isInRanges(r, col, ranges)) {
         rowInfo.push({ mode: 'skip' });
-      } else if (getExclusionReason(text, col, opts)) {
+      } else if (getExclusionReason(text, col, opts, r)) {
         rowInfo.push({ mode: 'skip' });
       } else if (opts.excludeDates === false && isDateLike(trimmed)) {
         rowInfo.push({ mode: 'date' });
@@ -277,7 +277,7 @@ function roundTable(table, options) {
         const num = toNumber(text);
         if (num !== null) {
           rowInfo.push({ mode: 'pure', num });
-        } else if (!opts.excludeWords) {
+        } else if (opts.includeWords) {
           const matches = extractNumbersInText(text);
           if (matches.length > 0) {
             rowInfo.push({ mode: 'extracted', matches });
@@ -442,14 +442,15 @@ function resolveNumTop(value, fallback) {
   return Math.floor(num);
 }
 
-function getExclusionReason(text, columnIndex, options) {
+function getExclusionReason(text, columnIndex, options, rowIndex) {
+  if (options.excludeFirstRow && rowIndex === 0) return 'firstRow';
   if (options.excludeFirstColumn && columnIndex === 0) return 'firstColumn';
   if (typeof text !== 'string') return null;
   const t = text.trim();
   if (options.excludeDates && isDateLike(t)) return 'dates';
   if (options.excludeTimes && isTimeLike(t)) return 'times';
-  if (options.excludePercent && /%/.test(t)) return 'percent';
-  if (options.excludeCurrency && /[$€£¥₹]/.test(t)) return 'currency';
+  if (!options.includePercent && /%/.test(t)) return 'percent';
+  if (!options.includeCurrency && /[$€£¥₹]/.test(t)) return 'currency';
   return null;
 }
 

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -11,22 +11,17 @@
       padding: 16px;
       color: #202124;
     }
-    h1 {
-      font-size: 16px;
-      font-weight: 600;
-      margin: 0 0 16px 0;
-    }
-    .master-row {
+    .title-row {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 12px;
-      padding: 8px 0 16px;
-      border-bottom: 1px solid #e8eaed;
-      margin-bottom: 16px;
+      margin: 0 0 16px 0;
     }
-    .master-row .label {
-      font-weight: 500;
+    .title-row h1 {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 0;
     }
     /* iOS-style toggle */
     .switch {
@@ -82,6 +77,12 @@
       color: #5f6368;
       margin-bottom: 8px;
     }
+    .section-heading {
+      font-size: 12px;
+      font-weight: 500;
+      color: #3c4043;
+      margin: 0 0 4px 0;
+    }
     label.checkbox-row {
       display: flex;
       align-items: center;
@@ -110,6 +111,9 @@
       font-size: 11px;
       color: #5f6368;
       margin-right: 4px;
+    }
+    .exclusion-group {
+      margin-bottom: 12px;
     }
     details.advanced {
       margin-top: 4px;
@@ -188,62 +192,70 @@
   </style>
 </head>
 <body>
-  <h1>Dynamic Rounding</h1>
-
-  <div class="master-row">
-    <span class="label">Apply dynamic rounding</span>
+  <div class="title-row">
+    <h1>Dynamic Rounding</h1>
     <label class="switch">
       <input type="checkbox" id="enabled" checked>
       <span class="slider"></span>
     </label>
   </div>
 
+  <div class="section" id="optionsSection">
+    <div class="exclusion-group">
+      <p class="section-heading">Simplify the data even when cells <em>also</em> have:</p>
+      <label class="checkbox-row">
+        <input type="checkbox" id="includeWords">
+        <span>words</span>
+      </label>
+      <label class="checkbox-row">
+        <input type="checkbox" id="includeCurrency">
+        <span>currencies</span>
+      </label>
+      <label class="checkbox-row">
+        <input type="checkbox" id="includePercent">
+        <span>percentages</span>
+      </label>
+    </div>
+
+    <div class="exclusion-group">
+      <p class="section-heading">Exclude:</p>
+      <label class="checkbox-row">
+        <input type="checkbox" id="excludeFirstRow">
+        <span>first row</span>
+      </label>
+      <label class="checkbox-row">
+        <input type="checkbox" id="excludeFirstColumn" checked>
+        <span>first column</span>
+      </label>
+      <label class="checkbox-row">
+        <input type="checkbox" id="excludeDates" checked>
+        <span class="row-label">dates</span>
+        <span class="granularity-label">round to:</span>
+        <select id="dateGranularity" disabled>
+          <option value="year" selected>year</option>
+          <option value="decade">decade</option>
+          <option value="century">century</option>
+        </select>
+      </label>
+      <label class="checkbox-row">
+        <input type="checkbox" id="excludeTimes" checked>
+        <span class="row-label">times</span>
+        <span class="granularity-label">round to:</span>
+        <select id="timeGranularity" disabled>
+          <option value="minute" selected>minute</option>
+          <option value="hour">hour</option>
+        </select>
+      </label>
+    </div>
+  </div>
+
   <div class="section" id="rangeSection">
     <div class="section-title">Range</div>
-    <input type="text" id="rangeExpr" placeholder="A1:E8 (blank = whole table)" autocomplete="off">
+    <input type="text" id="rangeExpr" placeholder="(blank = whole table)" autocomplete="off">
     <div class="range-help">
       <code>A</code>, <code>A:D</code>, <code>1:10</code>, <code>B2:E8</code>,
       or <code>{A1:E8, G3:G}</code>
     </div>
-  </div>
-
-  <div class="section" id="optionsSection">
-    <div class="section-title">Exclude cells also containing:</div>
-    <label class="checkbox-row">
-      <input type="checkbox" id="excludeWords" checked>
-      <span>words</span>
-    </label>
-    <label class="checkbox-row">
-      <input type="checkbox" id="excludeDates" checked>
-      <span class="row-label">dates</span>
-      <span class="granularity-label">round to:</span>
-      <select id="dateGranularity" disabled>
-        <option value="year" selected>year</option>
-        <option value="decade">decade</option>
-        <option value="century">century</option>
-      </select>
-    </label>
-    <label class="checkbox-row">
-      <input type="checkbox" id="excludeTimes" checked>
-      <span class="row-label">times</span>
-      <span class="granularity-label">round to:</span>
-      <select id="timeGranularity" disabled>
-        <option value="minute" selected>minute</option>
-        <option value="hour">hour</option>
-      </select>
-    </label>
-    <label class="checkbox-row">
-      <input type="checkbox" id="excludeFirstColumn" checked>
-      <span>first column</span>
-    </label>
-    <label class="checkbox-row">
-      <input type="checkbox" id="excludePercent">
-      <span>percentages</span>
-    </label>
-    <label class="checkbox-row">
-      <input type="checkbox" id="excludeCurrency">
-      <span>currencies</span>
-    </label>
   </div>
 
   <details class="advanced section" id="advancedSection">

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -10,12 +10,13 @@ const optionsSection = document.getElementById('optionsSection');
 const statusEl = document.getElementById('status');
 
 const CHECKBOX_TO_SETTING = {
-  excludeWords: 'excludeWords',
-  excludeDates: 'excludeDates',
-  excludeTimes: 'excludeTimes',
+  includeWords: 'includeWords',
+  includeCurrency: 'includeCurrency',
+  includePercent: 'includePercent',
+  excludeFirstRow: 'excludeFirstRow',
   excludeFirstColumn: 'excludeFirstColumn',
-  excludePercent: 'excludePercent',
-  excludeCurrency: 'excludeCurrency'
+  excludeDates: 'excludeDates',
+  excludeTimes: 'excludeTimes'
 };
 
 const dateGranularityEl = document.getElementById('dateGranularity');

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -332,33 +332,118 @@ eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
 })();
 
 (function exclusionPercent() {
-  eq('exclude: percent off by default',
-    getExclusionReason('45%', 1, {}), null);
-  eq('exclude: percent on',
-    getExclusionReason('45%', 1, { excludePercent: true }), 'percent');
+  // New semantics: percent cells are EXCLUDED by default (includePercent defaults false/unset).
+  eq('exclude: percent excluded by default (includePercent unset)',
+    getExclusionReason('45%', 1, {}), 'percent');
+  eq('exclude: percent excluded when includePercent=false',
+    getExclusionReason('45%', 1, { includePercent: false }), 'percent');
+  eq('exclude: percent included when includePercent=true',
+    getExclusionReason('45%', 1, { includePercent: true }), null);
 })();
 
 (function exclusionCurrency() {
-  eq('exclude: currency off by default',
-    getExclusionReason('$1,234', 1, {}), null);
-  eq('exclude: currency on',
-    getExclusionReason('$1,234', 1, { excludeCurrency: true }), 'currency');
-  eq('exclude: euro on',
-    getExclusionReason('€1,234', 1, { excludeCurrency: true }), 'currency');
-  eq('exclude: rupee on',
-    getExclusionReason('₹615', 1, { excludeCurrency: true }), 'currency');
+  // New semantics: currency cells are EXCLUDED by default (includeCurrency defaults false/unset).
+  eq('exclude: currency excluded by default (includeCurrency unset)',
+    getExclusionReason('$1,234', 1, {}), 'currency');
+  eq('exclude: currency excluded when includeCurrency=false',
+    getExclusionReason('$1,234', 1, { includeCurrency: false }), 'currency');
+  eq('exclude: currency included when includeCurrency=true',
+    getExclusionReason('$1,234', 1, { includeCurrency: true }), null);
+  eq('exclude: euro excluded by default',
+    getExclusionReason('€1,234', 1, {}), 'currency');
+  eq('exclude: euro included when includeCurrency=true',
+    getExclusionReason('€1,234', 1, { includeCurrency: true }), null);
+  eq('exclude: rupee excluded by default',
+    getExclusionReason('₹615', 1, {}), 'currency');
 })();
 
-// First-match-wins priority: firstColumn beats dates beats times beats percent beats currency
+// --- Sprint sidebar-restructure: excludeFirstRow ---
+
+(function excludeFirstRowTests() {
+  // excludeFirstRow=true: row 0 must be excluded regardless of cell content
+  eq('excludeFirstRow: row 0 excluded when flag is true',
+    getExclusionReason('1,234', 1, { excludeFirstRow: true }, 0), 'firstRow');
+  // excludeFirstRow=true: row 1 is not affected
+  eq('excludeFirstRow: row 1 not excluded when flag is true',
+    getExclusionReason('1,234', 1, { excludeFirstRow: true }, 1), null);
+  // excludeFirstRow=false: row 0 is NOT excluded
+  eq('excludeFirstRow: row 0 not excluded when flag is false',
+    getExclusionReason('1,234', 1, { excludeFirstRow: false }, 0), null);
+  // excludeFirstRow unset (default): row 0 is NOT excluded
+  eq('excludeFirstRow: row 0 not excluded when flag is unset (default)',
+    getExclusionReason('1,234', 1, {}, 0), null);
+  // excludeFirstRow takes priority over firstColumn check
+  eq('excludeFirstRow: firstRow beats firstColumn when both apply',
+    getExclusionReason('anything', 0, { excludeFirstRow: true, excludeFirstColumn: true }, 0), 'firstRow');
+})();
+
+// --- Sprint sidebar-restructure: includeWords semantics ---
+
+(function includeWordsTests() {
+  // With includeWords=true, a cell with a number AND a word should be rounded
+  // (mode='extracted' in roundTable). We test the path via the roundTable flow
+  // by checking that the cell text '8,584,629 USD' gets an 'extracted' mode.
+  const textWithWord = '$5.123 USD';
+  const textPure = '5.123';
+
+  // includeWords=true: extractNumbersInText finds a match and cell would be rounded
+  (function includeWordsOn() {
+    const matches = extractNumbersInText(textWithWord);
+    eq('includeWords=true: extractNumbersInText finds number in "$5.123 USD"',
+      matches.length > 0, true);
+    // Simulate the branch in roundTable: if (opts.includeWords) -> extracted path
+    const num = toNumber(textWithWord);
+    eq('includeWords=true: toNumber("$5.123 USD") is null (not pure numeric)',
+      num, null);
+    // When includeWords=true, the cell would go through extracted path
+    const optsInclude = { includeWords: true };
+    const wouldRound = num !== null ? true : (optsInclude.includeWords && matches.length > 0);
+    eq('includeWords=true: cell with words would be rounded', wouldRound, true);
+  })();
+
+  // includeWords=false (default): cell with words must NOT be rounded
+  (function includeWordsOff() {
+    const num = toNumber(textWithWord);
+    const optsExclude = { includeWords: false };
+    // Simulate roundTable logic: toNumber returns null, includeWords=false -> skip
+    const wouldRound = num !== null ? true : (optsExclude.includeWords === true);
+    eq('includeWords=false: cell with words would NOT be rounded', wouldRound, false);
+    // Same with default (unset)
+    const optsDefault = {};
+    const wouldRoundDefault = num !== null ? true : (optsDefault.includeWords === true);
+    eq('includeWords unset: cell with words would NOT be rounded', wouldRoundDefault, false);
+  })();
+})();
+
+// --- Sprint sidebar-restructure: includePercent / includeCurrency round-trip ---
+
+(function includePercentRoundTrip() {
+  // includeCurrency: true -> currency cells are NOT excluded
+  eq('includeCurrency=true: $1,234 is not excluded',
+    getExclusionReason('$1,234', 1, { includeCurrency: true }), null);
+  // includeCurrency unset -> currency cells ARE excluded
+  eq('includeCurrency unset: $1,234 is excluded',
+    getExclusionReason('$1,234', 1, {}), 'currency');
+  // includePercent: true -> percent cells are NOT excluded
+  eq('includePercent=true: 45% is not excluded',
+    getExclusionReason('45%', 1, { includePercent: true }), null);
+  // includePercent unset -> percent cells ARE excluded
+  eq('includePercent unset: 45% is excluded',
+    getExclusionReason('45%', 1, {}), 'percent');
+})();
+
+// First-match-wins priority: firstRow beats firstColumn beats dates beats times beats percent beats currency
 (function exclusionPriority() {
   const opts = {
-    excludeFirstColumn: true, excludeDates: true, excludeTimes: true,
-    excludePercent: true, excludeCurrency: true
+    excludeFirstRow: true, excludeFirstColumn: true, excludeDates: true, excludeTimes: true,
+    includePercent: false, includeCurrency: false
   };
-  eq('priority: first column wins even when value is a date',
-    getExclusionReason('2018', 0, opts), 'firstColumn');
+  eq('priority: first row wins even when value is a date',
+    getExclusionReason('2018', 0, opts, 0), 'firstRow');
+  eq('priority: first column wins even when value is a date (non-zero row)',
+    getExclusionReason('2018', 0, opts, 1), 'firstColumn');
   eq('priority: dates beats percent for a year value',
-    getExclusionReason('2018', 1, opts), 'dates');
+    getExclusionReason('2018', 1, opts, 1), 'dates');
 })();
 
 // --- Sprint B: per-type granularity ---


### PR DESCRIPTION
Plan: `plan/chrome-ext-ux-polish:docs/sprint-plans/chrome-ext-ux-polish.md`

## Acceptance criteria

- [x] Sidebar top-to-bottom: title row with inline toggle (no separate "Apply dynamic rounding" label) → exclusion groups → Range textbox (placeholder `(blank = whole table)`) → Advanced.
- [x] The word *also* rendered in italics (`<em>`) in the new section heading.
- [x] `#excludeFirstRow` ticking causes row 0 to be skipped during rounding (5 new assertions in `chrome-extension/tests.js`).
- [x] Context menu and in-extension UI show `Toggle readable data` instead of show-original / show-rounded.
- [x] `node chrome-extension/tests.js` passes (162/162). `node js/tests.js` passes (94/94).

## Reviewer notes

- `excludeWords` / `excludeCurrency` / `excludePercent` renamed to `includeWords` / `includeCurrency` / `includePercent`; boolean inverted at all read sites. Defaults preserve historical exclude-by-default behavior. New section heading is "Simplify the data even when cells *also* have:" with words / currency / percentage.
- New "Exclude:" section with first row, first column, dates, times. `excludeFirstRow` priority is above `excludeFirstColumn` in `getExclusionReason`.
- Bump manifest version to **1.9.0** (this is the last to merge of the two minors).
- Non-blocking: a code comment near `DEFAULT_SIDEBAR_OPTIONS` noting the include-flag inversion would help future readers