### PR TITLE
Suppress toggle switch on layout tables via isDataTable heuristic

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -206,7 +206,28 @@ function positionToggle(table, labelEl) {
   labelEl.style.top = top + 'px';
 }
 
+function isDataTable(table) {
+  if (table.rows.length < 2) return false;
+  let hasMultipleColumns = false;
+  for (let i = 0; i < table.rows.length; i++) {
+    if (table.rows[i].cells.length >= 2) {
+      hasMultipleColumns = true;
+      break;
+    }
+  }
+  if (!hasMultipleColumns) return false;
+  for (let i = 0; i < table.rows.length; i++) {
+    const row = table.rows[i];
+    for (let j = 0; j < row.cells.length; j++) {
+      const text = row.cells[j].textContent.trim().replace(CLEAN_REGEX, '');
+      if (text !== '' && isFinite(parseFloat(text))) return true;
+    }
+  }
+  return false;
+}
+
 function createToggleForTable(table) {
+  if (!isDataTable(table)) return;
   ensureToggleStyleInjected();
 
   const label = document.createElement('label');

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1943,7 +1943,10 @@ function injectToggleEntry(table) {
     }
   };
 
-  const table = makeToggleTable([{ tag: 'td', text: '50000' }]);
+  const table = makeToggleTable([
+    [{ tag: 'td', text: '50000' }, { tag: 'td', text: '100' }],
+    [{ tag: 'td', text: '200' }, { tag: 'td', text: '300' }],
+  ]);
   // Stub table.getBoundingClientRect (already defined on makeToggleTable)
 
   // ensureToggleStyleInjected calls document.createElement('style') + appendChild;

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -58,6 +58,7 @@ globalThis.createToggleForTable = createToggleForTable;
 globalThis.runToggleAction = runToggleAction;
 globalThis.toggleOriginalValues = toggleOriginalValues;
 globalThis.injectTableToggles = injectTableToggles;
+globalThis.isDataTable = isDataTable;
 `);
 
 let passed = 0;
@@ -2251,7 +2252,10 @@ function injectToggleEntry(table) {
   global.document.documentElement = { appendChild() {} };
   toggleStyleInjected = false;
 
-  const table = makeToggleTable([{ tag: 'td', text: '50000' }]);
+  const table = makeToggleTable([
+    [{ tag: 'td', text: '50000' }, { tag: 'td', text: '100' }],
+    [{ tag: 'td', text: '200' },   { tag: 'td', text: '300' }],
+  ]);
   createToggleForTable(table);
 
   // Restore
@@ -2343,7 +2347,10 @@ function injectToggleEntry(table) {
   global.document.documentElement = { appendChild() {} };
   toggleStyleInjected = false;
 
-  const table = makeToggleTable([{ tag: 'td', text: '50000' }]);
+  const table = makeToggleTable([
+    [{ tag: 'td', text: '50000' }, { tag: 'td', text: '100' }],
+    [{ tag: 'td', text: '200' },   { tag: 'td', text: '300' }],
+  ]);
   createToggleForTable(table);
 
   // Restore
@@ -2385,6 +2392,80 @@ function injectToggleEntry(table) {
   }
   eq('accessibility AC3: non-Enter keydown does NOT call input.click()',
     inputEl ? inputEl._clickCount : -1, clicksBefore);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint layout-table-exclusion: isDataTable heuristic
+// ---------------------------------------------------------------------------
+//
+// isDataTable(table) returns true iff:
+//   - table.rows.length >= 2
+//   - at least one row has cells.length >= 2
+//   - at least one cell has numeric textContent (CLEAN_REGEX stripped + parseFloat + isFinite)
+//
+// Helper: build a minimal table stub for isDataTable.
+// rowsSpec: array of arrays of textContent strings.
+function makeIsDataTable(rowsSpec) {
+  return {
+    rows: rowsSpec.map(rowTexts => ({
+      cells: rowTexts.map(text => ({ textContent: text }))
+    }))
+  };
+}
+
+// AC1: 1×1 table with a numeric cell → false (< 2 rows AND < 2 columns)
+(function isDataTable_1x1_numeric() {
+  const table = makeIsDataTable([['42']]);
+  eq('isDataTable: 1×1 table with numeric cell -> false (too few rows)',
+    isDataTable(table), false);
+})();
+
+// AC2: 2×2 table with no numeric cells → false
+(function isDataTable_2x2_noNumeric() {
+  const table = makeIsDataTable([
+    ['foo', 'bar'],
+    ['baz', 'qux'],
+  ]);
+  eq('isDataTable: 2×2 table with no numeric cells -> false',
+    isDataTable(table), false);
+})();
+
+// AC3: 2×2 table with one numeric cell → true
+(function isDataTable_2x2_oneNumeric() {
+  const table = makeIsDataTable([
+    ['label', 'other'],
+    ['row2',  '1,234'],
+  ]);
+  eq('isDataTable: 2×2 table with one numeric cell -> true',
+    isDataTable(table), true);
+})();
+
+// AC4: 3×3 table with all-text cells → false
+(function isDataTable_3x3_allText() {
+  const table = makeIsDataTable([
+    ['Name',  'Role',   'Dept'],
+    ['Alice', 'Eng',    'R&D'],
+    ['Bob',   'Design', 'UX'],
+  ]);
+  eq('isDataTable: 3×3 table with all-text cells -> false',
+    isDataTable(table), false);
+})();
+
+// AC5: 1-row table with numeric cells → false (< 2 rows)
+(function isDataTable_1row_numeric() {
+  const table = makeIsDataTable([['100', '200', '300']]);
+  eq('isDataTable: 1-row table with numeric cells -> false (< 2 rows)',
+    isDataTable(table), false);
+})();
+
+// AC6: 2-row, 1-column table with numeric cells → false (< 2 columns in every row)
+(function isDataTable_2row_1col_numeric() {
+  const table = makeIsDataTable([
+    ['1000'],
+    ['2000'],
+  ]);
+  eq('isDataTable: 2-row 1-column table with numeric cells -> false (< 2 columns)',
+    isDataTable(table), false);
 })();
 
 // --- Report ---


### PR DESCRIPTION
Plan: feature/auto-table-toggle2:docs/sprint-plans/auto-table-toggle2.md

## Acceptance criteria
- [x] A `<table>` with no numeric cells receives no toggle switch.
- [x] A `<table>` with fewer than 2 rows or 2 columns receives no toggle switch.
- [x] A `<table>` with ≥ 2×2 structure and at least one numeric cell receives a toggle switch.
- [x] `node chrome-extension/tests.js` passes including the new `isDataTable` tests.

## Reviewer notes
- `isDataTable` reuses `CLEAN_REGEX` — no second detection expression.
- MutationObserver path inherits the gate via `createToggleForTable` early return.
- Existing `createToggleForTable` stub updated from 1-cell to 2×2 numeric table.
- Tests: 344 passed, 0 failed (+6 new isDataTable tests).