### PR TITLE
fix(ci): use gh pr create instead of curl in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -79,6 +79,8 @@ jobs:
           PY
 
       - name: Open version-bump PR if anything changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git add -A
           if git diff --cached --quiet; then
@@ -89,13 +91,8 @@ jobs:
           git checkout -b "$BUMP_BRANCH"
           git commit -m "chore(version): bump after #${{ github.event.pull_request.number }}"
           git push origin "$BUMP_BRANCH"
-          curl -s -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/pulls \
-            -d "{
-              \"title\": \"chore(version): bump after #${{ github.event.pull_request.number }}\",
-              \"head\": \"$BUMP_BRANCH\",
-              \"base\": \"main\",
-              \"body\": \"Automated version bump triggered by merge of PR #${{ github.event.pull_request.number }}.\"
-            }"
+          gh pr create \
+            --title "chore(version): bump after #${{ github.event.pull_request.number }}" \
+            --body "Automated version bump triggered by merge of PR #${{ github.event.pull_request.number }}." \
+            --base main \
+            --head "$BUMP_BRANCH"


### PR DESCRIPTION
The previous `curl -s` call silently swallowed all errors, so failures were invisible. Switching to `gh pr create` (pre-installed on Actions runners) gives proper exit codes and visible error output.

**One manual step required after merging:** Go to **Settings → Actions → General** and enable **"Allow GitHub Actions to create and approve pull requests"** — otherwise `gh pr create` will get a 403 regardless of the workflow token permissions.