### PR TITLE
Sprint half-step-floor-python: Features 1+2+3 in python/dynamic_rounding/

### DIFF
--- a/docs/sprint-logs/offset-semantics-v2-half-step-floor-python.md
+++ b/docs/sprint-logs/offset-semantics-v2-half-step-floor-python.md
@@ -38,3 +38,24 @@ Not touched (out of scope per plan): `python/pyproject.toml`, `python/README.md`
 - This is a **breaking change** for callers passing positive non-integer offsets (`+0.5`, `+1.5`, …); their results now differ from the previous (buggy) behavior. The sprint plan acknowledges this and routes the version bump (`0.1.x → 0.2.0`) through the release sprint.
 - The legacy `TestOffsetSymmetry` class was renamed to `TestOffsetSignDirection` and inverted to assert the new asymmetry, since the old symmetry was itself the bug being fixed.
 - A handful of `TrailingZeros` tests originally used `offset=0.25` to exercise a quarter-step path. The new semantics treat *every* non-integer offset as a half-step, so the one test that depended on an actual 0.25-step (`(1.13, 0.25) → 1.25`) was dropped; the surviving test was rewritten to verify the half-step path with `offset=-0.25`.
+
+## Fixup — generalize fraction formula to all non-integer offsets
+
+Reviewer noted that the original implementation collapsed every non-integer offset to a half-step. `_round_with_offset` now uses the general fractional formula:
+
+```
+target_mag = current_mag + ceil(offset)
+f          = abs(offset - trunc(offset))   # fractional magnitude in (0, 1)
+step       = f * 10**target_mag
+```
+
+This recovers genuine quarter-step (and arbitrary fractional) behavior while keeping `±0.5` byte-identical to the previous half-step path (since `f = 0.5`). The value-OoM floor and `X_FLOOR_THRESHOLD`-gated x-floor still apply for any non-integer offset.
+
+### Added tests
+
+- `TestQuarterStep` — parametrized grid covering `±0.25` and `±1.25` against the value triplet `(87054321, 47054321, 17054321)`, plus the recomputed legacy small-value case `(1.13, 0.25) → 1` (under formula B: step = 2.5 → raw = 0 → value-OoM floor lifts to 1).
+
+### Verification
+
+- After fixup: **92 passed, 1 skipped, 0 failed** (`python -m pytest python/tests/`).
+- All 27 grid cells, all `-0.5` regression cases, all monotonicity cases, and the threshold-flip test still pass — the change is additive for half-steps and only introduces new behavior for non-half fractional offsets.

--- a/docs/sprint-logs/offset-semantics-v2-half-step-floor-python.md
+++ b/docs/sprint-logs/offset-semantics-v2-half-step-floor-python.md
@@ -1,0 +1,40 @@
+# Sprint log — half-step-floor-python
+
+Sprint plan: `docs/sprint-plans/offset-semantics-v2.md` (offset-semantics-v2, sprint `half-step-floor-python`).
+
+## Scope delivered
+
+- **Feature 1 — Sign-aware half-step semantics.** `_round_with_offset` now computes `target_mag = current_mag + ceil(offset)` and `step = 0.5 * 10^target_mag` for any non-integer offset, so `+0.5` rounds to the next coarser half (`87,054,321 → 100,000,000`) while `-0.5` preserves legacy behavior (`87,054,321 → 85,000,000`).
+- **Feature 2 — Value-OoM floor.** After the raw round we take `max(raw, 10^current_mag)`, preventing a positive value from collapsing past its own order of magnitude (e.g. `17,054,321 @ +0.5` no longer falls below `10^7`).
+- **Feature 3 — `X_FLOOR_THRESHOLD` constant.** New module-level constant (default `1`) gating an x-floor: for half-step offsets where `|trunc(offset)| >= X_FLOOR_THRESHOLD`, the result is additionally floored by the integer-offset result at `trunc(offset)`. Setting `X_FLOOR_THRESHOLD = 0` opts in to the x-floor for `±0.5` as well.
+
+Public function signatures unchanged. `_preserve_type` is applied after the floor logic on the final result, exactly as before.
+
+## Files touched
+
+- `python/dynamic_rounding/__init__.py` — added `X_FLOOR_THRESHOLD`, rewrote `_round_with_offset` per spec.
+- `python/tests/test_core.py` —
+  - Added `TestOffsetGrid` (27-cell parametrized grid from spec).
+  - Added `TestMonotonicity` (sorted-list ordering for `offset=1`, `0.5`, `-0.5`).
+  - Added `TestXFloorThreshold` including the `monkeypatch.setattr` flip test.
+  - Added `TestNegativeHalfRegression` to lock in unchanged `-0.5` behavior.
+  - Updated legacy tests that asserted the old buggy behavior (sign-agnostic `±0.5` symmetry, the `-1.5` example, and `TrailingZeros` cases that relied on `+0.5 == -0.5`). All such fixtures were either flipped to negative offsets (preserving their original intent) or rewritten to assert the new sign-aware values.
+  - Updated `test_version_exists` to match the current `0.1.4` package version (pre-existing baseline failure).
+
+Not touched (out of scope per plan): `python/pyproject.toml`, `python/README.md`.
+
+## Verification
+
+`cd python && python -m pytest tests/`
+
+- Baseline (main): 43 passed, 1 skipped, 1 pre-existing fail (`test_version_exists` asserted `0.1.3` but pyproject is `0.1.4`).
+- After sprint: **83 passed, 1 skipped, 0 failed.**
+- 27/27 cells in the verification grid pass.
+- Monotonicity verified across `offset ∈ {1, 0.5, -0.5}` on `[73, 4591, 63538, 162583, 400000]`.
+- Threshold-flip test confirms `X_FLOOR_THRESHOLD = 0` makes `round_dynamic(17054321, offset=0.5) == 20000000`.
+
+## Caveats
+
+- This is a **breaking change** for callers passing positive non-integer offsets (`+0.5`, `+1.5`, …); their results now differ from the previous (buggy) behavior. The sprint plan acknowledges this and routes the version bump (`0.1.x → 0.2.0`) through the release sprint.
+- The legacy `TestOffsetSymmetry` class was renamed to `TestOffsetSignDirection` and inverted to assert the new asymmetry, since the old symmetry was itself the bug being fixed.
+- A handful of `TrailingZeros` tests originally used `offset=0.25` to exercise a quarter-step path. The new semantics treat *every* non-integer offset as a half-step, so the one test that depended on an actual 0.25-step (`(1.13, 0.25) → 1.25`) was dropped; the surviving test was rewritten to verify the half-step path with `offset=-0.25`.

--- a/python/dynamic_rounding/__init__.py
+++ b/python/dynamic_rounding/__init__.py
@@ -12,6 +12,7 @@ __version__ = "0.1.4"
 
 # Constants
 DEFAULT_OFFSET = -0.5
+X_FLOOR_THRESHOLD: float = 1
 VALIDATION_LIMIT = 20
 EPSILON = 1e-9
 
@@ -146,25 +147,49 @@ def _find_max_magnitude(values: List[Any]) -> Optional[int]:
 def _round_with_offset(value: float, offset: float) -> float:
     """
     Round a number using the offset model.
-    
+
     offset = OoM offset + optional fraction
         0 = current OoM
         -1 = one OoM finer
         1 = one OoM coarser
         0.5 = half of current OoM (same as -0.5)
         -1.5 = half of one OoM finer
+
+    Sign-aware: rounding is performed on the absolute value, then the sign is
+    re-applied. A value-OoM floor prevents results from dropping below the
+    current order of magnitude, so a positive input never rounds toward zero
+    past its own OoM. For half-steps with a large integer offset component
+    (|trunc(offset)| >= X_FLOOR_THRESHOLD), an additional x-floor is applied
+    so that a half-step never rounds finer than the corresponding integer
+    offset would.
     """
-    current_mag = math.floor(math.log10(abs(value)))
-    
-    # Decompose offset into integer part and fraction
-    oom_offset = math.trunc(offset)
-    fraction = abs(offset - oom_offset) or 1.0
-    
-    target_mag = current_mag + oom_offset
-    rounding_base = (10 ** target_mag) * fraction
-    
-    # Add epsilon to handle floating point inaccuracies
-    return round(value / rounding_base + EPSILON) * rounding_base
+    if value == 0:
+        return 0
+
+    sign = -1 if value < 0 else 1
+    absval = abs(value)
+    current_mag = math.floor(math.log10(absval))
+
+    if float(offset).is_integer():
+        target_mag = current_mag + int(offset)
+        step = 10 ** target_mag
+    else:  # half-step
+        target_mag = current_mag + math.ceil(offset)
+        step = 0.5 * (10 ** target_mag)
+
+    raw = round(absval / step + EPSILON) * step
+    floor_oom = 10 ** current_mag  # Feature 2: value-OoM floor
+
+    result = max(raw, floor_oom)
+
+    # Feature 3: x-floor for half-steps with large integer part
+    if not float(offset).is_integer():
+        x_int = math.trunc(offset)
+        if abs(x_int) >= X_FLOOR_THRESHOLD:
+            floor_x = _round_with_offset(absval, x_int)
+            result = max(result, abs(floor_x))
+
+    return sign * result
 
 
 def _preserve_type(result: float, original_value: Any) -> Union[int, float]:

--- a/python/dynamic_rounding/__init__.py
+++ b/python/dynamic_rounding/__init__.py
@@ -173,16 +173,17 @@ def _round_with_offset(value: float, offset: float) -> float:
     if float(offset).is_integer():
         target_mag = current_mag + int(offset)
         step = 10 ** target_mag
-    else:  # half-step
+    else:  # general fractional offset
         target_mag = current_mag + math.ceil(offset)
-        step = 0.5 * (10 ** target_mag)
+        f = abs(offset - math.trunc(offset))  # fractional magnitude in (0, 1)
+        step = f * (10 ** target_mag)
 
     raw = round(absval / step + EPSILON) * step
     floor_oom = 10 ** current_mag  # Feature 2: value-OoM floor
 
     result = max(raw, floor_oom)
 
-    # Feature 3: x-floor for half-steps with large integer part
+    # Feature 3: x-floor for fractional offsets with large integer part
     if not float(offset).is_integer():
         x_int = math.trunc(offset)
         if abs(x_int) >= X_FLOOR_THRESHOLD:

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -7,7 +7,7 @@ from dynamic_rounding import round_dynamic, __version__
 
 class TestVersion:
     def test_version_exists(self):
-        assert __version__ == "0.1.3"
+        assert __version__ == "0.1.4"
 
 
 class TestSingleMode:
@@ -31,8 +31,11 @@ class TestSingleMode:
         assert round_dynamic(87654321, offset=1) == 100000000
     
     def test_offset_negative_one_point_five(self):
-        # Offset -1.5 = half of one OoM finer
-        assert round_dynamic(87654321, offset=-1.5) == 87500000
+        # Offset -1.5 under new sign-aware semantics with the x-floor (Feature 3):
+        # the half-step result (87_500_000) is floored by the integer-offset
+        # result at trunc(-1.5) = -1, which yields 88_000_000. So the x-floor
+        # raises -1.5 up to match -1.
+        assert round_dynamic(87654321, offset=-1.5) == 88000000
     
     def test_zero_value(self):
         # Zero returns 0, preserving int type
@@ -183,51 +186,53 @@ class TestEdgeCases:
         assert result[0] == 4500000
 
 
-class TestOffsetSymmetry:
-    """Test that 0.5 and -0.5 produce same results (as documented)."""
+class TestOffsetSignDirection:
+    """Under sign-aware semantics, +0.5 and -0.5 step in opposite directions."""
 
-    def test_half_offset_symmetry(self):
-        assert round_dynamic(87654321, offset=0.5) == round_dynamic(87654321, offset=-0.5)
+    def test_positive_half_steps_coarser(self):
+        # +0.5: target_mag = current_mag + ceil(0.5) = 8, step = 5e7,
+        # round(87654321 / 5e7) = 2 -> 1e8.
+        assert round_dynamic(87654321, offset=0.5) == 100000000
 
-    def test_point_three_symmetry(self):
-        assert round_dynamic(87654321, offset=0.3) == round_dynamic(87654321, offset=-0.3)
+    def test_negative_half_keeps_legacy_behavior(self):
+        # -0.5 preserves the default behavior used historically.
+        assert round_dynamic(87654321, offset=-0.5) == 90000000
+
+    def test_positive_and_negative_half_differ(self):
+        assert round_dynamic(87654321, offset=0.5) != round_dynamic(87654321, offset=-0.5)
 
 
 class TestTrailingZeros:
     """Whole-number results with |value| < 10 should return int, not float."""
 
     def test_whole_number_result_is_int(self):
-        result = round_dynamic(1.13, offset=0.5)
+        result = round_dynamic(1.13, offset=-0.5)
         assert result == 1
         assert isinstance(result, int)
 
     def test_whole_number_negative_is_int(self):
-        result = round_dynamic(-1.13, offset=0.5)
+        result = round_dynamic(-1.13, offset=-0.5)
         assert result == -1
         assert isinstance(result, int)
 
     def test_whole_number_two_is_int(self):
-        result = round_dynamic(1.76, offset=0.5)
+        result = round_dynamic(1.76, offset=-0.5)
         assert result == 2
         assert isinstance(result, int)
 
     def test_whole_number_from_exact_input_is_int(self):
-        result = round_dynamic(1.0, offset=0.5)
+        result = round_dynamic(1.0, offset=-0.5)
         assert result == 1
         assert isinstance(result, int)
 
     def test_fractional_result_stays_float(self):
-        result = round_dynamic(1.42, offset=0.5)
+        result = round_dynamic(1.42, offset=-0.5)
         assert result == 1.5
         assert isinstance(result, float)
 
-    def test_two_decimal_result_stays_float(self):
-        result = round_dynamic(1.13, offset=0.25)
-        assert result == 1.25
-        assert isinstance(result, float)
-
-    def test_one_decimal_result_stays_float(self):
-        result = round_dynamic(1.42, offset=0.25)
+    def test_half_step_decimal_input_returns_float(self):
+        # Half-step on a value with mag=0: step=0.5*10^0=0.5; 1.42/0.5=2.84 → 3 → 1.5
+        result = round_dynamic(1.42, offset=-0.25)
         assert result == 1.5
         assert isinstance(result, float)
 
@@ -238,8 +243,99 @@ class TestTrailingZeros:
         assert isinstance(result, float)
 
     def test_whole_number_in_list(self):
-        result = round_dynamic([1.13, 1.42], offset_top=0.5)
+        result = round_dynamic([1.13, 1.42], offset_top=-0.5)
         assert result[0] == 1
         assert isinstance(result[0], int)
         assert result[1] == 1.5
         assert isinstance(result[1], float)
+
+
+# ---------------------------------------------------------------------------
+# Sprint half-step-floor-python: Features 1 (sign-aware half-step),
+# 2 (value-OoM floor), and 3 (X_FLOOR_THRESHOLD-gated x-floor).
+# ---------------------------------------------------------------------------
+
+
+class TestOffsetGrid:
+    """27-cell verification grid covering the new sign-aware semantics."""
+
+    @pytest.mark.parametrize("value,offset,expected", [
+        (87054321, 2, 10000000),
+        (87054321, 1.5, 100000000),
+        (87054321, 1, 100000000),
+        (87054321, 0.5, 100000000),
+        (87054321, 0, 90000000),
+        (87054321, -0.5, 85000000),
+        (87054321, -1, 87000000),
+        (87054321, -1.5, 87000000),
+        (87054321, -2, 87100000),
+        (47054321, 2, 10000000),
+        (47054321, 1.5, 10000000),
+        (47054321, 1, 10000000),
+        (47054321, 0.5, 50000000),
+        (47054321, 0, 50000000),
+        (47054321, -0.5, 45000000),
+        (47054321, -1, 47000000),
+        (47054321, -1.5, 47000000),
+        (47054321, -2, 47100000),
+        (17054321, 2, 10000000),
+        (17054321, 1.5, 10000000),
+        (17054321, 1, 10000000),
+        (17054321, 0.5, 10000000),
+        (17054321, 0, 20000000),
+        (17054321, -0.5, 15000000),
+        (17054321, -1, 17000000),
+        (17054321, -1.5, 17000000),
+        (17054321, -2, 17100000),
+    ])
+    def test_grid(self, value, offset, expected):
+        assert round_dynamic(value, offset=offset) == expected
+
+
+class TestMonotonicity:
+    """Sorted inputs must round to a non-decreasing sequence."""
+
+    SORTED = [73, 4591, 63538, 162583, 400000]
+
+    def test_offset_one_preserves_order(self):
+        out = [round_dynamic(v, offset=1) for v in self.SORTED]
+        assert out == sorted(out)
+
+    def test_offset_half_preserves_order(self):
+        out = [round_dynamic(v, offset=0.5) for v in self.SORTED]
+        assert out == sorted(out)
+
+    def test_offset_negative_half_preserves_order(self):
+        out = [round_dynamic(v, offset=-0.5) for v in self.SORTED]
+        assert out == sorted(out)
+
+
+class TestXFloorThreshold:
+    """The module-level X_FLOOR_THRESHOLD constant gates Feature 3."""
+
+    def test_threshold_default_is_one(self):
+        import dynamic_rounding
+        assert dynamic_rounding.X_FLOOR_THRESHOLD == 1
+
+    def test_x_floor_threshold_can_be_relaxed(self, monkeypatch):
+        import dynamic_rounding
+        monkeypatch.setattr(dynamic_rounding, "X_FLOOR_THRESHOLD", 0)
+        # Relaxing the threshold to 0 makes the x-floor apply even for
+        # ±0.5; offset=0.5 then must not round below the offset=0 result.
+        assert dynamic_rounding.round_dynamic(17054321, offset=0.5) == 20000000
+
+
+class TestNegativeHalfRegression:
+    """offset=-0.5 must remain unchanged for existing fixtures."""
+
+    @pytest.mark.parametrize("value,expected", [
+        (87654321, 90000000),
+        (4321, 4500),
+        (4428910, 4500000),
+        (983321, 1000000),
+        (42109, 40000),
+        (-87654321, -90000000),
+        (-4321, -4500),
+    ])
+    def test_default_offset_regression(self, value, expected):
+        assert round_dynamic(value, offset=-0.5) == expected

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -325,6 +325,33 @@ class TestXFloorThreshold:
         assert dynamic_rounding.round_dynamic(17054321, offset=0.5) == 20000000
 
 
+class TestQuarterStep:
+    """Quarter-step (and other non-half fractional) offsets use the general formula.
+
+    Under the general fraction formula:
+        if offset is non-integer:
+            target_mag = current_mag + ceil(offset)
+            f          = abs(offset - trunc(offset))
+            step       = f * 10**target_mag
+    """
+
+    @pytest.mark.parametrize("value,offset,expected", [
+        (87054321,  0.25,  75000000),
+        (87054321, -0.25,  87500000),
+        (47054321,  0.25,  50000000),
+        (47054321, -0.25,  47500000),
+        (17054321,  0.25,  25000000),
+        (17054321, -0.25,  17500000),
+        (87054321,  1.25, 100000000),   # x-floor at rd(87M, 1) = 100M
+        (87054321, -1.25,  87000000),   # step 250K; x-floor at rd(87M, -1) = 87M
+        # Previously-dropped small-value quarter-step, recomputed under formula B:
+        # OoM=0, target_mag=1, f=0.25, step=2.5; round(1.13/2.5)=0 -> floored to 10^0 = 1.
+        (1.13, 0.25, 1),
+    ])
+    def test_quarter_step_grid(self, value, offset, expected):
+        assert round_dynamic(value, offset=offset) == expected
+
+
 class TestNegativeHalfRegression:
     """offset=-0.5 must remain unchanged for existing fixtures."""
 


### PR DESCRIPTION
Implements Features 1 (sign-aware half-step), 2 (value-OoM floor), and 3 (`X_FLOOR_THRESHOLD`-gated x-floor) from the `offset-semantics-v2` plan in the Python package.

## Summary

- `_round_with_offset` rewritten per spec: `target_mag = current_mag + ceil(offset)`, `step = 0.5 * 10^target_mag` for non-integer offsets; integer offsets keep `step = 10^(current_mag + offset)`.
- Value-OoM floor (`max(raw, 10^current_mag)`) added so positive values cannot collapse below their own OoM.
- New module-level constant `X_FLOOR_THRESHOLD: float = 1` near `DEFAULT_OFFSET`. When `|trunc(offset)| >= X_FLOOR_THRESHOLD`, the half-step result is additionally floored by the integer-offset result. Setting `X_FLOOR_THRESHOLD = 0` opts in for `±0.5`.
- Public function signatures unchanged; `_preserve_type` still applied on the final post-floor result.

## Tests

- 27-cell parametrized verification grid (per spec).
- Monotonicity checks for `offset ∈ {1, 0.5, -0.5}` on `[73, 4591, 63538, 162583, 400000]`.
- `monkeypatch.setattr` flip test: `X_FLOOR_THRESHOLD = 0` makes `round_dynamic(17054321, offset=0.5) == 20000000`.
- `-0.5` regression lock-in on existing fixtures.
- Legacy tests asserting the old buggy `+0.5 == -0.5` symmetry were updated to assert the new sign-aware behavior (this is a breaking change tracked in the plan).

## Verification

`cd python && python -m pytest tests/` → **83 passed, 1 skipped, 0 failed.**

## Sprint log

`docs/sprint-logs/offset-semantics-v2-half-step-floor-python.md`

## Out of scope

- `python/pyproject.toml` (CI handles version bumps).
- `python/README.md` (docs sprint).