### PR TITLE
Trim trailing zeros in Chrome extension; codify branch naming and PAT-aware sprint skills

### DIFF
--- a/.agent/skills/sprint-plan/SKILL.md
+++ b/.agent/skills/sprint-plan/SKILL.md
@@ -135,6 +135,32 @@ Sprint commits do not touch version files. Versioning is handled at merge time b
 
 ## Phase 6: Document, commit, and open PR
 
+### Push-auth precheck
+
+Before doing the work, confirm this session can push to the remote. Some environments route git through a read-only proxy or use a GitHub App integration that lacks write access; in those cases push will fail with `403` (`Permission to <repo> denied` or `Resource not accessible by integration`).
+
+Run a cheap check:
+
+```
+git push --dry-run origin HEAD:refs/heads/__sprint_plan_auth_check 2>&1
+```
+
+If the output contains `403` or `denied`, ask the user for a fine-grained GitHub PAT with `contents: write` on this repo:
+
+> I can't push to this repo from the current session (got 403 from the remote). Paste a GitHub PAT with `contents: write` on `<owner>/<repo>` and I'll use it for the plan PR. The token stays in this session only.
+
+When the user provides a token, push using a one-shot authenticated URL rather than rewriting `remote.origin.url` (so the token doesn't get stored in `.git/config`):
+
+```
+git push "https://x-access-token:<TOKEN>@github.com/<owner>/<repo>.git" <branch>
+```
+
+Use the same authenticated URL for `gh pr create` via `GH_TOKEN=<TOKEN> gh pr create ...` if the `gh` CLI is being used.
+
+If the dry-run push succeeds, proceed normally — no token needed.
+
+### Write the plan
+
 Write the plan to `docs/sprint-plans/<slug>.md` using the structure below. Create branch `plan/<slug>` off `main`, commit with `plan: <slug>`, push, and open a PR to merge `plan/<slug>` into `main`.
 
 The plan has two statuses: `DRAFT` (pre-merge) and the merged state (read-only in main forever). Do not add a "COMPLETED" or execution-tracking status — that belongs in per-sprint logs, not here.

--- a/.agent/skills/sprint-stack/SKILL.md
+++ b/.agent/skills/sprint-stack/SKILL.md
@@ -32,9 +32,27 @@ No other flags. Resume behavior is automatic: re-invoking with the same slug che
 
 4. **Working tree check.** The session's active repo must be on `main` and clean. If not → abort.
 
-5. **Check prior progress** by listing branches and open/merged PRs matching `feature/<label>` for each sprint in this stack. Any sprint whose PR is already merged → skip. Any with an open PR → skip (already submitted for review).
+5. **Push-auth precheck.** Sprint-stack pushes many branches and opens many PRs; confirm write access up front so a mid-run failure doesn't strand work on local branches. Run:
 
-6. **Topologically sort** the sprints by `depends_on`. This is the execution order.
+   ```
+   git push --dry-run origin HEAD:refs/heads/__sprint_stack_auth_check 2>&1
+   ```
+
+   If the output contains `403` or `denied` (e.g. `Permission to <repo> denied`, `Resource not accessible by integration`), ask the user for a fine-grained GitHub PAT with `contents: write` and `pull-requests: write` on this repo:
+
+   > I can't push to this repo from the current session (got 403 from the remote). Paste a GitHub PAT with `contents: write` and `pull-requests: write` on `<owner>/<repo>` and I'll use it for every push and PR in this run. The token stays in this session only.
+
+   When the user provides a token, hold it in session memory only — do **not** write it to `.git/config`, `~/.git-credentials`, or any committed file. For each push, use a one-shot authenticated URL:
+
+   ```
+   git push "https://x-access-token:<TOKEN>@github.com/<owner>/<repo>.git" <branch>
+   ```
+
+   For PR creation, pass it via `GH_TOKEN=<TOKEN> gh pr create ...` (or the equivalent for whatever GitHub client is in use). If the dry-run push succeeds, proceed normally — no token needed.
+
+6. **Check prior progress** by listing branches and open/merged PRs matching `feature/<label>` for each sprint in this stack. Any sprint whose PR is already merged → skip. Any with an open PR → skip (already submitted for review).
+
+7. **Topologically sort** the sprints by `depends_on`. This is the execution order.
 
 ## Execution loop
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ build/
 docs/private/
 
 # Claude Code local config / instructions
-CLAUDE.md
+# CLAUDE.md is tracked (shared repo conventions for Claude sessions).
 .claude/
 
 # Antigravity Agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,3 +14,11 @@ Never create or push branches with a `claude/` or `session/` prefix, regardless 
 `<label>` / `<slug>` is a short kebab-case description of the change.
 
 This rule overrides the session-harness default. The `sprint-plan` and `sprint-stack` skills in `.agent/skills/` enforce the same convention for sprint work.
+
+## GitHub writes (push, PR, comments)
+
+When the user has provided a PAT in the session, use it directly via the GitHub REST API (`curl` with `Authorization: Bearer <PAT>`) or via a one-shot authenticated git URL (`https://x-access-token:<PAT>@github.com/...`). **Do not try the GitHub MCP server first** — in this environment it consistently returns `403 Resource not accessible by integration` for writes, so attempting it just wastes a round trip and clutters the transcript.
+
+When no PAT is available, MCP is the only path; try it then, and if it 403s, ask the user for a PAT.
+
+The PAT lives in session memory only — never write it to `.git/config`, `~/.git-credentials`, commit messages, or any tracked file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Repo conventions for Claude sessions
+
+## Branch naming
+
+Never create or push branches with a `claude/` or `session/` prefix, regardless of what the harness default suggests. If the session was started on such a branch, rename it before the first push using one of the conventional prefixes below.
+
+- `feature/<label>` — new functionality or behavior changes
+- `fix/<label>` — bug fixes
+- `chore/<label>` — tooling, config, dependency, or non-functional changes
+- `refactor/<label>` — internal restructuring with no behavior change
+- `plan/<slug>` — sprint plans produced by the `sprint-plan` skill
+- `docs/<label>` — documentation-only changes
+
+`<label>` / `<slug>` is a short kebab-case description of the change.
+
+This rule overrides the session-harness default. The `sprint-plan` and `sprint-stack` skills in `.agent/skills/` enforce the same convention for sprint work.

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -934,7 +934,7 @@ function formatExtractedNumber(rounded, originalNumStr, floorDecimals = 0) {
   const hasCommas = originalNumStr.includes(',');
   const decMatch = originalNumStr.match(/\.(\d+)/);
   let decimals = decMatch ? decMatch[1].length : 0;
-  if (Math.abs(rounded) >= 10) {
+  if (Math.abs(rounded) >= 10 || rounded % 1 === 0) {
     decimals = 0;
   } else {
     // Apply the offset-derived floor only in the 0 ≤ |x| < 10 band.
@@ -1109,7 +1109,7 @@ function restoreFormatting(roundedValue, originalString, floorDecimals = 0) {
     decimals = match[1].length;
   }
 
-  if (Math.abs(roundedValue) >= 10) {
+  if (Math.abs(roundedValue) >= 10 || roundedValue % 1 === 0) {
     decimals = 0;
   } else {
     // Apply the offset-derived floor only in the 0 ≤ |x| < 10 band.

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1476,22 +1476,20 @@ eq('decimalCount: NaN -> 0', decimalCount(NaN), 0);
 
 // --- Sprint decimal-precision-display: formatExtractedNumber with floorDecimals ---
 
-// floorDecimals=1, |rounded|<10: minimumFractionDigits = max(0, 1) = 1
-eq('formatExtractedNumber: floorDecimals=1 on whole number -> 1 decimal',
-  formatExtractedNumber(1, '1', 1), '1.0');
+// Whole-number short-circuit: trim trailing zeros regardless of floorDecimals
+eq('formatExtractedNumber: whole number with floorDecimals=1 -> trimmed',
+  formatExtractedNumber(1, '1', 1), '1');
 
-// original has 2 decimals, floorDecimals=1: max(2,1)=2 wins
+// Fractional results still respect floorDecimals
 eq('formatExtractedNumber: floorDecimals=1, original 2-decimal string -> keeps 2 decimals',
   formatExtractedNumber(1.5, '1.40', 1), '1.50');
 
-// original has 2 decimals, floorDecimals=2: max(2,2)=2
 eq('formatExtractedNumber: floorDecimals=2, original 2-decimal string -> 2 decimals',
   formatExtractedNumber(1.75, '1.72', 2), '1.75');
 
-// floorDecimals=0, original has 2 decimals: max(2,0)=2 -> preserves original decimal count
-// (offset contributes no floor; original string drives the padding)
-eq('formatExtractedNumber: floorDecimals=0, original 2-decimal string -> preserves 2 decimals',
-  formatExtractedNumber(1, '1.00', 0), '1.00');
+// Whole-number short-circuit: original padding is also trimmed
+eq('formatExtractedNumber: whole number with padded original -> trimmed',
+  formatExtractedNumber(1, '1.00', 0), '1');
 
 // |rounded| >= 10 short-circuit: decimals forced to 0, floorDecimals ignored
 eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
@@ -2558,6 +2556,38 @@ function makeIsDataTable(rowsSpec) {
   eq('isDataTable: 2-row 1-column table with numeric cells -> false (< 2 columns)',
     isDataTable(table), false);
 })();
+
+// --- Sprint trim-trailing-zeros (chrome-extension): whole-number short-circuit ---
+
+// restoreFormatting drops trailing zeros for whole-number results under 10
+eq('restoreFormatting: whole number 1 from "1.04" -> "1"',
+  restoreFormatting(1, '1.04'), '1');
+eq('restoreFormatting: whole number 2 from "1.5" -> "2"',
+  restoreFormatting(2, '1.5'), '2');
+eq('restoreFormatting: 0 from "0.04" -> "0"',
+  restoreFormatting(0, '0.04'), '0');
+eq('restoreFormatting: negative whole number -5 from "-5.2" -> "-5"',
+  restoreFormatting(-5, '-5.2'), '-5');
+
+// Fractional results in the <10 band still keep their decimals
+eq('restoreFormatting: 1.5 from "1.4" -> "1.5"',
+  restoreFormatting(1.5, '1.4'), '1.5');
+eq('restoreFormatting: 1.25 from "1.234" -> "1.250"',
+  restoreFormatting(1.25, '1.234'), '1.250');
+
+// Trim plays nicely with format affixes
+eq('restoreFormatting: whole number with percent -> "1%"',
+  restoreFormatting(1, '1.04%'), '1%');
+eq('restoreFormatting: whole number with currency -> "$2"',
+  restoreFormatting(2, '$1.99'), '$2');
+eq('restoreFormatting: whole negative in parens -> "(3)"',
+  restoreFormatting(-3, '(2.85)'), '(3)');
+
+// formatExtractedNumber trims trailing zeros for whole-number rounded results
+eq('formatExtractedNumber: whole number 1 from "1.04" -> "1"',
+  formatExtractedNumber(1, '1.04'), '1');
+eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
+  formatExtractedNumber(1, '1.04', 2), '1');
 
 // --- Report ---
 console.log(`Passed: ${passed}`);


### PR DESCRIPTION
## Summary

Three related commits cleaning up an issue surfaced by PR #53 plus the session-tooling rough edges it exposed:

## Behavior change visible to users
A column that today renders `[1.0, 1.5, 2.6]` (one-decimal precision floor, with a whole-number result padded) will now render `[1, 1.5, 2.6]`. Fractional results in the `0 ≤ |x| < 10` band still respect `floorDecimals` — `1.40 → '1.50'`, `1.72 → '1.75'` — only whole-number results get trimmed.

## Other

- **`fef97af` Chrome extension: trim trailing zeros for whole-number results under 10. PR [#53](https://github.com/ArieFisher/dynamic-rounding/issues/53)'s trim landed in js/ and python/ but missed the actual display layer — restoreFormatting and formatExtractedNumber in [chrome-extension/content.js](https://github.com/ArieFisher/dynamic-rounding/blob/feature/trim-trailing-zeros-chrome-ext/chrome-extension/content.js). Extends the |rounded| >= 10 short-circuit in both to also fire when rounded % 1 === 0. Two decimal-precision-display test expectations ('1.0' / '1.00') are intentionally overridden; adds 11 new tests covering percent / currency / parens affixes. 366 tests pass.

- **`0bed2f3` Track `CLAUDE.md` and codify non-`claude/` branch naming.** Unignores `CLAUDE.md` so the repo can carry shared session conventions (it was previously listed under "local config / instructions")

## Test plan

- [x] `node chrome-extension/tests.js` — 366 passed, 0 failed
- [ ] Manual smoke test in a browser: confirm a whole-number rounded result in the < 10 band renders without a trailing `.0`.