### PR TITLE
fix: restore missing })(); closing visGate_normalVisible test

### DIFF
--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -2483,6 +2483,9 @@ function injectToggleEntry(table) {
 
   eq('visGate: normal visible table → labelEl.style.display is "" (shown)',
     labelEl.style.display, '');
+})();
+
+// ---------------------------------------------------------------------------
 // Sprint layout-table-exclusion: isDataTable heuristic
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
The GitHub merge editor dropped the `})();` that closes the `visGate_normalVisible` IIFE when resolving the conflict between PRs #45 and #46. This left the isDataTable test section inside an unclosed function, causing a `SyntaxError: Unexpected end of input` in CI.

Fix: insert the missing `})();` and the separator comment line.

355 tests pass locally.