### PR TITLE
Round date cells to a whole year; display only the year

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -921,6 +921,13 @@ function isDateLike(text) {
   return parseDateLike(text) !== null || parseAmbiguousNumericDate(text) !== null;
 }
 
+// Kept for backward-compat with tests; delegates to parseDateLike bare-year branch.
+function isYearValue(text) {
+  if (!/^\d{4}$/.test(text)) return false;
+  const n = parseInt(text, 10);
+  return n >= 1900 && n <= 2099;
+}
+
 function isTimeLike(text) {
   // HH:MM or HH:MM:SS, optional AM/PM
   return /^\d{1,2}:\d{2}(:\d{2})?(\s*[ap]\.?m\.?)?$/i.test(text);

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -548,7 +548,14 @@ function roundTable(table, options) {
       } else if (isWholeCellQuoted) {
         rowInfo.push({ mode: 'skip' });
       } else if (opts.excludeDates === false && isDateLike(trimmed)) {
-        rowInfo.push({ mode: 'date' });
+        const ambig = parseAmbiguousNumericDate(trimmed);
+        if (ambig !== null) {
+          rowInfo.push({ mode: 'date', ambiguous: ambig });
+        } else {
+          // Unambiguous: parse now and store the resolved fields
+          const parsed = parseDateLike(trimmed);
+          rowInfo.push({ mode: 'date', month: parsed.month, day: parsed.day, year: parsed.year });
+        }
       } else if (opts.excludeTimes === false && isTimeLike(trimmed)) {
         rowInfo.push({ mode: 'time' });
       } else {
@@ -582,6 +589,53 @@ function roundTable(table, options) {
     cellInfo.push(rowInfo);
   }
 
+  // --- Column post-pass: resolve ambiguous numeric date cells per column ---
+  // Determine the maximum number of data columns across all rows.
+  const numCols = cellInfo.reduce((max, row) => Math.max(max, row.length), 0);
+  for (let c = 0; c < numCols; c++) {
+    // Collect all ambiguous date cells in this column.
+    const ambigCells = [];
+    for (let r = 0; r < cellInfo.length; r++) {
+      const info = cellInfo[r][c];
+      if (info && info.mode === 'date' && info.ambiguous) {
+        ambigCells.push({ r, info });
+      }
+    }
+    if (ambigCells.length === 0) continue;
+
+    // Compute format hint from the ambiguous cells.
+    let hasN1gt12 = false; // n1 > 12 → rejects MDY interpretation (n1 must be day)
+    let hasN2gt12 = false; // n2 > 12 → rejects DMY interpretation (n2 must be day)
+    for (const { info } of ambigCells) {
+      if (info.ambiguous.n1 > 12) hasN1gt12 = true;
+      if (info.ambiguous.n2 > 12) hasN2gt12 = true;
+    }
+
+    let formatHint;
+    if (hasN1gt12 && !hasN2gt12) {
+      formatHint = 'DMY'; // n1 is day, n2 is month
+    } else if (hasN2gt12 && !hasN1gt12) {
+      formatHint = 'MDY'; // n1 is month, n2 is day
+    } else if (hasN1gt12 && hasN2gt12) {
+      formatHint = 'MIXED';
+    } else {
+      formatHint = 'AMBIGUOUS';
+    }
+
+    // Resolve or downgrade each ambiguous cell based on the hint.
+    for (const { r, info } of ambigCells) {
+      if (formatHint === 'MDY') {
+        cellInfo[r][c] = { mode: 'date', month: info.ambiguous.n1, day: info.ambiguous.n2, year: info.ambiguous.year };
+      } else if (formatHint === 'DMY') {
+        cellInfo[r][c] = { mode: 'date', month: info.ambiguous.n2, day: info.ambiguous.n1, year: info.ambiguous.year };
+      } else {
+        // AMBIGUOUS or MIXED — cannot resolve safely
+        cellInfo[r][c] = { mode: 'skip' };
+      }
+    }
+  }
+  // --- End column post-pass ---
+
   const allNums = [];
   for (const row of cellInfo) {
     for (const info of row) {
@@ -607,8 +661,9 @@ function roundTable(table, options) {
       let formattedValue;
 
       if (info.mode === 'date') {
-        formattedValue = roundDateText(originalValue, opts.dateGranularity);
-        if (formattedValue === null || formattedValue === originalValue) continue;
+        const prefilled = (info.month !== undefined) ? { month: info.month, day: info.day, year: info.year } : undefined;
+        formattedValue = roundDateText(originalValue, opts.dateGranularity, prefilled);
+        if (formattedValue === originalValue) continue;
       } else if (info.mode === 'time') {
         formattedValue = roundTimeText(originalValue, opts.timeGranularity);
         if (formattedValue === null || formattedValue === originalValue) continue;
@@ -752,29 +807,118 @@ function getExclusionReason(text, columnIndex, options, rowIndex) {
   return null;
 }
 
-function isYearValue(text) {
-  if (!/^\d{4}$/.test(text)) return false;
-  const n = parseInt(text, 10);
-  return n >= 1900 && n <= 2099;
+const MONTH_NAMES = '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\\.?';
+
+// Map lowercase month abbreviation/name prefix → 1-based month number
+const MONTH_NAME_MAP = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, sept: 9, oct: 10, nov: 11, dec: 12
+};
+
+/**
+ * Resolve a matched month-name token (e.g. "June", "jun.", "Jul") to a 1-based month number.
+ * Returns null if not recognised.
+ */
+function resolveMonthName(token) {
+  const t = token.toLowerCase().replace(/[.\s]/g, '');
+  // Try exact key first, then 3-letter prefix
+  if (MONTH_NAME_MAP[t] !== undefined) return MONTH_NAME_MAP[t];
+  const prefix3 = t.slice(0, 4); // "sept" is 4 chars
+  if (MONTH_NAME_MAP[prefix3] !== undefined) return MONTH_NAME_MAP[prefix3];
+  const prefix3s = t.slice(0, 3);
+  if (MONTH_NAME_MAP[prefix3s] !== undefined) return MONTH_NAME_MAP[prefix3s];
+  return null;
 }
 
-const MONTH_NAMES = '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\\.?';
-const DATE_REGEXES = [
-  /^\d{4}-\d{2}-\d{2}$/,                              // 2024-03-14
-  /^\d{1,2}\/\d{1,2}\/\d{2,4}$/,                      // 3/14/2024
-  /^\d{1,2}-\d{1,2}-\d{2,4}$/,                        // 3-14-2024
-  new RegExp(`^${MONTH_NAMES}\\s+\\d{1,2},?\\s+\\d{4}$`, 'i'),  // March 14, 2024
-  new RegExp(`^\\d{1,2}\\s+${MONTH_NAMES}\\s+\\d{4}$`, 'i'),    // 14 March 2024
-  new RegExp(`^${MONTH_NAMES}\\s+\\d{4}$`, 'i'),               // March 2024
-  new RegExp(`^\\d{1,2}\\s+${MONTH_NAMES}$`, 'i')              // 14 March
-];
+/**
+ * Parse an unambiguous date-like string into {year, month, day}.
+ * Returns null for all-numeric N1/N2/Y or N1-N2-Y shapes (handled by parseAmbiguousNumericDate).
+ * Supported shapes:
+ *   ISO dash:      2020-07-21
+ *   ISO slash:     2020/07/21
+ *   Named-month:   June 21, 2020 / Jun 21, 2020 / 21 June 2020 / 2020 June 21 / Jun 2020
+ *   Bare year:     2020
+ */
+function parseDateLike(text) {
+  if (typeof text !== 'string') return null;
+  const t = text.trim();
+
+  // ISO dash: YYYY-MM-DD (must be 4-digit year first to avoid ambiguous N1-N2-Y)
+  const isoDash = t.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoDash) {
+    return { year: parseInt(isoDash[1], 10), month: parseInt(isoDash[2], 10), day: parseInt(isoDash[3], 10) };
+  }
+
+  // ISO slash: YYYY/MM/DD
+  const isoSlash = t.match(/^(\d{4})\/(\d{2})\/(\d{2})$/);
+  if (isoSlash) {
+    return { year: parseInt(isoSlash[1], 10), month: parseInt(isoSlash[2], 10), day: parseInt(isoSlash[3], 10) };
+  }
+
+  // Named-month forms (case-insensitive)
+  const mnRe = new RegExp(`^(${MONTH_NAMES})\\s+(\\d{1,2}),?\\s+(\\d{4})$`, 'i');
+  const mnMatch = t.match(mnRe);
+  if (mnMatch) {
+    const month = resolveMonthName(mnMatch[1]);
+    if (month !== null) return { year: parseInt(mnMatch[3], 10), month, day: parseInt(mnMatch[2], 10) };
+  }
+
+  // Day Month Year: 21 June 2020
+  const dmyRe = new RegExp(`^(\\d{1,2})\\s+(${MONTH_NAMES})\\s+(\\d{4})$`, 'i');
+  const dmyMatch = t.match(dmyRe);
+  if (dmyMatch) {
+    const month = resolveMonthName(dmyMatch[2]);
+    if (month !== null) return { year: parseInt(dmyMatch[3], 10), month, day: parseInt(dmyMatch[1], 10) };
+  }
+
+  // Year Month Day: 2020 June 21
+  const ymdRe = new RegExp(`^(\\d{4})\\s+(${MONTH_NAMES})\\s+(\\d{1,2})$`, 'i');
+  const ymdMatch = t.match(ymdRe);
+  if (ymdMatch) {
+    const month = resolveMonthName(ymdMatch[2]);
+    if (month !== null) return { year: parseInt(ymdMatch[1], 10), month, day: parseInt(ymdMatch[3], 10) };
+  }
+
+  // Month Year: Jun 2020
+  const myRe = new RegExp(`^(${MONTH_NAMES})\\s+(\\d{4})$`, 'i');
+  const myMatch = t.match(myRe);
+  if (myMatch) {
+    const month = resolveMonthName(myMatch[1]);
+    if (month !== null) return { year: parseInt(myMatch[2], 10), month, day: 1 };
+  }
+
+  // Bare year: 2020 (1900–2099)
+  const bareYear = t.match(/^(\d{4})$/);
+  if (bareYear) {
+    const y = parseInt(bareYear[1], 10);
+    if (y >= 1900 && y <= 2099) return { year: y, month: 1, day: 1 };
+  }
+
+  return null;
+}
+
+/**
+ * Parse an all-numeric ambiguous date: N1/N2/Y or N1-N2-Y.
+ * Supports 4-digit and 2-digit years. 2-digit-year pivot: yy < 50 → 2000+yy, else 1900+yy.
+ * Returns {n1, n2, year} or null.
+ */
+function parseAmbiguousNumericDate(text) {
+  if (typeof text !== 'string') return null;
+  const t = text.trim();
+  // N1/N2/Y or N1-N2-Y (but not YYYY-MM-DD or YYYY/MM/DD which are unambiguous)
+  const m = t.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+  if (!m) return null;
+  const n1 = parseInt(m[1], 10);
+  const n2 = parseInt(m[2], 10);
+  let year = parseInt(m[3], 10);
+  if (m[3].length === 2) {
+    year = year < 50 ? 2000 + year : 1900 + year;
+  }
+  return { n1, n2, year };
+}
 
 function isDateLike(text) {
-  if (isYearValue(text)) return true;
-  for (const re of DATE_REGEXES) {
-    if (re.test(text)) return true;
-  }
-  return false;
+  return parseDateLike(text) !== null || parseAmbiguousNumericDate(text) !== null;
 }
 
 function isTimeLike(text) {
@@ -782,18 +926,36 @@ function isTimeLike(text) {
   return /^\d{1,2}:\d{2}(:\d{2})?(\s*[ap]\.?m\.?)?$/i.test(text);
 }
 
-function roundDateText(text, granularity) {
-  if (typeof text !== 'string') return null;
-  if (granularity === 'year' || !granularity) return null; // no change at year granularity
-  const yearMatch = text.match(/\b(19\d{2}|20\d{2})\b/);
-  if (!yearMatch) return null;
-  const year = parseInt(yearMatch[1], 10);
-  let rounded;
-  if (granularity === 'decade') rounded = Math.floor(year / 10) * 10;
-  else if (granularity === 'century') rounded = Math.floor(year / 100) * 100;
-  else return null;
-  if (rounded === year) return null;
-  return text.substring(0, yearMatch.index) + String(rounded) + text.substring(yearMatch.index + yearMatch[1].length);
+/**
+ * Round a date cell to the requested granularity and return a year-only string.
+ *
+ * @param {string} text          - Original cell text.
+ * @param {string} granularity   - 'year' | 'decade' | 'century'.
+ * @param {{month: number, day: number, year: number}} [prefilled]
+ *   Pre-resolved date from the classification pass. If omitted, parseDateLike is called.
+ * @returns {string} Always returns a string (the rounded year as digits).
+ */
+function roundDateText(text, granularity, prefilled) {
+  const parsed = prefilled || parseDateLike(text);
+  if (!parsed) return text; // fallback: shouldn't happen for mode:'date' cells
+
+  const { year, month } = parsed;
+
+  // fractional = year + 0.5 if month >= 7, else year + 0
+  const fractional = year + (month >= 7 ? 0.5 : 0);
+
+  let roundedYear;
+  if (granularity === 'decade') {
+    roundedYear = Math.round(fractional / 10) * 10;
+  } else if (granularity === 'century') {
+    roundedYear = Math.round(fractional / 100) * 100;
+  } else {
+    // 'year' or default
+    roundedYear = Math.round(fractional);
+  }
+
+  const d = new Date(roundedYear, 0, 1);
+  return String(d.getFullYear());
 }
 
 function roundTimeText(text, granularity) {

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -921,13 +921,6 @@ function isDateLike(text) {
   return parseDateLike(text) !== null || parseAmbiguousNumericDate(text) !== null;
 }
 
-// Kept for backward-compat with tests; delegates to parseDateLike bare-year branch.
-function isYearValue(text) {
-  if (!/^\d{4}$/.test(text)) return false;
-  const n = parseInt(text, 10);
-  return n >= 1900 && n <= 2099;
-}
-
 function isTimeLike(text) {
   // HH:MM or HH:MM:SS, optional AM/PM
   return /^\d{1,2}:\d{2}(:\d{2})?(\s*[ap]\.?m\.?)?$/i.test(text);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -325,13 +325,9 @@ eq('restoreFormatting: parens-negative preserved',
 
 // --- Sprint A: exclusion checkboxes ---
 
-eq('isYearValue: 2018 -> true', isYearValue('2018'), true);
-eq('isYearValue: 1899 -> false', isYearValue('1899'), false);
-eq('isYearValue: 2100 -> false', isYearValue('2100'), false);
-eq('isYearValue: 12 -> false', isYearValue('12'), false);
-eq('isYearValue: 20181 -> false', isYearValue('20181'), false);
-
 eq('isDateLike: bare 4-digit year', isDateLike('2018'), true);
+eq('isDateLike: bare year out of range', isDateLike('1899'), false);
+eq('isDateLike: bare year out of range', isDateLike('2100'), false);
 eq('isDateLike: ISO date', isDateLike('2024-03-14'), true);
 eq('isDateLike: US slash date', isDateLike('3/14/2024'), true);
 eq('isDateLike: dash date', isDateLike('3-14-2024'), true);
@@ -2650,13 +2646,34 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   ];
   // Note: '06-21-2020' is an ambiguous numeric date (handled by column auto-detect,
   // not directly by roundDateText which only handles unambiguous shapes via parseDateLike).
-  // We test it separately via roundTable in AC5.
+  // It is tested end-to-end via roundTable below — a single-row column with n2=21>12
+  // forces MDY → June 21 → identical rounding to the other shapes.
 
   for (const shape of shapes) {
     eq(`shape-equiv: "${shape}" year -> "2020"`,   roundDateText(shape, 'year'),    '2020');
     eq(`shape-equiv: "${shape}" decade -> "2020"`, roundDateText(shape, 'decade'),  '2020');
     eq(`shape-equiv: "${shape}" century -> "2000"`,roundDateText(shape, 'century'), '2000');
   }
+
+  // End-to-end check for the ambiguous-numeric form: '06-21-2020' via roundTable.
+  withCreateTreeWalker(function() {
+    function runDateCell(text, gran) {
+      const tbl = makeMockTable([[{ tag: 'td', text }]]);
+      tbl.rows[0].cells[0].querySelectorAll = () => [];
+      roundTable(tbl, {
+        enabled: true, excludeDates: false, excludeTimes: true,
+        excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
+        includeWords: false, excludeFirstRow: false,
+        offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+        rangeExpr: '',
+        dateGranularity: gran,
+      });
+      return tbl.rows[0].cells[0].innerText;
+    }
+    eq('shape-equiv (via roundTable): "06-21-2020" year -> "2020"',    runDateCell('06-21-2020', 'year'),    '2020');
+    eq('shape-equiv (via roundTable): "06-21-2020" decade -> "2020"',  runDateCell('06-21-2020', 'decade'),  '2020');
+    eq('shape-equiv (via roundTable): "06-21-2020" century -> "2000"', runDateCell('06-21-2020', 'century'), '2000');
+  });
 })();
 
 // ---------------------------------------------------------------------------
@@ -2741,16 +2758,18 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       return tbl.rows.map(row => row.cells.map(c => c.innerText));
     }
 
-    // --- MDY column ---
-    // Column contains '04/13/2022' (n2=13 forces MDY) and '03-04-2022'.
-    // Under MDY, '03-04-2022' is March 4 → year 2022 → roundDateText returns '2022'.
-    // Both cells should become '2022' at year granularity.
+    // --- MDY column (discriminating) ---
+    // '04/13/2022' forces MDY (n2=13 > 12). The sibling '12-03-2022' is discriminating:
+    //   under MDY → Dec 3, fractional=2022.5, year rounds to 2023.
+    //   under DMY → Mar 12, fractional=2022.0, year rounds to 2022.
+    // If the column resolver picks MDY (as it should), the sibling rounds to 2023.
     const mdyResult = runDateTable([
       [{ tag: 'td', text: '04/13/2022' }],
-      [{ tag: 'td', text: '03-04-2022' }],
+      [{ tag: 'td', text: '12-03-2022' }],
     ], 'year');
     eq('MDY column: 04/13/2022 rounds to 2022', mdyResult[0][0], '2022');
-    eq('MDY column: 03-04-2022 resolved as MDY (March 4 → year 2022)', mdyResult[1][0], '2022');
+    eq('MDY column: 12-03-2022 resolved as MDY (Dec 3 → year 2023, not DMY Mar 12 → 2022)',
+      mdyResult[1][0], '2023');
 
     // --- DMY column ---
     // '13/04/2022' forces DMY (n1=13 > 12). '12-08-2022' under DMY = Aug 12 = 2022.

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -492,22 +492,26 @@ eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
 // --- Sprint B: per-type granularity ---
 
 // Date granularity
-eq('roundDateText: year granularity is a no-op (returns null)',
-  roundDateText('2018', 'year'), null);
-eq('roundDateText: decade rounds bare year',
-  roundDateText('2018', 'decade'), '2010');
-eq('roundDateText: century rounds bare year',
+// NEW CONTRACT (sprint date-round-to-year-display): roundDateText always returns a
+// 4-digit year string. It no longer returns null or a full date string like
+// "March 14, 2020". The caller (roundTable) compares formattedValue === originalValue
+// to detect the no-op case.
+eq('roundDateText: year granularity returns a 4-digit year string',
+  roundDateText('2018', 'year'), '2018');
+eq('roundDateText: decade rounds bare year 2018 -> 2020',
+  roundDateText('2018', 'decade'), '2020');
+eq('roundDateText: century rounds bare year 2018 -> 2000',
   roundDateText('2018', 'century'), '2000');
-eq('roundDateText: decade in "March 14, 2024"',
-  roundDateText('March 14, 2024', 'decade'), 'March 14, 2020');
-eq('roundDateText: century in "March 14, 2024"',
-  roundDateText('March 14, 2024', 'century'), 'March 14, 2000');
-eq('roundDateText: decade in ISO date',
-  roundDateText('2024-03-14', 'decade'), '2020-03-14');
-eq('roundDateText: no year present -> null',
-  roundDateText('hello world', 'decade'), null);
-eq('roundDateText: 2020 at decade granularity unchanged',
-  roundDateText('2020', 'decade'), null);
+eq('roundDateText: decade in "March 14, 2024" returns year string "2020"',
+  roundDateText('March 14, 2024', 'decade'), '2020');
+eq('roundDateText: century in "March 14, 2024" returns year string "2000"',
+  roundDateText('March 14, 2024', 'century'), '2000');
+eq('roundDateText: decade in ISO date "2024-03-14" returns "2020"',
+  roundDateText('2024-03-14', 'decade'), '2020');
+eq('roundDateText: unparseable input returns the original text unchanged',
+  roundDateText('hello world', 'decade'), 'hello world');
+eq('roundDateText: 2020 at decade granularity still returns "2020" (caller handles no-op)',
+  roundDateText('2020', 'decade'), '2020');
 
 // Time granularity
 eq('roundTimeText: minute granularity is a no-op',
@@ -2588,6 +2592,307 @@ eq('formatExtractedNumber: whole number 1 from "1.04" -> "1"',
   formatExtractedNumber(1, '1.04'), '1');
 eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   formatExtractedNumber(1, '1.04', 2), '1');
+
+// =============================================================================
+// Sprint date-round-to-year-display tests
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// AC1: Worked-examples table
+// Each row: [input, granularity, expected-year-string]
+// ---------------------------------------------------------------------------
+(function dateRoundWorkedExamples() {
+  const cases = [
+    // input              granularity  expected
+    ['Jun 21, 2020',      'year',      '2020'],
+    ['Jun 21, 2020',      'decade',    '2020'],
+    ['Jun 21, 2020',      'century',   '2000'],
+    ['Dec 21, 2020',      'year',      '2021'],
+    ['Dec 21, 2020',      'decade',    '2020'],
+    ['Dec 21, 2020',      'century',   '2000'],
+    ['Jun 21, 2025',      'year',      '2025'],
+    ['Jun 21, 2025',      'decade',    '2030'],
+    ['Jun 21, 2025',      'century',   '2000'],
+    ['Apr 11, 2026',      'year',      '2026'],
+    ['Apr 11, 2026',      'decade',    '2030'],
+    ['Apr 11, 2026',      'century',   '2000'],
+    ['May 9, 2026',       'year',      '2026'],
+    ['May 9, 2026',       'decade',    '2030'],
+    ['May 9, 2026',       'century',   '2000'],
+    ['Jun 30, 2024',      'year',      '2024'],
+    ['Jun 30, 2024',      'decade',    '2020'],
+    ['Jun 30, 2024',      'century',   '2000'],
+    ['Jul 1, 2024',       'year',      '2025'],
+    ['Jul 1, 2024',       'decade',    '2020'],
+    ['Jul 1, 2024',       'century',   '2000'],
+    ['1975',              'year',      '1975'],
+    ['1975',              'decade',    '1980'],
+    ['1975',              'century',   '2000'],
+  ];
+
+  for (const [input, gran, expected] of cases) {
+    eq(`worked-example: "${input}" at ${gran} -> "${expected}"`,
+      roundDateText(input, gran), expected);
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// AC2: Shape equivalence — same logical date, different textual forms
+// All forms of Jun 21, 2020 must round identically.
+// ---------------------------------------------------------------------------
+(function dateRoundShapeEquivalence() {
+  const shapes = [
+    'Jun 21, 2020',
+    '2020/06/21',
+    '2020-06-21',
+    '2020 June 21',
+    '21 June 2020',
+  ];
+  // Note: '06-21-2020' is an ambiguous numeric date (handled by column auto-detect,
+  // not directly by roundDateText which only handles unambiguous shapes via parseDateLike).
+  // We test it separately via roundTable in AC5.
+
+  for (const shape of shapes) {
+    eq(`shape-equiv: "${shape}" year -> "2020"`,   roundDateText(shape, 'year'),    '2020');
+    eq(`shape-equiv: "${shape}" decade -> "2020"`, roundDateText(shape, 'decade'),  '2020');
+    eq(`shape-equiv: "${shape}" century -> "2000"`,roundDateText(shape, 'century'), '2000');
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// AC3: Two-digit-year US dates via parseAmbiguousNumericDate + roundTable pipeline.
+// We test via roundTable since roundDateText only handles unambiguous (parseDateLike) shapes.
+// ---------------------------------------------------------------------------
+(function dateRoundTwoDigitYear() {
+  // 3/14/24 → 2024-03-14 (yy=24 < 50 → 2024). MDY forced since n2=14 > 12.
+  // year granularity → 2024, decade → 2020, century → 2000.
+  withCreateTreeWalker(function() {
+    function twoDigitTable(cellText, gran) {
+      const tbl = makeMockTable([[{ tag: 'td', text: cellText }]]);
+      tbl.rows[0].cells[0].querySelectorAll = () => [];
+      roundTable(tbl, {
+        enabled: true, excludeDates: false, excludeTimes: true,
+        excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
+        includeWords: false, excludeFirstRow: false,
+        offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+        rangeExpr: '',
+        dateGranularity: gran,
+      });
+      return tbl.rows[0].cells[0].innerText;
+    }
+
+    // 3/14/24 → MDY forced (14 > 12) → 2024-03-14
+    eq('two-digit-year: 3/14/24 year -> "2024"',   twoDigitTable('3/14/24', 'year'),    '2024');
+    eq('two-digit-year: 3/14/24 decade -> "2020"', twoDigitTable('3/14/24', 'decade'),  '2020');
+    eq('two-digit-year: 3/14/24 century -> "2000"',twoDigitTable('3/14/24', 'century'), '2000');
+
+    // 3/14/75 → MDY forced (14 > 12) → 1975-03-14 (yy=75 >= 50 → 1975)
+    eq('two-digit-year: 3/14/75 year -> "1975"',   twoDigitTable('3/14/75', 'year'),    '1975');
+    eq('two-digit-year: 3/14/75 decade -> "1980"', twoDigitTable('3/14/75', 'decade'),  '1980');
+    eq('two-digit-year: 3/14/75 century -> "2000"',twoDigitTable('3/14/75', 'century'), '2000');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC4: roundDateText always returns a 4-digit year string, never null.
+// Test via prefilled date objects (bypassing text parsing).
+// ---------------------------------------------------------------------------
+(function dateRoundReturnType() {
+  // Boundary: Dec 31 → fractional = year + 0.5 (month=12 >= 7)
+  const decDates = [
+    { year: 2020, month: 12, day: 31 },
+    { year: 1975, month: 6,  day: 1  },
+    { year: 2000, month: 1,  day: 1  },
+    { year: 2099, month: 7,  day: 1  },
+  ];
+  for (const d of decDates) {
+    const label = `${d.year}-${d.month}-${d.day}`;
+    for (const gran of ['year', 'decade', 'century']) {
+      const result = roundDateText('irrelevant', gran, d);
+      eq(`roundDateText always returns string: prefilled ${label} at ${gran}`,
+        typeof result === 'string' && /^\d{4}$/.test(result), true);
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// AC5: Column-level MDY/DMY auto-detect via roundTable pipeline.
+// ---------------------------------------------------------------------------
+(function dateRoundColumnAutoDetect() {
+  withCreateTreeWalker(function() {
+
+    // Helper: run roundTable with excludeDates:false and return cell text array.
+    function runDateTable(rowsSpec, gran) {
+      const tbl = makeMockTable(rowsSpec);
+      // Add querySelectorAll stub to all cells
+      for (const row of tbl.rows) {
+        for (const cell of row.cells) {
+          cell.querySelectorAll = () => [];
+        }
+      }
+      roundTable(tbl, {
+        enabled: true, excludeDates: false, excludeTimes: true,
+        excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
+        includeWords: false, excludeFirstRow: false,
+        offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+        rangeExpr: '',
+        dateGranularity: gran,
+      });
+      return tbl.rows.map(row => row.cells.map(c => c.innerText));
+    }
+
+    // --- MDY column ---
+    // Column contains '04/13/2022' (n2=13 forces MDY) and '03-04-2022'.
+    // Under MDY, '03-04-2022' is March 4 → year 2022 → roundDateText returns '2022'.
+    // Both cells should become '2022' at year granularity.
+    const mdyResult = runDateTable([
+      [{ tag: 'td', text: '04/13/2022' }],
+      [{ tag: 'td', text: '03-04-2022' }],
+    ], 'year');
+    eq('MDY column: 04/13/2022 rounds to 2022', mdyResult[0][0], '2022');
+    eq('MDY column: 03-04-2022 resolved as MDY (March 4 → year 2022)', mdyResult[1][0], '2022');
+
+    // --- DMY column ---
+    // '13/04/2022' forces DMY (n1=13 > 12). '12-08-2022' under DMY = Aug 12 = 2022.
+    // Under MDY, '12-08-2022' = Dec 8 → year rounds to 2023 (Dec → fractional=2022.5 → round → 2023).
+    // Under DMY, '12-08-2022' = Aug 12 → year rounds to 2022 (Aug → fractional=2022.5 → round → 2023).
+    // Hmm, let's recalculate: Aug → month=8 >= 7 → fractional=2022.5, Math.round(2022.5) = 2023.
+    // And Dec → month=12 >= 7 → fractional=2022.5, same result. Both give 2023 at year granularity.
+    // Better disambiguation: use a month < 7 for DMY path.
+    // '12-03-2022': DMY → month=3 < 7 → fractional=2022.0 → year=2022.
+    //               MDY → month=12 >= 7 → fractional=2022.5 → year=2023.
+    const dmyResult = runDateTable([
+      [{ tag: 'td', text: '13/04/2022' }],  // n1=13 forces DMY
+      [{ tag: 'td', text: '12-03-2022' }],  // DMY: day=12, month=Mar → 2022; MDY: month=Dec → 2023
+    ], 'year');
+    eq('DMY column: 13/04/2022 rounds to 2022', dmyResult[0][0], '2022');
+    eq('DMY column: 12-03-2022 resolved as DMY (Mar 12 → year 2022, not MDY Dec 12 → 2023)',
+      dmyResult[1][0], '2022');
+
+    // --- Ambiguous column ---
+    // Column where ALL cells have both components <= 12. Cannot auto-detect → mode:'skip'.
+    // Cell text must be unchanged.
+    const ambigResult = runDateTable([
+      [{ tag: 'td', text: '03-04-2022' }],
+      [{ tag: 'td', text: '05-06-2023' }],
+    ], 'year');
+    eq('ambiguous column: 03-04-2022 left unchanged (mode:skip)',
+      ambigResult[0][0], '03-04-2022');
+    eq('ambiguous column: 05-06-2023 left unchanged (mode:skip)',
+      ambigResult[1][0], '05-06-2023');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC6: Non-date strings pass through unchanged.
+// ---------------------------------------------------------------------------
+(function dateRoundNonDatePassthrough() {
+  withCreateTreeWalker(function() {
+    function runSingleCell(text) {
+      const tbl = makeMockTable([[{ tag: 'td', text }]]);
+      tbl.rows[0].cells[0].querySelectorAll = () => [];
+      roundTable(tbl, {
+        enabled: true, excludeDates: false, excludeTimes: true,
+        excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
+        includeWords: false, excludeFirstRow: false,
+        offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+        rangeExpr: '',
+        dateGranularity: 'decade',
+      });
+      return tbl.rows[0].cells[0].innerText;
+    }
+
+    eq('non-date passthrough: "hello" stays unchanged', runSingleCell('hello'), 'hello');
+    // "14 March" has no year → isDateLike returns false → treated as a word-embedded number
+    // excludeWords=false in our setup? Actually includeWords is false here, so it skips.
+    // Let's just verify it doesn't get the rounded class.
+    const tbl = makeMockTable([[{ tag: 'td', text: '14 March' }]]);
+    tbl.rows[0].cells[0].querySelectorAll = () => [];
+    roundTable(tbl, {
+      enabled: true, excludeDates: false, excludeTimes: true,
+      excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
+      includeWords: false, excludeFirstRow: false,
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: '',
+      dateGranularity: 'decade',
+    });
+    eq('non-date passthrough: "14 March" cell not rounded (no year)',
+      tbl.rows[0].cells[0].classList.contains('dr-ext-rounded'), false);
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC7: Bare-year no-op short-circuit — "2020" at decade granularity.
+// roundDateText returns "2020", originalValue is "2020" → formattedValue === originalValue
+// → roundTable skips it (no DOM rewrite, no dr-ext-rounded class).
+// ---------------------------------------------------------------------------
+(function dateRoundBareYearNoOp() {
+  // roundDateText itself returns "2020" for both inputs (2020 at decade is 2020).
+  eq('bare-year no-op: roundDateText("2020", "decade") returns "2020"',
+    roundDateText('2020', 'decade'), '2020');
+
+  // Via roundTable: the cell should NOT get the rounded class.
+  withCreateTreeWalker(function() {
+    const tbl = makeMockTable([[{ tag: 'td', text: '2020' }]]);
+    tbl.rows[0].cells[0].querySelectorAll = () => [];
+    roundTable(tbl, {
+      enabled: true, excludeDates: false, excludeTimes: true,
+      excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
+      includeWords: false, excludeFirstRow: false,
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: '',
+      dateGranularity: 'decade',
+    });
+    eq('bare-year no-op: "2020" at decade not marked as rounded (short-circuit)',
+      tbl.rows[0].cells[0].classList.contains('dr-ext-rounded'), false);
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC8: isDateLike accepts newly added shapes.
+// ---------------------------------------------------------------------------
+(function dateRoundIsDateLikeNewShapes() {
+  eq('isDateLike: "2020/07/21" (ISO slash) -> true',  isDateLike('2020/07/21'), true);
+  eq('isDateLike: "2020 June 21" (Year Month Day) -> true', isDateLike('2020 June 21'), true);
+  eq('isDateLike: "3/14/24" (two-digit year) -> true', isDateLike('3/14/24'), true);
+  eq('isDateLike: "06/21/2020" (MDY slash) -> true',  isDateLike('06/21/2020'), true);
+  eq('isDateLike: "21 June 2020" (DMY named) -> true', isDateLike('21 June 2020'), true);
+})();
+
+// ---------------------------------------------------------------------------
+// AC9: Boundary semantics — Jun 30 rounds down, Jul 1 rounds up.
+// ---------------------------------------------------------------------------
+(function dateRoundBoundarySemantics() {
+  // Jun 30: month=6 < 7 → fractional = 2024.0 → round → 2024 (year)
+  eq('boundary: Jun 30, 2024 year -> 2024', roundDateText('Jun 30, 2024', 'year'), '2024');
+  // Jul 1: month=7 >= 7 → fractional = 2024.5 → round → 2025 (year)
+  eq('boundary: Jul 1, 2024 year -> 2025', roundDateText('Jul 1, 2024', 'year'), '2025');
+
+  // Jun 30 decade: fractional=2024.0 → 2024/10=202.4 → round→202 → *10=2020
+  eq('boundary: Jun 30, 2024 decade -> 2020', roundDateText('Jun 30, 2024', 'decade'), '2020');
+  // Jul 1 decade: fractional=2024.5 → 2024.5/10=202.45 → round→202 → *10=2020
+  eq('boundary: Jul 1, 2024 decade -> 2020', roundDateText('Jul 1, 2024', 'decade'), '2020');
+
+  // Jun 21, 2025 decade: fractional=2025.0 → 2025/10=202.5 → round→203 (banker's rounds to 202 or 203?)
+  // Math.round(202.5) = 203 in JS → 2030
+  eq('boundary: Jun 21, 2025 decade -> 2030', roundDateText('Jun 21, 2025', 'decade'), '2030');
+})();
+
+// ---------------------------------------------------------------------------
+// Additional: static analysis — new functions exist in content.js
+// ---------------------------------------------------------------------------
+(function dateRoundStaticAnalysis() {
+  const src = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+
+  eq('static: parseDateLike is defined in content.js',
+    /function\s+parseDateLike\b/.test(src), true);
+  eq('static: parseAmbiguousNumericDate is defined in content.js',
+    /function\s+parseAmbiguousNumericDate\b/.test(src), true);
+  eq('static: roundDateText returns string (no null return for parsed dates)',
+    // The function must NOT have "return null" after the parsed guard
+    // (it uses "return text" as fallback for unparseable input).
+    /function roundDateText[\s\S]{0,800}return String\(/.test(src), true);
+})();
 
 // --- Report ---
 console.log(`Passed: ${passed}`);

--- a/docs/sprint-logs/date-round-to-year-display-date-round-to-year-display.md
+++ b/docs/sprint-logs/date-round-to-year-display-date-round-to-year-display.md
@@ -1,0 +1,20 @@
+# Sprint Log: date-round-to-year-display
+
+**Plan:** docs/sprint-plans/date-round-to-year-display.md
+**Sprint goal:** Round date cells to a whole year and display only the year, matching the user-described semantics for year / decade / century granularities.
+**Date:** 2026-05-27
+**Result:** Completed
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Rewrote `roundDateText` per §3.1 algorithm (fractional year + Jul 1 boundary, `Math.round` to base 1/10/100, return 4-digit year string). Added `parseDateLike` for unambiguous shapes (ISO dash/slash, named-month variants, bare year) and `parseAmbiguousNumericDate` for all-numeric `M/D/Y` / `M-D-Y` shapes with 2- and 4-digit year support (50-pivot). Extended the mode-classification pass to tag ambiguous-numeric cells with their raw `{n1, n2, year}` payload, then added a column post-pass between the row loop and the rendering loop that resolves each column's MDY/DMY/MIXED/AMBIGUOUS hint and either rewrites cells with concrete `{month, day, year}` or downgrades them to `mode: 'skip'`. Dropped the `formattedValue === null` half of the dispatch-site guard. Diff: `chrome-extension/content.js | 237 ++++++++++++++++++++++++++-----`.
+- **Tests:** pass (chrome-extension: 446, js: 103). Test-writer added ~73 new assertions covering all 9 acceptance-criterion blocks and corrected 7 pre-existing tests that asserted the old `null`-on-no-change contract.
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:**
+  - MDY-column test is non-discriminating on its own (both interpretations of `03-04-2022` yield 2022); the DMY test using `12-03-2022` is properly discriminating (MDY → Dec → 2023; DMY → Mar → 2022), so the suite as a whole proves the resolver picks the correct side. Consider strengthening the MDY test in a follow-up.
+  - Shape `06-21-2020` from the §5 acceptance criteria isn't asserted end-to-end; the implementation handles it correctly (column auto-detect forces MDY when n2=21>12), but a single-row `roundTable` test would close the loop.
+  - `isYearValue` is retained as a test-compat helper; harmless but technically dead outside of tests.
+
+## PR
+(opened by orchestrator after this log is committed)


### PR DESCRIPTION
Plan: `docs/sprint-plans/date-round-to-year-display.md`

Fixes the issue where only the year was being substituted into date cells (e.g. `Jun 21, 2025` → `Jun 21, 2020`). Dates now round to a whole year using a Jul 1 boundary, decade/century use `Math.round` (not floor), and the displayed cell becomes just the year (`2020`).

New/expanded date shapes accepted: `YYYY/MM/DD`, `YYYY Month DD`, and two-digit-year US dates (`3/14/24`, 50-pivot). For ambiguous all-numeric shapes (`03-04-2022`), the parser now resolves MDY vs DMY **at the column level** by looking for a sibling cell with a component > 12; columns with no disambiguating evidence pass the ambiguous cells through unchanged.

Internally, parsed dates are materialized as `new Date(roundedYear, 0, 1)` to make the "Jan 1 of rounded year" semantic explicit.

## Acceptance criteria
- [x] All §3.1 worked-examples produce the listed results (24 parameterized assertions)
- [x] Shape equivalence: same logical date yields the same year across ISO dash/slash, named-month, and resolved-numeric forms
- [x] Two-digit-year `3/14/24` → 2024-03-14; `3/14/75` → 1975-03-14 (50-pivot)
- [x] Non-date strings unchanged in the cell
- [x] `roundDateText` always returns a 4-digit year string (never `null`); no overloaded sentinel
- [x] Column-level MDY/DMY auto-detect with `mode:skip` downgrade in ambiguous/mixed columns
- [x] Jul 1 boundary (Jun 30 → year unchanged; Jul 1 → year+1)
- [x] Decade/century use `Math.round` (Jun 21, 2025 → decade 2030, not 2020)
- [x] `node chrome-extension/tests.js` passes (446 pass, 0 fail); `node js/tests.js` passes (103/0)

## Reviewer notes
- MDY-column test is non-discriminating on its own (both interpretations of `03-04-2022` yield 2022 for year granularity); the DMY test using `12-03-2022` is properly discriminating (MDY → Dec → 2023; DMY → Mar → 2022). Worth strengthening the MDY test in a follow-up.
- Shape `06-21-2020` from the acceptance criteria is handled by column auto-detect (n2=21>12 forces MDY) but is not asserted end-to-end as a single-row `roundTable` test. Minor coverage gap.
- `isYearValue` is retained as a small test-compat helper; harmless but technically dead outside tests.