### PR TITLE
chore: stop version-bump workflow from cascading on its own merges

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   bump:
-    if: github.event.pull_request.merged == true
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check out main


### PR DESCRIPTION
## Problem

The workflow `.github/workflows/bump-version.yml` triggers on `pull_request: closed && merged == true` and uses `dorny/paths-filter` against `python/**` and `chrome-extension/**`. The bump itself modifies files in those paths, so merging a bot-authored bump PR re-triggers the workflow, opening another bump PR — forever (e.g. #71 → #72 → #73 → #74 → #76).

## Fix

Add a guard so the workflow skips PRs authored by `github-actions[bot]`.

## After this merges

- Close any open cascade PRs (#76 is a pure cascade; #75 represents the real bump for #70 and can be merged if a Python patch bump is wanted).
- Subsequent real merges only fire one bump PR each.

## Test plan

- [ ] Merge this PR (should not trigger a follow-up bump PR — touches `.github/workflows/`, not `python/**` or `chrome-extension/**`).
- [ ] Merge a real change to `chrome-extension/**` and verify exactly one bump PR opens, and merging that bump PR opens zero further PRs.