### PR TITLE
Sidebar and toggle share defaults

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -16,22 +16,9 @@ const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
 
-const DEFAULT_SIDEBAR_OPTIONS = {
-  enabled: true,
-  includeWords: false,
-  includeCurrency: false,
-  includePercent: false,
-  excludeFirstRow: false,
-  excludeFirstColumn: true,
-  excludeDates: true,
-  excludeTimes: true,
-  dateGranularity: 'year',     // year | decade | century
-  timeGranularity: 'minute',   // minute | hour
-  offsetTop: null,             // null = use DEFAULT_OFFSET_TOP
-  offsetOther: null,           // null = inherit from offsetTop
-  numTop: null,                // null = use DEFAULT_NUM_TOP
-  rangeExpr: ''                // '' = whole table; otherwise A1-style range expression
-};
+// DR_DEFAULTS is loaded from defaults.js (declared first in manifest content_scripts).
+// It is shared with sidebar.js so the sidebar UI's initial state and the
+// right-click toggle's fallback options come from a single source.
 
 let lastRightClickedElement = null;
 let lastRightClickedTable = null;
@@ -82,7 +69,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
   if (request.action === 'APPLY_SIDEBAR_SETTINGS') {
     if (lastRightClickedTable) {
-      applySidebarRounding(lastRightClickedTable, request.settings || DEFAULT_SIDEBAR_OPTIONS);
+      applySidebarRounding(lastRightClickedTable, request.settings || DR_DEFAULTS);
     }
     return;
   }
@@ -105,7 +92,7 @@ function requestSidebarSettingsAndApply(table, attempt = 0) {
       if (attempt < 10) {
         setTimeout(() => requestSidebarSettingsAndApply(table, attempt + 1), 50);
       } else {
-        applySidebarRounding(table, DEFAULT_SIDEBAR_OPTIONS);
+        applySidebarRounding(table, DR_DEFAULTS);
       }
       return;
     }
@@ -114,7 +101,7 @@ function requestSidebarSettingsAndApply(table, attempt = 0) {
 }
 
 function applySidebarRounding(table, options) {
-  const opts = Object.assign({}, DEFAULT_SIDEBAR_OPTIONS, options || {});
+  const opts = Object.assign({}, DR_DEFAULTS, options || {});
   ensureHighlightStyleInjected();
   resetTable(table);
   if (opts.enabled !== false) {
@@ -251,7 +238,7 @@ function resetTable(table) {
 }
 
 function roundTable(table, options) {
-  const opts = Object.assign({}, DEFAULT_SIDEBAR_OPTIONS, options || {});
+  const opts = Object.assign({}, DR_DEFAULTS, options || {});
   tableOptions.set(table, opts);
   const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
   const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
@@ -703,7 +690,7 @@ function toggleOriginalValues(table) {
   if (showingOriginal) {
     // Re-run the pipeline with the last-used options so the rounded view
     // reflects current parameters rather than a stale cached value.
-    const opts = tableOptions.get(table) || DEFAULT_SIDEBAR_OPTIONS;
+    const opts = tableOptions.get(table) || DR_DEFAULTS;
     resetTable(table);
     roundTable(table, opts);
   } else {

--- a/chrome-extension/defaults.js
+++ b/chrome-extension/defaults.js
@@ -1,0 +1,23 @@
+/**
+ * Single source of truth for sidebar UI defaults and content-script fallback.
+ * Loaded by both the content script (via manifest content_scripts) and the
+ * sidebar page (via <script src>). Editing values here changes both the
+ * sidebar's initial checkbox/dropdown state and the right-click toggle's
+ * default behavior so they stay in lockstep.
+ */
+const DR_DEFAULTS = {
+  enabled: true,
+  includeWords: true,
+  includeCurrency: true,
+  includePercent: true,
+  excludeFirstRow: false,
+  excludeFirstColumn: true,
+  excludeDates: true,
+  excludeTimes: true,
+  dateGranularity: 'decade',
+  timeGranularity: 'minute',
+  offsetTop: null,
+  offsetOther: null,
+  numTop: null,
+  rangeExpr: ''
+};

--- a/chrome-extension/defaults.js
+++ b/chrome-extension/defaults.js
@@ -10,7 +10,7 @@ const DR_DEFAULTS = {
   includeWords: true,
   includeCurrency: true,
   includePercent: true,
-  excludeFirstRow: false,
+  excludeFirstRow: true,
   excludeFirstColumn: true,
   excludeDates: true,
   excludeTimes: true,

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dynamic Rounding",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Applies dynamic rounding to tables on arbitrary websites.",
   "permissions": ["contextMenus", "activeTab", "scripting", "sidePanel"],
   "background": {
@@ -10,7 +10,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["content.js"]
+      "js": ["defaults.js", "content.js"]
     }
   ],
   "side_panel": {

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -195,7 +195,7 @@
   <div class="title-row">
     <h1>Dynamic Rounding</h1>
     <label class="switch">
-      <input type="checkbox" id="enabled" checked>
+      <input type="checkbox" id="enabled">
       <span class="slider"></span>
     </label>
   </div>
@@ -204,15 +204,15 @@
     <div class="exclusion-group">
       <p class="section-heading"><em>Include</em> numbers in cells containing:</p>
       <label class="checkbox-row">
-        <input type="checkbox" id="includeWords" checked>
+        <input type="checkbox" id="includeWords">
         <span>words</span>
       </label>
       <label class="checkbox-row">
-        <input type="checkbox" id="includeCurrency" checked>
+        <input type="checkbox" id="includeCurrency">
         <span>currencies</span>
       </label>
       <label class="checkbox-row">
-        <input type="checkbox" id="includePercent" checked>
+        <input type="checkbox" id="includePercent">
         <span>percentages</span>
       </label>
     </div>
@@ -224,25 +224,25 @@
         <span>first row</span>
       </label>
       <label class="checkbox-row">
-        <input type="checkbox" id="excludeFirstColumn" checked>
+        <input type="checkbox" id="excludeFirstColumn">
         <span>first column</span>
       </label>
       <label class="checkbox-row">
-        <input type="checkbox" id="excludeDates" checked>
+        <input type="checkbox" id="excludeDates">
         <span class="row-label">dates</span>
         <span class="granularity-label">round to:</span>
         <select id="dateGranularity" disabled>
           <option value="year">year</option>
-          <option value="decade" selected>decade</option>
+          <option value="decade">decade</option>
           <option value="century">century</option>
         </select>
       </label>
       <label class="checkbox-row">
-        <input type="checkbox" id="excludeTimes" checked>
+        <input type="checkbox" id="excludeTimes">
         <span class="row-label">times</span>
         <span class="granularity-label">round to:</span>
         <select id="timeGranularity" disabled>
-          <option value="minute" selected>minute</option>
+          <option value="minute">minute</option>
           <option value="hour">hour</option>
         </select>
       </label>
@@ -281,6 +281,7 @@
 
   <div class="status" id="status"></div>
 
+  <script src="defaults.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -218,7 +218,7 @@
     </div>
 
     <div class="exclusion-group">
-      <p class="section-heading">Exclude:</p>
+      <p class="section-heading"><em>Exclude</em>:</p>
       <label class="checkbox-row">
         <input type="checkbox" id="excludeFirstRow">
         <span>first row</span>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -133,6 +133,23 @@ window.addEventListener('unload', () => {
   }
 });
 
+// Seed the UI from the shared defaults so the sidebar and content.js never
+// drift apart. Editing defaults.js updates both at once.
+function applyDefaultsToUI() {
+  enabledEl.checked = DR_DEFAULTS.enabled !== false;
+  for (const id in CHECKBOX_TO_SETTING) {
+    const el = document.getElementById(id);
+    if (el) el.checked = !!DR_DEFAULTS[CHECKBOX_TO_SETTING[id]];
+  }
+  if (dateGranularityEl && DR_DEFAULTS.dateGranularity) {
+    dateGranularityEl.value = DR_DEFAULTS.dateGranularity;
+  }
+  if (timeGranularityEl && DR_DEFAULTS.timeGranularity) {
+    timeGranularityEl.value = DR_DEFAULTS.timeGranularity;
+  }
+}
+applyDefaultsToUI();
+
 // Defensively clear rangeExpr so browser autofill can never leak a stale value
 // into a hidden field and silently constrain content.js output.
 if (rangeExprEl) rangeExprEl.value = '';

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -20,8 +20,12 @@ global.document = { addEventListener: () => {} };
 global.window = { addEventListener: () => {} };
 global.NodeFilter = { SHOW_TEXT: 4 };
 
+// In a browser/extension the two files share a single top-level scope; we
+// emulate that here by evaluating them together, and re-expose DR_DEFAULTS on
+// globalThis so test assertions outside the eval can read it.
+const defaultsCode = fs.readFileSync(path.join(__dirname, 'defaults.js'), 'utf8');
 const code = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
-eval(code);
+eval(defaultsCode + '\n' + code + '\nglobalThis.DR_DEFAULTS = DR_DEFAULTS;');
 
 let passed = 0;
 let failed = 0;
@@ -1224,12 +1228,12 @@ function withLinkCreateTreeWalker(fn) {
   });
 })();
 
-// --- AC5: Version bumped in manifest.json (post-stack: 1.11.0) ---
+// --- AC5: Version bumped in manifest.json (post-stack: 1.12.0) ---
 (function ac5_manifestVersion() {
   const manifest = JSON.parse(
     require('fs').readFileSync(require('path').join(__dirname, 'manifest.json'), 'utf8'));
-  eq('AC5: manifest.json version is 1.11.0',
-    manifest.version, '1.11.0');
+  eq('AC5: manifest.json version is 1.12.0',
+    manifest.version, '1.12.0');
 })();
 
 // --- AC6: scope guard removed — was a git-diff-based assertion that
@@ -1392,10 +1396,10 @@ function withLinkCreateTreeWalker(fn) {
   eq('regression: read source is cell.innerText || cell.textContent',
     contentSrc.includes('cell.innerText || cell.textContent'), true);
 
-  // 5b. Manifest version is 1.11.0 (sprint 4 stacked on sprint 3 bumps further)
+  // 5b. Manifest version is 1.12.0 (sprint 4 stacked on sprint 3 bumps further)
   const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest.json'), 'utf8'));
-  eq('regression: manifest.version === "1.11.0"',
-    manifest.version, '1.11.0');
+  eq('regression: manifest.version === "1.12.0"',
+    manifest.version, '1.12.0');
 
   // 5c. Out-of-scope files not modified: sidebar.html, sidebar.js, js/, python/
   // We verify their content by checking they exist but do NOT contain getQuoteMaskedRanges.
@@ -1462,8 +1466,8 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
   const changelogPath = path.join(__dirname, '..', 'js', 'CHANGELOG.md');
 
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  eq('sprint regression: manifest version is 1.11.0',
-    manifest.version, '1.11.0');
+  eq('sprint regression: manifest version is 1.12.0',
+    manifest.version, '1.12.0');
 
   const readme = fs.readFileSync(readmePath, 'utf8');
   eq('sprint regression: js/README.md contains Sheets decimal precision section header',
@@ -1496,24 +1500,30 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
   const contentJsPath = path.join(__dirname, 'content.js');
   const contentJsSource = fs.readFileSync(contentJsPath, 'utf8');
 
-  // AC1: includeWords, includeCurrency, includePercent checkboxes must be pre-checked.
-  eq('sidebar-defaults: includeWords checkbox has "checked" attribute',
-    /id="includeWords"[^>]*checked/.test(sidebarHtml) ||
-    /<input[^>]*checked[^>]*id="includeWords"/.test(sidebarHtml), true);
-  eq('sidebar-defaults: includeCurrency checkbox has "checked" attribute',
-    /id="includeCurrency"[^>]*checked/.test(sidebarHtml) ||
-    /<input[^>]*checked[^>]*id="includeCurrency"/.test(sidebarHtml), true);
-  eq('sidebar-defaults: includePercent checkbox has "checked" attribute',
-    /id="includePercent"[^>]*checked/.test(sidebarHtml) ||
-    /<input[^>]*checked[^>]*id="includePercent"/.test(sidebarHtml), true);
-
-  // AC2: Date dropdown has decade as selected, and year option does NOT have selected.
-  eq('sidebar-defaults: date dropdown has decade selected',
-    /<option value="decade"[^>]*selected/.test(sidebarHtml) ||
-    /selected[^>]*value="decade"/.test(sidebarHtml), true);
-  eq('sidebar-defaults: date dropdown year option is NOT selected',
-    /<option value="year"[^>]*selected/.test(sidebarHtml) ||
-    /selected[^>]*value="year"/.test(sidebarHtml), false);
+  // AC1/AC2: Sidebar UI defaults now live in defaults.js (single source of
+  // truth shared with content.js). The HTML must NOT hard-code checked /
+  // selected attributes — they would shadow the JS-applied defaults.
+  eq('sidebar-defaults: includeWords default is true in DR_DEFAULTS',
+    DR_DEFAULTS.includeWords, true);
+  eq('sidebar-defaults: includeCurrency default is true in DR_DEFAULTS',
+    DR_DEFAULTS.includeCurrency, true);
+  eq('sidebar-defaults: includePercent default is true in DR_DEFAULTS',
+    DR_DEFAULTS.includePercent, true);
+  eq('sidebar-defaults: dateGranularity default is "decade" in DR_DEFAULTS',
+    DR_DEFAULTS.dateGranularity, 'decade');
+  eq('sidebar-defaults: timeGranularity default is "minute" in DR_DEFAULTS',
+    DR_DEFAULTS.timeGranularity, 'minute');
+  eq('sidebar-defaults: sidebar.html does not hard-code "checked" attributes',
+    /<input[^>]*checked/i.test(sidebarHtml), false);
+  eq('sidebar-defaults: sidebar.html does not hard-code "selected" options',
+    /<option[^>]*selected/i.test(sidebarHtml), false);
+  eq('sidebar-defaults: sidebar.html loads defaults.js before sidebar.js',
+    /defaults\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
+  eq('sidebar-defaults: sidebar.js applies DR_DEFAULTS to the UI on load',
+    /applyDefaultsToUI[\s\S]*DR_DEFAULTS/.test(sidebarJsSource), true);
+  eq('sidebar-defaults: manifest content_scripts loads defaults.js before content.js',
+    manifest.content_scripts[0].js[0] === 'defaults.js' &&
+    manifest.content_scripts[0].js[1] === 'content.js', true);
 
   // AC3: Section heading contains <em>Include</em> followed by " numbers in cells containing:"
   eq('sidebar-defaults: section-heading has <em>Include</em> with correct text',
@@ -1532,9 +1542,9 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
   eq('sidebar-defaults: content.js still defines parseRangeExpr',
     /function parseRangeExpr\b/.test(contentJsSource), true);
 
-  // AC6: manifest.json version is 1.11.0.
-  eq('sidebar-defaults: manifest version is 1.11.0',
-    manifest.version, '1.11.0');
+  // AC6: manifest.json version is 1.12.0.
+  eq('sidebar-defaults: manifest version is 1.12.0',
+    manifest.version, '1.12.0');
 
   // AC7: manifest permissions do NOT include "storage".
   eq('sidebar-defaults: manifest permissions does not include "storage"',
@@ -1548,7 +1558,7 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
 })();
 
 // ---------------------------------------------------------------------------
-// Sprint sidebar-settings-pull-and-unified-toggle (v1.11.0)
+// Sprint sidebar-settings-pull-and-unified-toggle (v1.12.0)
 // ---------------------------------------------------------------------------
 
 (function sprintSidebarPullAndUnifiedToggle() {
@@ -1560,8 +1570,8 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
   eq('pull: content.js sends GET_SIDEBAR_SETTINGS',
     /chrome\.runtime\.sendMessage\(\s*\{\s*action:\s*['"]GET_SIDEBAR_SETTINGS['"]/.test(contentSrc), true);
 
-  eq('pull: content.js no longer applies DEFAULT_SIDEBAR_OPTIONS on SIDEBAR_OPENED',
-    /SIDEBAR_OPENED[\s\S]{0,200}applySidebarRounding\([^)]*DEFAULT_SIDEBAR_OPTIONS/.test(contentSrc), false);
+  eq('pull: content.js no longer applies defaults on SIDEBAR_OPENED',
+    /SIDEBAR_OPENED[\s\S]{0,200}applySidebarRounding\([^)]*DR_DEFAULTS/.test(contentSrc), false);
 
   eq('pull: sidebar.js handles GET_SIDEBAR_SETTINGS and responds with currentSettings()',
     /GET_SIDEBAR_SETTINGS[\s\S]{0,120}sendResponse\([^)]*currentSettings\(\)/.test(sidebarSrc), true);


### PR DESCRIPTION
## Summary
- **Shared defaults**: extract sidebar UI defaults and content-script
  fallback options into a single `chrome-extension/defaults.js`
  (`DR_DEFAULTS`), loaded by both the content script (via manifest
  content_scripts) and the sidebar page (via <script src>). Strip
  hard-coded `checked`/`selected` attributes from `sidebar.html`;
  `sidebar.js` seeds the UI from `DR_DEFAULTS` on load. Fixes the
  divergence where the right-click "Toggle readable data" rounded
  aggressively but the sidebar's first paint rounded lightly because
  the two sides held drifted copies of the defaults.
- **Pull sidebar settings on open**: content script now requests
  `GET_SIDEBAR_SETTINGS` from the sidebar on `SIDEBAR_OPENED` (with
  brief retry while the panel finishes loading) instead of applying
  defaults that may not match the visible checkbox state.
- **Unified rounding path**: drop the per-cell `data-rounded-value`
  cache. Each rounded cell stores its pristine `innerHTML` in
  `data-original-html`, and the table remembers its last-applied
  options in a per-table `WeakMap`. `resetTable` and the "show
  original" branch of toggle restore from the HTML cache; the "show
  rounded" branch re-runs `roundTable` with the stored options so it
  always reflects current parameters.
- **Format-only simplification**: cells like `"35.0"` whose numeric
  value rounds to itself but whose display format would simplify
  (to `"35"`) are now re-rendered instead of skipped.
- **excludeFirstRow** now defaults to `true`; "Exclude" heading
  italicized to match "Include".