### PR TITLE
Sprint half-step-floor-chrome: Features 1+2+3 in chrome-extension/content.js

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -15,6 +15,12 @@ const DEFAULT_OFFSET_TOP = -0.5;
 const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
 const EPSILON = 1e-9;
+// Threshold for the "no-coarser-than-x" floor in half-step rounding. When the
+// integer part of a half-step offset has |trunc(offset)| >= X_FLOOR_THRESHOLD,
+// the result is also floored at roundWithOffset(|num|, trunc(offset)). Module-
+// level constant (not exposed via any public function signature) so the team
+// can later loosen it without an API change.
+const X_FLOOR_THRESHOLD = 1;
 
 // DR_DEFAULTS is loaded from defaults.js (declared first in manifest content_scripts).
 // It is shared with sidebar.js so the sidebar UI's initial state and the
@@ -1202,22 +1208,61 @@ function roundCellSetAware(value, num, max_mag, offset_top, offset_other, num_to
   return roundWithOffset(num, offset);
 }
 
+/**
+ * Rounds a number using the offset model.
+ *
+ * Step formula:
+ *   integer offset:    step = 10^(current_mag + offset)
+ *   half-step offset:  step = 0.5 * 10^(current_mag + ceil(offset))
+ *
+ * Examples for v=87,054,321 (current_mag = 7):
+ *   offset = +2   -> step = 1e9       -> raw = 0
+ *   offset = +1.5 -> step = 5e8       -> raw = 0
+ *   offset = +1   -> step = 1e8       -> raw = 100,000,000
+ *   offset = +0.5 -> step = 5e7       -> raw = 100,000,000
+ *   offset =  0   -> step = 1e7       -> raw = 90,000,000
+ *   offset = -0.5 -> step = 5e6       -> raw = 85,000,000
+ *   offset = -1   -> step = 1e6       -> raw = 87,000,000
+ *   offset = -1.5 -> step = 5e5       -> raw = 87,000,000
+ *   offset = -2   -> step = 1e5       -> raw = 87,100,000
+ *
+ * Floors applied after raw rounding:
+ *   Feature 2: result >= 10^current_mag (value-OoM floor, always on)
+ *   Feature 3: when offset is half-step and |trunc(offset)| >= X_FLOOR_THRESHOLD,
+ *              also floor at roundWithOffset(|num|, trunc(offset)).
+ */
 function roundWithOffset(num, offset) {
-  const current_mag = Math.floor(Math.log10(Math.abs(num)));
+  if (num === 0) return 0;
 
-  const oom_offset = Math.trunc(offset);
-  const fraction = Math.abs(offset - oom_offset) || 1;
+  const sign = num < 0 ? -1 : 1;
+  const absnum = Math.abs(num);
+  const current_mag = Math.floor(Math.log10(absnum));
 
-  const target_mag = current_mag + oom_offset;
-  const rounding_base = Math.pow(10, target_mag) * fraction;
-
-  let rounded = Math.round(num / rounding_base + EPSILON) * rounding_base;
-
-  if (Math.abs(rounded) >= 10) {
-    rounded = Math.round(rounded);
+  let target_mag;
+  let step;
+  if (Number.isInteger(offset)) {
+    target_mag = current_mag + offset;
+    step = Math.pow(10, target_mag);
+  } else {
+    target_mag = current_mag + Math.ceil(offset);
+    step = 0.5 * Math.pow(10, target_mag);
   }
 
-  return rounded;
+  const raw = Math.round(absnum / step + EPSILON) * step;
+  const floor_oom = Math.pow(10, current_mag);
+  let result = Math.max(raw, floor_oom);
+
+  if (!Number.isInteger(offset) && Math.abs(Math.trunc(offset)) >= X_FLOOR_THRESHOLD) {
+    const x_int = Math.trunc(offset);
+    const floor_x = roundWithOffset(absnum, x_int);
+    result = Math.max(result, floor_x);
+  }
+
+  if (result >= 10 || result % 1 === 0) {
+    result = Math.round(result);
+  }
+
+  return sign * result;
 }
 
 function toNumber(value) {

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1212,8 +1212,9 @@ function roundCellSetAware(value, num, max_mag, offset_top, offset_other, num_to
  * Rounds a number using the offset model.
  *
  * Step formula:
- *   integer offset:    step = 10^(current_mag + offset)
- *   half-step offset:  step = 0.5 * 10^(current_mag + ceil(offset))
+ *   integer offset:      step = 10^(current_mag + offset)
+ *   fractional offset:   step = f * 10^(current_mag + ceil(offset))
+ *                        where f = |offset - trunc(offset)| in (0, 1)
  *
  * Examples for v=87,054,321 (current_mag = 7):
  *   offset = +2   -> step = 1e9       -> raw = 0
@@ -1228,7 +1229,7 @@ function roundCellSetAware(value, num, max_mag, offset_top, offset_other, num_to
  *
  * Floors applied after raw rounding:
  *   Feature 2: result >= 10^current_mag (value-OoM floor, always on)
- *   Feature 3: when offset is half-step and |trunc(offset)| >= X_FLOOR_THRESHOLD,
+ *   Feature 3: when offset is non-integer and |trunc(offset)| >= X_FLOOR_THRESHOLD,
  *              also floor at roundWithOffset(|num|, trunc(offset)).
  */
 function roundWithOffset(num, offset) {
@@ -1245,7 +1246,8 @@ function roundWithOffset(num, offset) {
     step = Math.pow(10, target_mag);
   } else {
     target_mag = current_mag + Math.ceil(offset);
-    step = 0.5 * Math.pow(10, target_mag);
+    const f = Math.abs(offset - Math.trunc(offset));
+    step = f * Math.pow(10, target_mag);
   }
 
   const raw = Math.round(absnum / step + EPSILON) * step;

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -2946,6 +2946,27 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     roundWithOffset(0, 1.5), 0);
 })();
 
+(function quarterStepGrid() {
+  // Generalized fractional formula: any non-integer offset uses
+  // step = f * 10^(current_mag + ceil(offset)) where f = |offset - trunc(offset)|.
+  // Quarter-step (f = 0.25) spot checks across 87M / 47M / 17M.
+  const cases = [
+    [87054321,  0.25,  75000000],
+    [87054321, -0.25,  87500000],
+    [47054321,  0.25,  50000000],
+    [47054321, -0.25,  47500000],
+    [17054321,  0.25,  25000000],
+    [17054321, -0.25,  17500000],
+    // |trunc(offset)| >= X_FLOOR_THRESHOLD triggers the x-floor too.
+    [87054321,  1.25, 100000000],  // x-floor at rd(87M, 1) = 100M
+    [87054321, -1.25,  87000000],  // very fine step, x-floor at rd(87M, -1) = 87M
+  ];
+  for (const [v, off, expected] of cases) {
+    eq(`quarter-step grid: roundWithOffset(${v}, ${off})`,
+      roundWithOffset(v, off), expected);
+  }
+})();
+
 (function halfStepMonotonicity() {
   // Monotonicity at offsets 1 and 0.5 across [73, 4591, 63538, 162583, 400000]
   const values = [73, 4591, 63538, 162583, 400000];

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -2913,6 +2913,88 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     /function roundDateText[\s\S]{0,800}return String\(/.test(src), true);
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint half-step-floor-chrome: Features 1 (sign-aware half-step),
+// 2 (value-OoM floor), 3 (X_FLOOR_THRESHOLD-gated x-floor)
+// ---------------------------------------------------------------------------
+(function halfStepFloorGrid() {
+  // 27-cell grid: {87M, 47M, 17M} x {+2, +1.5, +1, +0.5, 0, -0.5, -1, -1.5, -2}
+  const grid = [
+    { v: 87054321, expected: { '2': 10000000, '1.5': 100000000, '1': 100000000,
+      '0.5': 100000000, '0': 90000000, '-0.5': 85000000, '-1': 87000000,
+      '-1.5': 87000000, '-2': 87100000 } },
+    { v: 47054321, expected: { '2': 10000000, '1.5': 10000000, '1': 10000000,
+      '0.5': 50000000, '0': 50000000, '-0.5': 45000000, '-1': 47000000,
+      '-1.5': 47000000, '-2': 47100000 } },
+    { v: 17054321, expected: { '2': 10000000, '1.5': 10000000, '1': 10000000,
+      '0.5': 10000000, '0': 20000000, '-0.5': 15000000, '-1': 17000000,
+      '-1.5': 17000000, '-2': 17100000 } },
+  ];
+  const offsets = [2, 1.5, 1, 0.5, 0, -0.5, -1, -1.5, -2];
+  for (const row of grid) {
+    for (const off of offsets) {
+      const key = String(off);
+      eq(`half-step grid: roundWithOffset(${row.v}, ${off})`,
+        roundWithOffset(row.v, off), row.expected[key]);
+    }
+  }
+
+  // Negative-value sign preservation (spot check)
+  eq('half-step grid: sign preserved for negative input',
+    roundWithOffset(-87054321, -0.5), -85000000);
+  eq('half-step grid: zero short-circuits',
+    roundWithOffset(0, 1.5), 0);
+})();
+
+(function halfStepMonotonicity() {
+  // Monotonicity at offsets 1 and 0.5 across [73, 4591, 63538, 162583, 400000]
+  const values = [73, 4591, 63538, 162583, 400000];
+  for (const off of [1, 0.5]) {
+    const out = values.map(v => roundWithOffset(v, off));
+    let monotonic = true;
+    for (let i = 1; i < out.length; i++) {
+      if (out[i] < out[i - 1]) { monotonic = false; break; }
+    }
+    eq(`monotonicity: non-decreasing at offset=${off} (got ${JSON.stringify(out)})`,
+      monotonic, true);
+  }
+})();
+
+(function xFloorThresholdFlip() {
+  // Re-eval content.js with X_FLOOR_THRESHOLD = 0 to confirm the x-floor
+  // gates on the constant. We sandbox the patched source so the eq()
+  // assertions below don't disturb the live extension globals.
+  const src = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+  const patched = src.replace(
+    /const X_FLOOR_THRESHOLD = 1;/,
+    'const X_FLOOR_THRESHOLD = 0;'
+  );
+  eq('x-floor flip: source contains X_FLOOR_THRESHOLD declaration',
+    patched.includes('const X_FLOOR_THRESHOLD = 0;'), true);
+
+  const sandbox = {
+    chrome: global.chrome,
+    document: global.document,
+    window: global.window,
+    NodeFilter: global.NodeFilter,
+    MutationObserver: global.MutationObserver,
+    ResizeObserver: global.ResizeObserver,
+    Node: global.Node,
+    DR_DEFAULTS: globalThis.DR_DEFAULTS,
+  };
+  const vm = require('vm');
+  const ctx = vm.createContext(sandbox);
+  vm.runInContext(patched + '\nthis.__roundWithOffset = roundWithOffset;', ctx);
+  const patchedRound = sandbox.__roundWithOffset;
+
+  eq('x-floor flip: rd(17054321, 0.5) === 20000000 with X_FLOOR_THRESHOLD=0',
+    patchedRound(17054321, 0.5), 20000000);
+  // And confirm the live (X_FLOOR_THRESHOLD=1) implementation does NOT
+  // apply the x-floor for the same call.
+  eq('x-floor flip: rd(17054321, 0.5) === 10000000 with X_FLOOR_THRESHOLD=1 (default)',
+    roundWithOffset(17054321, 0.5), 10000000);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/docs/sprint-logs/offset-semantics-v2-half-step-floor-chrome.md
+++ b/docs/sprint-logs/offset-semantics-v2-half-step-floor-chrome.md
@@ -1,0 +1,61 @@
+# Sprint log: half-step-floor-chrome
+
+**Plan:** `docs/sprint-plans/offset-semantics-v2.md`
+**Branch:** `feature/half-step-floor-chrome`
+**Date:** 2026-05-28
+
+## Summary
+
+Implemented Features 1+2+3 of the offset-semantics-v2 plan in
+`chrome-extension/content.js`, mirroring the spec the JS and Python sprints
+use. Public signatures (`ROUND_DYNAMIC`, `singleValueMode`, `datasetMode`,
+`roundCellSetAware`, `roundTable`) are unchanged.
+
+### Feature 1 — sign-aware half-step
+`roundWithOffset` now branches on `Number.isInteger(offset)`:
+
+- integer offset: `step = 10^(current_mag + offset)`
+- half-step offset: `target_mag = current_mag + ceil(offset)`, `step = 0.5 * 10^target_mag`
+
+`ceil(-0.5) = 0`, `ceil(+0.5) = 1`, so `-0.5` keeps its legacy meaning while
+`+0.5`, `+1.5`, ... finally express "half of the next-coarser OoM step".
+
+### Feature 2 — value-OoM floor
+After raw rounding, the absolute result is floored at `10^current_mag` so a
+single tens-of-millions value can no longer collapse to 0. Sign is reapplied
+at the end.
+
+### Feature 3 — module-level `X_FLOOR_THRESHOLD`
+Added `const X_FLOOR_THRESHOLD = 1;` to the content.js constants block
+(alongside `EPSILON`, `VALIDATION_LIMIT`, `DEFAULT_OFFSET_TOP`). When the
+offset is half-step and `|trunc(offset)| >= X_FLOOR_THRESHOLD`, the result is
+also floored at `roundWithOffset(|num|, trunc(offset))`. Not exposed via any
+public function signature — flipping the threshold is a one-line edit.
+
+### Other changes
+- `num === 0` short-circuits inside `roundWithOffset` (callers already guard,
+  but the recursive x-floor branch needs it too).
+- Final `Math.round` short-circuit now triggers on `result >= 10 || result % 1 === 0`,
+  matching the spec; this is wider than the prior `Math.abs(rounded) >= 10`
+  condition and clears trailing-float noise for whole-number results below 10.
+
+## Tests
+
+`node chrome-extension/tests.js` — **480 passed, 0 failed** (446 prior + 34 new).
+
+New coverage in `chrome-extension/tests.js`:
+- 27-cell grid for `{87M, 47M, 17M} x {+2, +1.5, +1, +0.5, 0, -0.5, -1, -1.5, -2}`
+- sign-preservation + zero short-circuit spot checks
+- monotonicity on `[73, 4591, 63538, 162583, 400000]` at offsets `1` and `0.5`
+- threshold-flip: a `vm`-sandboxed re-eval of `content.js` with the constant
+  patched to `0` confirms `rd(17054321, 0.5) === 20000000`, and the live
+  (default) implementation returns `10000000` for the same call.
+
+All pre-existing `-0.5` regression tests pass unchanged — the default-path
+behavior is identical to v0.2.x.
+
+## Out of scope (per plan)
+
+- `chrome-extension/manifest.json` (CI bump handles)
+- `chrome-extension/README.md`, `defaults.js`, `sidebar.html` (docs sprint)
+- Public function signatures

--- a/docs/sprint-logs/offset-semantics-v2-half-step-floor-chrome.md
+++ b/docs/sprint-logs/offset-semantics-v2-half-step-floor-chrome.md
@@ -54,6 +54,29 @@ New coverage in `chrome-extension/tests.js`:
 All pre-existing `-0.5` regression tests pass unchanged — the default-path
 behavior is identical to v0.2.x.
 
+## Fixup: generalize fractional formula
+
+The original `roundWithOffset` non-integer branch hard-coded `step = 0.5 * 10^(...)`,
+so any non-half fractional offset (e.g. `0.25`, `1.25`) collapsed to a half-step.
+Replaced the branch with the general formula
+
+```
+target_mag = current_mag + Math.ceil(offset)
+f          = |offset - trunc(offset)|         // in (0, 1)
+step       = f * 10^target_mag
+```
+
+`Math.ceil` gives uniform handling of negative non-integers (`ceil(-0.25)=0`,
+`ceil(-1.25)=-1`). The Feature-3 x-floor gate now keys on `!Number.isInteger(offset)`
+instead of the implicit half-step assumption. This mirrors the parallel fix in
+`js/round_dynamic.js`.
+
+New `quarterStepGrid` test in `chrome-extension/tests.js` locks in 8 quarter-step
+cases across `{87M, 47M, 17M}` at `±0.25` plus `87M @ ±1.25` (x-floor exercised).
+All 488 tests pass; the prior 27-cell half-step grid, monotonicity, and
+threshold-flip tests are unaffected because the new formula yields `f = 0.5` for
+half-step offsets — bit-identical to the prior `0.5 *` constant.
+
 ## Out of scope (per plan)
 
 - `chrome-extension/manifest.json` (CI bump handles)


### PR DESCRIPTION
Implements Features 1 (sign-aware half-step), 2 (value-OoM floor), and 3 (module-level `X_FLOOR_THRESHOLD` gating the x-floor) of the offset-semantics-v2 plan in the Chrome extensions embedded `roundWithOffset`.

Public signatures (`ROUND_DYNAMIC`, `singleValueMode`, `datasetMode`, `roundCellSetAware`, `roundTable`) are unchanged. Default-path `-0.5` behavior is preserved.

## Tests

`node chrome-extension/tests.js` -> **480 passed, 0 failed** (446 prior + 34 new):
- 27-cell grid for `{87M, 47M, 17M} x {+2, +1.5, +1, +0.5, 0, -0.5, -1, -1.5, -2}`
- sign + zero short-circuit spot checks
- monotonicity on `[73, 4591, 63538, 162583, 400000]` at offsets `1` and `0.5`
- threshold-flip via a sandboxed `vm` re-eval of `content.js` with `X_FLOOR_THRESHOLD=0`, asserting `rd(17054321, 0.5) === 20000000`

All prior tests pass unmodified.

Sprint log: `docs/sprint-logs/offset-semantics-v2-half-step-floor-chrome.md`
Plan: `docs/sprint-plans/offset-semantics-v2.md`