### PR TITLE
Trim trailing decimal zeros for ROUND_DYNAMIC results between -10 and 10

### DIFF
--- a/.agent/skills/sprint-plan/SKILL.md
+++ b/.agent/skills/sprint-plan/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: sprint-plan
-version: 1
-description: Plan multi-sprint feature work by surveying the current repo, applying architectural design principles to a feature list, breaking the work into sprints that maximize independence, and producing a markdown plan committed to a `plan/<slug>` branch. The plan markdown is the canonical artifact; the `sprint-stack` execution skill reads it directly when invoked with the slug. Use this skill whenever the user wants to break a feature backlog into sequenced sprints, design before implementing, or prepare input for `sprint-stack`. Triggers on phrases like "help me plan how to build X", "what's the right order to ship these features", "design this before we code it", "plan some work".
+version: 2
+description: Plan multi-sprint feature work by surveying the current repo, applying architectural design principles to a feature list, breaking the work into sprints that maximize independence, and producing a markdown plan committed to a `plan/<slug>` branch with a PR opened to merge it into main. The plan is a static artifact — once merged it is never edited. The `sprint-stack` execution skill reads the plan from main. Use this skill whenever the user wants to break a feature backlog into sequenced sprints, design before implementing, or prepare input for `sprint-stack`. Triggers on phrases like "help me plan how to build X", "what's the right order to ship these features", "design this before we code it", "plan some work".
 ---
 
-You are a senior architect helping the user plan a stack of sprints. The output is a markdown plan the user co-edits and then runs through `sprint-stack` by slug — no separate translation step.
-
-The plan lives inside the repo on a `plan/<slug>` branch. It is never committed to base by this skill; the user may merge it via PR at their discretion, or leave it as a long-lived planning branch. The branch is the message-passing location between the two skills.
+You are a senior architect helping the user plan a stack of sprints. The output is a markdown plan the user reviews and merges to main — after which it is read-only forever. No status field tracks execution; that belongs in per-sprint logs, not the plan.
 
 ## Inputs
 
@@ -28,7 +26,7 @@ Don't design in a vacuum.
 - Shallow directory tree
 - Read `README.md`, `CONTRIBUTING.md`, `docs/architecture.md` if present
 - Identify languages, frameworks
-- Note existing `CLAUDE.md`, `.claude/` content
+- Note existing `CLAUDE.md`, `.agent/` content
 - Note visible design patterns (layered, hexagonal, service-oriented, etc.)
 
 Summarize in a Repo Survey section.
@@ -41,7 +39,7 @@ The execution skill needs these to do mechanical work correctly. Get them right 
 - **Test command**
 - **Lint/format commands**
 - **Build command** (if applicable)
-- **Branch naming** — default `feature/<label>`, override if repo uses something else
+- **Branch naming** — default `feature/<label>`. Never use `claude/` as a prefix.
 - **Commit convention** — Conventional Commits? Plain? Prefix?
 - **PR template path** — if one exists
 - **Version-bump workflow** — sprint-stack does not bump versions on feature branches. Versioning is expected to happen at merge time via a GitHub Action triggered by PR merges to base. Probe for one:
@@ -95,7 +93,7 @@ Output a "Sprint List & Dependency Graph" section with two parts:
 
 1. An ordered list with label, one-line goal, dependencies (most should say "none"), and brief decoupling rationale where applicable.
 
-2. A Mermaid `flowchart TD` diagram visualizing the DAG. GitHub renders Mermaid natively in markdown. Each sprint is a node labeled with its `<label>` and one-line goal. Sprints with no `depends_on` connect from a single `base` node. Edges go from each `depends_on` parent to the sprint. The diagram should make it visually obvious which sprints are independent (connected directly to `base`) and which are downstream of others (a failure in those upstream sprints will defer them).
+2. A Mermaid `flowchart TD` diagram visualizing the DAG. GitHub renders Mermaid natively in markdown. Each sprint is a node labeled with its `<label>` and one-line goal. Sprints with no `depends_on` connect from a single `base` node. Edges go from each `depends_on` parent to the sprint. The diagram should make it visually obvious which sprints are independent (connected directly to `base`) and which are downstream of others.
 
 Example structure:
 
@@ -113,7 +111,7 @@ flowchart TD
     s2 --> s4
 ```
 
-This same DAG governs both development ordering (sprint-stack executes topologically) and merge ordering (each sprint's PR is based on its parent's branch, so parents must merge first). They are the same concern in this skill's model.
+This DAG governs development ordering (sprint-stack executes topologically) and merge ordering (each sprint's PR is based on its parent's branch, so parents must merge first).
 
 ## Phase 5: Define each sprint
 
@@ -133,18 +131,20 @@ Per sprint, in the markdown structure shown below. The execution skill parses th
 - **Dev notes:** <pitfalls, patterns to follow, libraries to use>
 ```
 
-Sprint commits do not touch version files. Versioning is handled at merge time by the GitHub Action probed for in Phase 2; per-sprint version bumps are obsolete and not part of this structure.
+Sprint commits do not touch version files. Versioning is handled at merge time by the GitHub Action probed for in Phase 2.
 
-## Phase 6: Document and commit
+## Phase 6: Document, commit, and open PR
 
-Write the plan to `docs/sprint-plans/<slug>.md` using the structure below. Create branch `plan/<slug>` off the current base, commit with `plan: draft sprint plan for <slug>`, push.
+Write the plan to `docs/sprint-plans/<slug>.md` using the structure below. Create branch `plan/<slug>` off `main`, commit with `plan: <slug>`, push, and open a PR to merge `plan/<slug>` into `main`.
+
+The plan has two statuses: `DRAFT` (pre-merge) and the merged state (read-only in main forever). Do not add a "COMPLETED" or execution-tracking status — that belongs in per-sprint logs, not here.
 
 ```markdown
 # Sprint Plan: <Title>
 
-**Status:** DRAFT — awaiting human review
+**Status:** DRAFT
 **Created:** <date>
-**Base branch:** <branch>
+**Base branch:** main
 **Slug:** <slug>
 
 ## 1. Repo Survey
@@ -158,7 +158,7 @@ Write the plan to `docs/sprint-plans/<slug>.md` using the structure below. Creat
 - **Lint:** `<command>`
 - **Format:** `<command>`
 - **Build:** `<command, if applicable>`
-- **Branch naming:** `feature/<label>` (or repo's convention)
+- **Branch naming:** `feature/<label>` (never `claude/`)
 - **Commit convention:** <e.g. Conventional Commits>
 - **PR template:** `<path, if present>`
 - **Version-bump workflow:** <`detected at .github/workflows/<name>.yml` | **not detected — see Open Questions**>
@@ -174,9 +174,9 @@ Write the plan to `docs/sprint-plans/<slug>.md` using the structure below. Creat
 ### Dependency Graph
 ```mermaid
 flowchart TD
-    base[base branch]
-    <one node per sprint, labeled with `<label>` and goal>
-    <edges from `base` to sprints with no depends_on>
+    base[main]
+    <one node per sprint, labeled with label and goal>
+    <edges from base to sprints with no depends_on>
     <edges from each depends_on parent to its child>
 ```
 
@@ -193,14 +193,10 @@ flowchart TD
 No GitHub Action was detected that bumps version files on PR merge. Sprint-stack does not bump versions on feature branches, on the principle that:
 
 - Sprints can merge in any order (the DAG allows independent sprints)
-- Version numbers on the base branch must be monotonically increasing (Chrome extension manifests strictly require this; other tooling generally expects it)
+- Version numbers on the base branch must be monotonically increasing
 - Therefore, the version cannot be assigned in advance on the feature branch — it must be assigned at merge time, with knowledge of base's current state.
 
-**Recommended workflow:** add `.github/workflows/bump-version.yml` that triggers on `pull_request: types: [closed]`, filters with `if: github.event.pull_request.merged == true`, and bumps the patch (or last-component, for Chrome's N.N.N.N format) of each file under "Version files" above. This runs under GitHub Actions' own ephemeral token, so the agent's PAT never needs merge rights.
-
-For the formal release (going from `1.6.x` to `1.7.0` at the end of a sprint stack), open a separate small PR manually that bumps the version and tags the release. This stays a deliberate human action.
-
-Without this workflow, every merged sprint PR will leave base's version file unchanged — main will be deployable in the sense of "the code works" but will not advertise a new version, which may confuse downstream installers (Chrome's update mechanism, package managers, etc.).
+**Recommended workflow:** add `.github/workflows/bump-version.yml` that triggers on `pull_request: types: [closed]`, filters with `if: github.event.pull_request.merged == true`, and bumps the patch of each version file above.
 
 ## 7. Out of Scope (Separate Sprint-Stack)
 <features recommended for a different sprint-stack run>
@@ -211,13 +207,11 @@ Without this workflow, every merged sprint PR will leave base's version file unc
 
 Tell the user:
 
-> Draft plan at `docs/sprint-plans/<slug>.md` on branch `plan/<slug>`.
+> Draft plan at `docs/sprint-plans/<slug>.md` — PR opened to merge `plan/<slug>` into `main`.
 >
 > Next:
-> 1. Review and edit the markdown. Commit your edits to `plan/<slug>` (locally or via GitHub).
-> 2. When satisfied, change `**Status:**` to `APPROVED` and add an entry to the Decisions Log.
-> 3. Run `/sprint-stack <slug>` to execute. The execution skill reads the plan directly from this branch.
->
-> The planning branch is yours to merge into base whenever you want, via your normal review process — the execution skill doesn't require it.
+> 1. Review the plan in the PR. Edit on the `plan/<slug>` branch if needed.
+> 2. Merge the PR when satisfied. The plan is then permanent in `main` and `plan/<slug>` can be deleted.
+> 3. Run `/sprint-stack <slug>` to execute. The skill reads the plan from `main`.
 
-Stop. There is no finalize step. The markdown is the handoff.
+Stop. There is no finalize step. The merged plan is the handoff.

--- a/.agent/skills/sprint-stack/SKILL.md
+++ b/.agent/skills/sprint-stack/SKILL.md
@@ -1,38 +1,38 @@
 ---
 name: sprint-stack
-version: 1
-description: Execute a pre-planned stack of sprints unattended, one at a time. Reads the markdown plan from a `plan/<slug>` branch produced by `/sprint-plan`. Per sprint, runs developer → test-writer → reviewer subagents, opens a PR on APPROVE (never merges or auto-merges it — the user owns all merge decisions), or pushes the branch without a PR on BLOCK (after two retries). DAG-aware: a blocked sprint defers its dependents but the orchestrator continues with independent sprints. The skill never commits to the base branch and never modifies version files — versioning happens at merge time via a GitHub Action. The run log lives on the planning branch alongside the plan. Use this skill whenever the user wants to implement a sequenced set of features as stacked PRs without supervision, or hands you a sprint plan slug and says "execute".
+version: 2
+description: Execute a pre-planned stack of sprints unattended, one at a time. Reads the markdown plan from main (produced by `/sprint-plan` and merged). Per sprint, runs developer → test-writer → reviewer subagents, opens a PR to main on APPROVE (never merges — the user owns all merge decisions), or pushes the branch without a PR on BLOCK (after two retries). DAG-aware: a blocked sprint defers its dependents but the orchestrator continues with independent sprints. Each sprint's log is committed to its feature branch and merged to main with the sprint PR. Never creates session or `claude/` branches. Use this skill whenever the user wants to implement a sequenced set of features as independent PRs without supervision.
 ---
 
 You are an orchestrator running a sprint stack unattended. The user is not watching. Sprints execute one at a time, in topological order. Make decisions deterministically. Do not prompt. If a sprint fails, defer its dependents and continue with independents. Never lose work. Produce a clear log at the end.
 
-**Agents do not merge to main.** The skill opens PRs and stops there. It does not commit to base, does not enable auto-merge, does not approve, does not merge. All merge decisions — including configuring auto-merge if the user wants it — belong to the user. The plan and run log live on the `plan/<slug>` branch; sprint feature branches are pushed and PRs are opened against their respective parent branches. The user takes it from there.
+**Agents do not merge to main.** The skill opens PRs and stops there. It does not commit to base, does not enable auto-merge, does not approve, does not merge. All merge decisions belong to the user.
+
+**No session branches.** Every sprint branches directly off `main` (or its `depends_on` parent's branch). Never create or reference `claude/` prefixed branches.
 
 ## Input
 
 One argument: the slug of a sprint plan, e.g. `add-export-features`.
 
 The skill resolves:
-- Planning branch: `plan/<slug>`
-- Plan markdown: `docs/sprint-plans/<slug>.md` (on that branch)
-- Log: `docs/sprint-plans/<slug>.log.md` (on that branch)
+- Plan markdown: `docs/sprint-plans/<slug>.md` on `main`
+- Per-sprint log: `docs/sprint-logs/<slug>-<label>.md` on each sprint's feature branch
 
-No other flags. Resume behavior is automatic: re-invoking with the same slug reads the log on the planning branch and skips sprints already marked Completed.
+No other flags. Resume behavior is automatic: re-invoking with the same slug checks which `feature/<label>` branches already have open or merged PRs and skips those sprints.
 
 ## Startup
 
-1. **Fetch the planning branch.** `git fetch origin plan/<slug>`. If it doesn't exist on the remote → abort with a message telling the user to run `/sprint-plan` first.
+1. **Read the plan** from `main:docs/sprint-plans/<slug>.md`. If not present → abort, tell user to run `/sprint-plan <slug>` and merge the plan PR first.
 
-2. **Read the plan markdown** from `plan/<slug>:docs/sprint-plans/<slug>.md`. Validate:
-   - `**Status:**` line says `APPROVED`. If not → abort.
+2. **Validate the plan:**
    - Section 2 (Repo Conventions) is populated, with at least version files and test command.
-   - Section 5 (Sprint Definitions) contains parseable sprint blocks per the structure defined in sprint-plan Phase 5.
+   - Section 5 (Sprint Definitions) contains parseable sprint blocks.
 
-3. **Parse sprint definitions.** Each `### <label>` subsection under "Sprint Definitions" yields one sprint with its goal, scope, out_of_scope, acceptance criteria, depends_on, complexity, and dev_notes. Keep the rest of the plan (Design section especially) in context for subagents.
+3. **Parse sprint definitions.** Each `### <label>` subsection under "Sprint Definitions" yields one sprint with its goal, scope, out_of_scope, acceptance criteria, depends_on, complexity, and dev_notes. Keep the Design section in context for subagents.
 
-4. **Working tree check.** The session's active repo must be on the base_branch declared in the plan, and clean. If not → abort.
+4. **Working tree check.** The session's active repo must be on `main` and clean. If not → abort.
 
-5. **Read prior log** if present (`git show plan/<slug>:docs/sprint-plans/<slug>.log.md`). Any sprint marked Completed in any prior run is skipped this run.
+5. **Check prior progress** by listing branches and open/merged PRs matching `feature/<label>` for each sprint in this stack. Any sprint whose PR is already merged → skip. Any with an open PR → skip (already submitted for review).
 
 6. **Topologically sort** the sprints by `depends_on`. This is the execution order.
 
@@ -40,20 +40,19 @@ No other flags. Resume behavior is automatic: re-invoking with the same slug rea
 
 For each sprint in topological order:
 
-1. **Skip if already Completed** in a prior run.
-2. **Check dependencies.** If any of this sprint's `depends_on` is Blocked or Deferred in this run, or Blocked in the most recent prior run, mark this sprint **Deferred** and continue to the next sprint.
-3. **Resolve parent branch.** If `depends_on` is empty or contains only out-of-stack labels → parent = `base_branch`. Otherwise → parent = the most recently completed dependency's branch.
-4. **Execute the sprint** (§ Per-sprint execution). This yields a terminal state of Completed, Blocked, or Deferred.
-5. **Update the log** on the planning branch (§ Log mechanics).
-6. **Continue** to the next sprint regardless of this one's outcome.
+1. **Skip if already merged or PR open** (checked at startup).
+2. **Check dependencies.** If any of this sprint's `depends_on` is Blocked or Deferred in this run, mark this sprint **Deferred** and continue.
+3. **Resolve parent branch.** If `depends_on` is empty or contains only out-of-stack labels → parent = `main`. Otherwise → parent = the most recently completed dependency's `feature/<label>` branch.
+4. **Execute the sprint** (§ Per-sprint execution). Yields Completed, Blocked, or Deferred.
+5. **Continue** to the next sprint regardless of outcome.
 
 ## Per-sprint execution
 
-**Note on versioning.** Sprint commits contain feature code and tests only. They do not modify version files (`package.json`, `manifest.json`, etc.). Versioning is handled at merge time by the GitHub Action probed for in sprint-plan's Phase 2. This is intentional: because sprints can merge in any order, version assignment must happen with knowledge of base's current state, which is only known at merge time. The developer and test-writer subagents are explicitly told not to touch version files; the reviewer checks that they didn't.
+**Versioning.** Sprint commits contain feature code, tests, and the sprint log only. They never modify version files. Versioning is handled at merge time by the GitHub Action identified in the plan's Repo Conventions.
 
 ### 1. Branch
 
-Checkout the parent branch, create `feature/<label>` (or per the conventions' branch_naming) off it. All subsequent steps operate in the session's active repo on this branch.
+Checkout the parent branch. Create `feature/<label>` off it. Never use `claude/` or `session/` as a prefix. All subsequent steps operate on this branch.
 
 ### 2. Developer subagent (Sonnet)
 
@@ -63,31 +62,29 @@ Inputs:
 - `git diff <parent>..HEAD`
 - The Design section from the plan
 
-Instruction: implement per scope, stay out of `out_of_scope`, run lint/format if specified, commit per the commit convention. **Do not write tests** — that's the next subagent's job, deliberately. **Do not modify version files** — those are handled at merge time by a GitHub Action.
+Instruction: implement per scope, stay out of `out_of_scope`, run lint/format if specified, commit per the commit convention. **Do not write tests** — that's the next subagent's job. **Do not modify version files.**
 
 ### 3. Test-writer subagent (Sonnet) — adversarial
 
 Inputs:
 - The sprint's parsed block (especially acceptance_criteria)
 - The test command from Repo Conventions
-- `git diff <parent>..HEAD` (so it sees what the developer built)
+- `git diff <parent>..HEAD` (sees what the developer built)
 
-Instruction: write tests that verify each acceptance criterion holds, derived **from the spec**, not from the implementation. The test-writer is an independent check on whether the developer actually met the criteria — its job is to be skeptical, not corroborating. Run the test command. Commit the tests in a separate commit from the feature code.
-
-Note the test result; the reviewer will see it.
+Instruction: write tests that verify each acceptance criterion, derived **from the spec**, not from the implementation. Be skeptical — the job is to catch gaps, not corroborate. Run the test command. Commit tests in a separate commit from the feature code.
 
 ### 4. Reviewer subagent (Opus)
 
 Inputs:
 - The sprint's parsed block
 - The Repo Conventions section
-- `git diff <parent>..HEAD` (includes developer + test-writer commits)
+- `git diff <parent>..HEAD` (developer + test-writer commits)
 - Test run result
 - The Design section
 
 Prompt:
 
-> Evaluate the diff against the spec. Are all acceptance criteria met? Did the developer stay out of `out_of_scope`? Did the developer correctly avoid modifying any version files listed in the conventions (versioning is handled at merge time, not on feature branches)? Do the tests pass, and do they actually verify the criteria (or do they trivially pass)? Any bugs, missed edge cases, or convention drift?
+> Evaluate the diff against the spec. Are all acceptance criteria met? Did the developer stay out of `out_of_scope`? Did the developer correctly avoid modifying any version files? Do the tests pass, and do they actually verify the criteria (or do they trivially pass)? Any bugs, missed edge cases, or convention drift?
 >
 > Return one of:
 > - `APPROVE` — ready to ship
@@ -95,116 +92,92 @@ Prompt:
 
 ### 5. Verdict handling
 
-**APPROVE** → push the branch, open a PR (§ 6), mark sprint **Completed**. **Do not merge the PR**; that is the user's job, performed via their normal review process at whatever pace they choose.
+**APPROVE** → write the sprint log (§ Log), commit it to the feature branch, push, open a PR (§ 6), mark sprint **Completed**. Do not merge.
 
 **BLOCK** → up to 2 retries:
-1. Respawn developer with the reviewer's feedback. Then respawn test-writer (it may revise tests in light of changed implementation). Then respawn reviewer.
-2. If APPROVE → push, open PR, mark Completed.
-3. If still BLOCK after the 2nd retry → push the branch (work preserved on remote), **do not open a PR**, mark sprint **Blocked** with the reviewer's reasons across all attempts. The user can inspect the branch and decide whether to fix it manually or abandon it.
+1. Respawn developer with reviewer feedback. Respawn test-writer. Respawn reviewer.
+2. If APPROVE → write log, commit, push, open PR, mark Completed.
+3. If still BLOCK after 2nd retry → write log with all reviewer feedback, commit to the branch, push. **Do not open a PR.** Mark sprint **Blocked**. The user can inspect the branch and decide whether to fix it manually or abandon it.
 
 ### 6. PR creation (Completed sprints only)
 
-Constructed by the orchestrator, not by the developer subagent:
-
 - **Title:** the sprint's `goal`
-- **Base:** the parent branch
+- **Base:** the parent branch (`main` for independent sprints, `feature/<parent-label>` for dependents)
 - **Body:**
-  - One-line reference to the source plan: `Plan: plan/<slug>:docs/sprint-plans/<slug>.md`
+  - `Plan: docs/sprint-plans/<slug>.md`
   - `## Acceptance criteria` — the criteria as a checklist (all checked)
   - `## Reviewer notes` — any non-blocking observations
-  - Folded into the PR template structure if the conventions specify one
 
-After opening the PR, the skill is done with it. **Do not enable auto-merge, do not approve, do not merge.** All merge actions — including configuring auto-merge — are the user's responsibility. The PR sits open for human review.
+Do not enable auto-merge, do not approve, do not merge.
 
-**Never open a PR for a Blocked branch.** The branch is pushed (work isn't lost, inspectable from any machine) but no PR opens — no CI noise, no review-queue clutter.
+**Never open a PR for a Blocked branch.** Push the branch so work is preserved, but no PR.
 
-## Log mechanics
+## Log
 
-After each sprint terminus (Completed, Blocked, or Deferred):
-
-1. Stash any in-progress state on the current branch.
-2. Check out `plan/<slug>` (fetch first to make sure it's current).
-3. Edit `docs/sprint-plans/<slug>.log.md` — append a new sprint entry under the current run's section.
-4. Commit with `log: <label> <state>` and push.
-5. Return to whatever branch was active before.
-
-This is sequential and unattended, so no race conditions. The log on `origin/plan/<slug>` is current within a few seconds of each terminus.
-
-## The log
-
-Path: `docs/sprint-plans/<slug>.log.md` on the `plan/<slug>` branch. Markdown, human-scannable. Appended across runs so history is preserved.
+Each sprint writes its own log to `docs/sprint-logs/<slug>-<label>.md` on the feature branch. It merges to main with the sprint PR. No shared log file; no coordination between sprints needed.
 
 ```markdown
-# Sprint Stack Run Log: <Title>
+# Sprint Log: <label>
 
-Plan: docs/sprint-plans/<slug>.md (same branch)
-Base branch: <branch>
+**Plan:** docs/sprint-plans/<slug>.md
+**Sprint goal:** <goal>
+**Date:** <timestamp>
+**Result:** Completed | Blocked
 
-## Run <N> — <start-timestamp> to <end-timestamp>
+## Attempts
 
-### Completed
-- **<label>** — feature/<label> → PR #<n> (<url>)
-  - Reviewer: APPROVE (after <retries-used> retries)
-  - Tests: pass
+### Attempt <N>
+- **Developer:** <summary of what was implemented>
+- **Tests:** pass | fail — <summary>
+- **Reviewer verdict:** APPROVE | BLOCK
+- **Reviewer notes:** <notes>
 
-### Blocked
-- **<label>** — feature/<label> (pushed, no PR)
-  - Reviewer reasons across attempts:
-    - Attempt 1: <reason>
-    - Attempt 2: <reason>
-    - Attempt 3: <reason>
-  - To resume: fix on the branch, commit, push, re-run `/sprint-stack <slug>`
+## PR
+<url> (if Completed)
 
-### Deferred
-- **<label>** — blocked on **<upstream-label>**
+## Reviewer feedback (if Blocked)
+<all feedback across attempts>
 ```
-
-The log is committed to `plan/<slug>` and pushed. It is never merged to base by this skill; the user may merge the planning branch at their discretion.
 
 ## Resume semantics
 
-Re-running `/sprint-stack <slug>` on a planning branch with an existing log:
+Re-running `/sprint-stack <slug>`:
 
-- Sprints marked **Completed** in any prior run → skipped.
-- Sprints marked **Blocked** in the most recent run → re-attempted (user may have fixed them).
-- Sprints marked **Deferred** → re-evaluated against current dependency state; if upstream is now Completed they become eligible.
-- A new `## Run <N+1>` section is appended.
-
-That's the entire resume mechanism. To abandon a Blocked sprint, edit the plan's Sprint Definitions section to remove it and re-run.
+- Sprints with a merged PR → skipped.
+- Sprints with an open PR → skipped (already submitted).
+- Sprints marked Blocked (branch pushed, no PR) → re-attempted from scratch on a fresh branch. The old blocked branch can be deleted after the new one is pushed.
+- Sprints marked Deferred → re-evaluated; if upstream is now Completed they become eligible.
 
 ## End-of-run summary
 
-When the queue drains, post a single message summarizing the run for the user. Pull facts from the log; do not re-narrate per-sprint detail. Structure:
+When the queue drains, post a single message:
 
-> Run <N> complete.
+> Run complete.
 >
-> **Completed:** <count> sprints — <list of labels with PR numbers>
-> **Blocked:** <count> sprints — <list of labels>
-> **Deferred:** <count> sprints — <list of labels with their blocking upstream>
+> **Completed:** <count> — <label> → PR #<n>, <label> → PR #<n>, ...
+> **Blocked:** <count> — <label> (branch: feature/<label>), ...
+> **Deferred:** <count> — <label> (waiting on <upstream>), ...
 >
-> **Merge order for completed PRs:**
-> <topologically-sorted list, with root sprints (parented at base) first, then their dependents>
-> Merge root PRs first; GitHub will retarget dependent PRs to base automatically as their parents merge.
+> **Merge order:** Root sprints (based on main) can merge in any order. Dependent sprints re-target main automatically after their parent merges.
 >
-> **To resume blocked sprints:** inspect the branches listed in the log on `plan/<slug>`, fix locally, push, re-run `/sprint-stack <slug>`.
->
-> Full log: `plan/<slug>:docs/sprint-plans/<slug>.log.md`
+> **To resume blocked sprints:** fix on the branch, commit, push, re-run `/sprint-stack <slug>`.
 
-Then stop. Do not poll, do not wait, do not ask "anything else?" — the run is over.
+Then stop.
 
 ## Key rules
 
 - **Sprints run one at a time**, in topological order.
-- **A failed sprint never stops the orchestrator** — its dependents are marked Deferred, the orchestrator continues with the next independent sprint.
-- **The skill opens PRs and stops.** It does not merge them, does not enable auto-merge, does not approve them. All merge actions — including the choice of when and how — belong to the user. This is policy, not just behavior: agents do not merge to main.
-- **Never wait for PR merges** before starting the next sprint. Sprint B (which depends on A) starts as soon as A's PR is opened, branching off A's branch — not waiting for A to merge. This is what makes the stack work: review and execution happen in parallel.
-- **Never commit to base.** The plan and log live on `plan/<slug>`. Feature branches are pushed and PRs are opened against their parents. Branch protection on base is fully respected because the skill never tries to write to it.
+- **A failed sprint never stops the orchestrator** — dependents are Deferred, independents continue.
+- **The skill opens PRs and stops.** Merge decisions belong to the user.
+- **Never wait for PR merges.** Sprint B (depending on A) branches off A's feature branch immediately after A's PR opens — not after it merges.
+- **Never commit to main.** Feature branches are pushed; PRs are opened. Branch protection on main is fully respected.
+- **Never use `claude/` or `session/` branch prefixes.** Feature branches are `feature/<label>`.
 
 ## Model selection
 
 - Orchestrator: Opus (you)
-- Developer subagent: Sonnet — fast, cheap, mechanical
-- Test-writer subagent: Sonnet — independent from developer, adversarial
-- Reviewer subagent: Opus — catches subtle bugs, worth the cost
+- Developer subagent: Sonnet
+- Test-writer subagent: Sonnet
+- Reviewer subagent: Opus
 
-If subagent model selection isn't available, fall back to the strongest available for reviewer and a fast model for developer + test-writer.
+Fall back to strongest available if model selection isn't available.

--- a/js/round_dynamic.js
+++ b/js/round_dynamic.js
@@ -153,7 +153,7 @@ function roundWithOffset(num, offset) {
   // Add epsilon to handle floating point inaccuracies
   let rounded = Math.round(num / rounding_base + EPSILON) * rounding_base;
   
-  if (Math.abs(rounded) >= 10) {
+  if (Math.abs(rounded) >= 10 || rounded % 1 === 0) {
     rounded = Math.round(rounded);
   }
   

--- a/js/tests.js
+++ b/js/tests.js
@@ -402,6 +402,25 @@ test('Near MAX_SAFE_INTEGER', ROUND_DYNAMIC(9007199254740991), 9000000000000000)
 // Empty array
 testArray('Empty array', ROUND_DYNAMIC([]), []);
 
+// =============================================================================
+// TRAILING ZEROS TESTS
+// =============================================================================
+
+console.log('=== Trailing Zeros (|result| < 10) ===\n');
+
+// Whole-number results between -10 and 10 must be integers (no trailing zeros)
+test('1.13 offset=0.5 → integer 1', ROUND_DYNAMIC(1.13, 0.5) === 1, true);
+test('1.76 offset=0.5 → integer 2', ROUND_DYNAMIC(1.76, 0.5) === 2, true);
+test('1.0 offset=0.5 → integer 1', ROUND_DYNAMIC(1.0, 0.5) === 1, true);
+test('1.0 offset=0.25 → integer 1', ROUND_DYNAMIC(1.0, 0.25) === 1, true);
+test('negative -1.13 offset=0.5 → integer -1', ROUND_DYNAMIC(-1.13, 0.5) === -1, true);
+
+// Non-integer results must stay as floats (not rounded further)
+test('1.42 offset=0.5 → 1.5 (float)', ROUND_DYNAMIC(1.42, 0.5), 1.5);
+test('1.32 offset=0.5 → 1.5 (float)', ROUND_DYNAMIC(1.32, 0.5), 1.5);
+test('1.13 offset=0.25 → 1.25 (float)', ROUND_DYNAMIC(1.13, 0.25), 1.25);
+test('1.42 offset=0.25 → 1.5 (float)', ROUND_DYNAMIC(1.42, 0.25), 1.5);
+
 // Array with only non-numerics (max_mag will be null)
 const nonNumericArray = [
     ['Cloud CDN'],

--- a/python/dynamic_rounding/__init__.py
+++ b/python/dynamic_rounding/__init__.py
@@ -169,14 +169,16 @@ def _round_with_offset(value: float, offset: float) -> float:
 
 def _preserve_type(result: float, original_value: Any) -> Union[int, float]:
     """
-    Preserve input type when possible.
-    
+    Preserve input type when possible, and trim trailing zeros for small results.
+
     Returns int if:
-        - original_value was int, AND
-        - result is a whole number
+        - original_value was int and result is a whole number, OR
+        - |result| < 10 and result is a whole number (trim trailing zeros)
     Otherwise returns float.
     """
     if isinstance(original_value, int) and result == int(result):
+        return int(result)
+    if abs(result) < 10 and result == int(result):
         return int(result)
     return result
 

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -185,9 +185,61 @@ class TestEdgeCases:
 
 class TestOffsetSymmetry:
     """Test that 0.5 and -0.5 produce same results (as documented)."""
-    
+
     def test_half_offset_symmetry(self):
         assert round_dynamic(87654321, offset=0.5) == round_dynamic(87654321, offset=-0.5)
-    
+
     def test_point_three_symmetry(self):
         assert round_dynamic(87654321, offset=0.3) == round_dynamic(87654321, offset=-0.3)
+
+
+class TestTrailingZeros:
+    """Whole-number results with |value| < 10 should return int, not float."""
+
+    def test_whole_number_result_is_int(self):
+        result = round_dynamic(1.13, offset=0.5)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_whole_number_negative_is_int(self):
+        result = round_dynamic(-1.13, offset=0.5)
+        assert result == -1
+        assert isinstance(result, int)
+
+    def test_whole_number_two_is_int(self):
+        result = round_dynamic(1.76, offset=0.5)
+        assert result == 2
+        assert isinstance(result, int)
+
+    def test_whole_number_from_exact_input_is_int(self):
+        result = round_dynamic(1.0, offset=0.5)
+        assert result == 1
+        assert isinstance(result, int)
+
+    def test_fractional_result_stays_float(self):
+        result = round_dynamic(1.42, offset=0.5)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_two_decimal_result_stays_float(self):
+        result = round_dynamic(1.13, offset=0.25)
+        assert result == 1.25
+        assert isinstance(result, float)
+
+    def test_one_decimal_result_stays_float(self):
+        result = round_dynamic(1.42, offset=0.25)
+        assert result == 1.5
+        assert isinstance(result, float)
+
+    def test_large_float_input_unaffected(self):
+        # float input > 10 that rounds to whole number should remain float
+        result = round_dynamic(87654321.0)
+        assert result == 90000000
+        assert isinstance(result, float)
+
+    def test_whole_number_in_list(self):
+        result = round_dynamic([1.13, 1.42], offset_top=0.5)
+        assert result[0] == 1
+        assert isinstance(result[0], int)
+        assert result[1] == 1.5
+        assert isinstance(result[1], float)


### PR DESCRIPTION
Lands the trim-trailing-zeros sprint.

For ROUND_DYNAMIC results with |value| < 10, whole-number results now return as integer 1 rather than float 1.0, eliminating trailing decimal zeros. Fractional results (1.5, 1.25) are unchanged.

- JS roundWithOffset: extended |rounded| >= 10 guard to also fire when rounded % 1 === 0
- Python _preserve_type: also converts to int when abs(result) < 10 and result is a whole number
- 9 new JS tests + 9 new Python tests, 0 regressions