### PR TITLE
Trim trailing decimal zeros for ROUND_DYNAMIC results between -10 and 10

### DIFF
--- a/js/round_dynamic.js
+++ b/js/round_dynamic.js
@@ -153,7 +153,7 @@ function roundWithOffset(num, offset) {
   // Add epsilon to handle floating point inaccuracies
   let rounded = Math.round(num / rounding_base + EPSILON) * rounding_base;
   
-  if (Math.abs(rounded) >= 10) {
+  if (Math.abs(rounded) >= 10 || rounded % 1 === 0) {
     rounded = Math.round(rounded);
   }
   

--- a/js/tests.js
+++ b/js/tests.js
@@ -402,6 +402,25 @@ test('Near MAX_SAFE_INTEGER', ROUND_DYNAMIC(9007199254740991), 9000000000000000)
 // Empty array
 testArray('Empty array', ROUND_DYNAMIC([]), []);
 
+// =============================================================================
+// TRAILING ZEROS TESTS
+// =============================================================================
+
+console.log('=== Trailing Zeros (|result| < 10) ===\n');
+
+// Whole-number results between -10 and 10 must be integers (no trailing zeros)
+test('1.13 offset=0.5 → integer 1', ROUND_DYNAMIC(1.13, 0.5) === 1, true);
+test('1.76 offset=0.5 → integer 2', ROUND_DYNAMIC(1.76, 0.5) === 2, true);
+test('1.0 offset=0.5 → integer 1', ROUND_DYNAMIC(1.0, 0.5) === 1, true);
+test('1.0 offset=0.25 → integer 1', ROUND_DYNAMIC(1.0, 0.25) === 1, true);
+test('negative -1.13 offset=0.5 → integer -1', ROUND_DYNAMIC(-1.13, 0.5) === -1, true);
+
+// Non-integer results must stay as floats (not rounded further)
+test('1.42 offset=0.5 → 1.5 (float)', ROUND_DYNAMIC(1.42, 0.5), 1.5);
+test('1.32 offset=0.5 → 1.5 (float)', ROUND_DYNAMIC(1.32, 0.5), 1.5);
+test('1.13 offset=0.25 → 1.25 (float)', ROUND_DYNAMIC(1.13, 0.25), 1.25);
+test('1.42 offset=0.25 → 1.5 (float)', ROUND_DYNAMIC(1.42, 0.25), 1.5);
+
 // Array with only non-numerics (max_mag will be null)
 const nonNumericArray = [
     ['Cloud CDN'],

--- a/python/dynamic_rounding/__init__.py
+++ b/python/dynamic_rounding/__init__.py
@@ -169,14 +169,16 @@ def _round_with_offset(value: float, offset: float) -> float:
 
 def _preserve_type(result: float, original_value: Any) -> Union[int, float]:
     """
-    Preserve input type when possible.
-    
+    Preserve input type when possible, and trim trailing zeros for small results.
+
     Returns int if:
-        - original_value was int, AND
-        - result is a whole number
+        - original_value was int and result is a whole number, OR
+        - |result| < 10 and result is a whole number (trim trailing zeros)
     Otherwise returns float.
     """
     if isinstance(original_value, int) and result == int(result):
+        return int(result)
+    if abs(result) < 10 and result == int(result):
         return int(result)
     return result
 

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -185,9 +185,61 @@ class TestEdgeCases:
 
 class TestOffsetSymmetry:
     """Test that 0.5 and -0.5 produce same results (as documented)."""
-    
+
     def test_half_offset_symmetry(self):
         assert round_dynamic(87654321, offset=0.5) == round_dynamic(87654321, offset=-0.5)
-    
+
     def test_point_three_symmetry(self):
         assert round_dynamic(87654321, offset=0.3) == round_dynamic(87654321, offset=-0.3)
+
+
+class TestTrailingZeros:
+    """Whole-number results with |value| < 10 should return int, not float."""
+
+    def test_whole_number_result_is_int(self):
+        result = round_dynamic(1.13, offset=0.5)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_whole_number_negative_is_int(self):
+        result = round_dynamic(-1.13, offset=0.5)
+        assert result == -1
+        assert isinstance(result, int)
+
+    def test_whole_number_two_is_int(self):
+        result = round_dynamic(1.76, offset=0.5)
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_whole_number_from_exact_input_is_int(self):
+        result = round_dynamic(1.0, offset=0.5)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_fractional_result_stays_float(self):
+        result = round_dynamic(1.42, offset=0.5)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_two_decimal_result_stays_float(self):
+        result = round_dynamic(1.13, offset=0.25)
+        assert result == 1.25
+        assert isinstance(result, float)
+
+    def test_one_decimal_result_stays_float(self):
+        result = round_dynamic(1.42, offset=0.25)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_large_float_input_unaffected(self):
+        # float input > 10 that rounds to whole number should remain float
+        result = round_dynamic(87654321.0)
+        assert result == 90000000
+        assert isinstance(result, float)
+
+    def test_whole_number_in_list(self):
+        result = round_dynamic([1.13, 1.42], offset_top=0.5)
+        assert result[0] == 1
+        assert isinstance(result[0], int)
+        assert result[1] == 1.5
+        assert isinstance(result[1], float)


### PR DESCRIPTION
Lands the `trim-trailing-zeros` sprint.

For `ROUND_DYNAMIC` results with `|value| < 10`, whole-number results now return as integer `1` rather than float `1.0`, eliminating trailing decimal zeros. Fractional results (`1.5`, `1.25`) are unchanged.

- JS `roundWithOffset`: `|rounded| >= 10 || rounded % 1 === 0` → `Math.round()`
- Python `_preserve_type`: also converts to `int` when `abs(result) < 10` and result is a whole number, regardless of input type
- 9 new JS tests + 9 new Python tests, all passing, 0 regressions