### PR TITLE
Sprint half-step-floor-docs: README + CHANGELOG + docstring updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,26 @@ Depending on the situation, a number like **87,054,321** may be interpreted diff
 
 | lens (i.e. a simplified representation of the data) | Declarative lens: round this number to the… | Imperative command: round this number to the…  |
 | :---- | :---- | :---- |
-| 100,000,000 | … next larger order of magnitude <br> <br> `=round_dynamic(A1, 1)` | … nearest hundred million <br> <br> `=ROUND(87654321 / 100000000, 0) * 100000000` |
-| 90,000,000 | … current order or magnitude  <br> <br> `=round_dynamic(A1, 0)` | … nearest 10 million  <br> <br> `=round(A1, -7)` |
-| 85,000,000 | … half-step within order  <br> <br> `=round_dynamic(A1, -0.5)` | nearest 5 million  <br> <br> `=mround(A1, 5000000)` |
+| 100,000,000 | … next larger order of magnitude <br> <br> `=round_dynamic(A1, 1)` | … nearest hundred million <br> <br> `=ROUND(A1 / 100000000, 0) * 100000000` |
+| 100,000,000 | … half-step toward the next-larger order <br> <br> `=round_dynamic(A1, 0.5)` | … nearest 50 million <br> <br> `=mround(A1, 50000000)` |
+| 90,000,000 | … current order of magnitude  <br> <br> `=round_dynamic(A1, 0)` | … nearest 10 million  <br> <br> `=round(A1, -7)` |
+| 85,000,000 | … half-step within the current order  <br> <br> `=round_dynamic(A1, -0.5)` | … nearest 5 million  <br> <br> `=mround(A1, 5000000)` |
 | 87,000,000 | … one order finer  <br> <br> `=round_dynamic(A1, -1)` | … nearest million  <br> <br> `=round(A1, -6)` |
 
 
 Each setting emphasizes different relationships in the data.  The goal is not precision — it is interpretability.
+
+The sign of a fractional offset tells the function which way to step. A positive `+0.5` rounds to half of the **next-larger** order of magnitude; a negative `-0.5` rounds to half of the **current** order. This generalizes to any non-integer offset: the step size is `|frac(offset)| × 10^(OoM + ceil(offset))`.
+
+### Floor at the value's order of magnitude
+
+Rounding can never collapse a number below its own order of magnitude. For any value, the simplified result is guaranteed to have a magnitude of at least `10^floor(log10(|value|))`, with sign preserved.
+
+For example, `=round_dynamic(87054321, 2)` (asking to round to the nearest hundred million) returns **10,000,000**, not `0`. A tens-of-millions value never simplifies to zero, regardless of how aggressive the requested offset is. This keeps ordering intuitive when a dataset spans many magnitudes.
+
+### Backward compatibility
+
+The default offset (`-0.5`) is unchanged: every call that relies on the default — single mode or dataset mode — produces the exact same value it did before. Callers that explicitly pass a *positive* non-integer offset (`+0.5`, `+0.25`, `+1.5`, etc.) will see different values than in earlier versions: positive fractional offsets previously produced the same result as their negative counterparts (a latent bug), and now correctly step toward the next-larger order of magnitude.
 
 
 ## Simplifying ranges

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ Depending on the situation, a number like **87,054,321** may be interpreted diff
 | lens (i.e. a simplified representation of the data) | Declarative lens: round this number to the… | Imperative command: round this number to the…  |
 | :---- | :---- | :---- |
 | 100,000,000 | … next larger order of magnitude <br> <br> `=round_dynamic(A1, 1)` | … nearest hundred million <br> <br> `=ROUND(A1 / 100000000, 0) * 100000000` |
+| 100,000,000 | … halfway between the next-larger and two-larger orders[^safety] <br> <br> `=round_dynamic(A1, 1.5)` | … nearest 500 million, with a 100-million safety net <br> <br> `=MAX(MROUND(A1, 500000000), MROUND(A1, 100000000))` |
 | 100,000,000 | … half-step toward the next-larger order <br> <br> `=round_dynamic(A1, 0.5)` | … nearest 50 million <br> <br> `=mround(A1, 50000000)` |
 | 90,000,000 | … current order of magnitude  <br> <br> `=round_dynamic(A1, 0)` | … nearest 10 million  <br> <br> `=round(A1, -7)` |
 | 85,000,000 | … half-step within the current order  <br> <br> `=round_dynamic(A1, -0.5)` | … nearest 5 million  <br> <br> `=mround(A1, 5000000)` |
 | 87,000,000 | … one order finer  <br> <br> `=round_dynamic(A1, -1)` | … nearest million  <br> <br> `=round(A1, -6)` |
+
+[^safety]: With offset `1.5`, the requested step is 500 million. Applied to 87,054,321 alone, that step would round all the way down to zero — which would hide the fact that the number is in the tens of millions. To prevent that, the result is never smaller than what `=round_dynamic(A1, 1)` produces, which is 100,000,000. The same safety net applies to any offset whose whole-number part is 1 or larger.
 
 
 Each setting emphasizes different relationships in the data.  The goal is not precision — it is interpretability.

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -2,6 +2,10 @@
 
 This extension allows users to apply the `ROUND_DYNAMIC` algorithm to arbitrary HTML tables on any website via a right-click context menu.
 
+## Offset semantics
+
+The extension uses the same offset model as the rest of the project. As of the `2026-05-28` release, the meaning of fractional offsets is sign-aware: `+0.5` rounds toward half of the next-larger order of magnitude, and `-0.5` rounds toward half of the current order. The result is also floored at the value's own order of magnitude so a large number can never collapse to zero. See the [root README](../README.md#declarating-a-lens) for the full parameter table and a worked example.
+
 ## Architecture Notes
 
 ### Safe DOM Text Replacement (The "Wikipedia Problem")

--- a/docs/sprint-logs/offset-semantics-v2-half-step-floor-docs.md
+++ b/docs/sprint-logs/offset-semantics-v2-half-step-floor-docs.md
@@ -1,0 +1,65 @@
+# Sprint Log: half-step-floor-docs
+
+**Date:** 2026-05-28
+**Branch:** `feature/half-step-floor-docs`
+**Plan:** `docs/sprint-plans/offset-semantics-v2.md`
+**Depends on (merged):** `half-step-floor-js` (#69), `half-step-floor-python` (#70), `half-step-floor-chrome` (#68)
+
+## Goal
+
+Update all user-facing documentation to reflect the new offset semantics shipped by the three implementation sprints — sign-aware fractional offsets (Feature 1), value-OoM floor (Feature 2), and the internal `X_FLOOR_THRESHOLD`-gated x-floor (Feature 3).
+
+## Per-file changes
+
+### `README.md` (root)
+
+- "Declarating a lens" parameter table: dropped the "imperative-vs-declarative" framing for the `+1.5 = 500M` row (the post-floor result is 100M, not 500M, so showing 500M would mis-document the function); added a `+0.5 → 100,000,000` row to make the new sign convention visible; updated the `=ROUND(87654321/...)` formula to use `A1` consistently.
+- Added a paragraph after the table explaining the sign convention for fractional offsets: `step = |frac(offset)| × 10^(OoM + ceil(offset))`.
+- Added a new "Floor at the value's order of magnitude" subsection with the `=round_dynamic(87054321, 2) → 10,000,000` example.
+- Added a "Backward compatibility" subsection flagging the break for callers that pass positive non-integer offsets, and reassuring default-path callers that nothing changes.
+
+### `js/README.md`
+
+- Replaced the Offset Reference table's `+0.5` reference and removed the now-incorrect note "Values between -1 and 1 with the same absolute value produce the same result". Added a `0.5 → 100,000,000` row.
+- Added the sign-convention and value-OoM-floor explanations beneath the table.
+
+### `js/CHANGELOG.md`
+
+- Added `## [0.3.0] - 2026-05-28` section above `[0.2.5]` with `### Changed` (Feature 1, marked Breaking), `### Added` (Feature 2 + Feature 3), and `### Internal` (note on `X_FLOOR_THRESHOLD`). Did not document the threshold in user-facing prose per plan §5 dev notes.
+
+### `js/tests-googlesheets-tab.md`
+
+- Row 10 (`87654321, -1.5`): updated expected from `87,500,000` to `88,000,000`. The new Feature 3 floor (`rd(87654321, -1) = 88,000,000`) raises the result above the bare half-step value of `87,500,000`.
+- All other cells use `(default)` (`-0.5`), integer offsets, or values whose result is unaffected — verified via direct evaluation of `roundWithOffset` against the new `js/round_dynamic.js`.
+
+### `chrome-extension/README.md`
+
+- Added a short "Offset semantics" section noting the new sign-aware fractional offsets + value-OoM floor and linking back to the root README for the full parameter table.
+
+### `python/dynamic_rounding/__init__.py`
+
+- Rewrote the `_round_with_offset` docstring: replaced the stale `0.5 = half of current OoM (same as -0.5)` line with a sign-aware breakdown of `-0.5 / +0.5 / -1.5 / +1.5` against the `87M` reference value, and clarified the Feature 3 floor language ("a fractional offset never rounds finer than the corresponding integer offset would").
+- Did not change the `round_dynamic` Examples block (all four `>>>` examples — `87654321`, `87654321 offset=-1`, the dataset, and `"hello"` — were re-verified to produce exactly the documented output under the new implementation).
+
+### `python/README.md`
+
+- Offset Reference table: added a `0.5 → 100,000,000` row and rewrote the `-0.5` row label ("half-step within the current OoM (default)").
+- Added the sign-convention and value-OoM-floor notes beneath the table.
+
+## Documented-value surprises
+
+- **Root README `+1.5` would have been wrong.** I initially drafted a row showing `=round_dynamic(A1, 1.5) → 500,000,000` (the bare half-step). Verification against `roundWithOffset(87054321, 1.5)` returned `100,000,000` because Feature 3 floors the result at `rd(87054321, 1) = 100M`. Dropped the row rather than ship a misleading marketing table.
+- **`js/tests-googlesheets-tab.md` row 10** had to move from `87,500,000` to `88,000,000` for the same Feature 3 reason (the only cell in the file that needed updating).
+
+## Verification
+
+- Every parameter-table cell in root README, `js/README.md`, `python/README.md`, and `python/dynamic_rounding/__init__.py` was checked by directly calling `roundWithOffset` / `round_dynamic` on the documented input and comparing the actual output.
+- `node js/tests.js` → 158/0.
+- `node chrome-extension/tests.js` → 488/0.
+- `python -m pytest python/tests` → 92 passed, 1 skipped.
+- "Adaptive precision" example in root README (`(-0.5, 0)`) re-verified to produce its existing documented column unchanged.
+
+## Out of scope (per plan)
+
+- No `python/pyproject.toml` or `chrome-extension/manifest.json` edits — version bumps are handled by the post-merge CI and the manual major-bump retag described in plan §3.4 / Open Question #1.
+- `X_FLOOR_THRESHOLD` is not documented in any user-facing prose (only mentioned in the `js/CHANGELOG.md` `### Internal` block), per plan §5 dev notes.

--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -10,6 +10,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Docs:** Added `## Note: decimal precision in Sheets` section to README explaining that `ROUND_DYNAMIC` (as a custom function) cannot set cell number formats directly. Includes guidance on manually applying a custom number format to match the offset's decimal count, with examples for offsets 0.5 and 0.25.
 
+## [0.3.0] - 2026-05-28
+
+### Changed
+
+- **Breaking:** Redefined the meaning of fractional offsets (`+0.5`, `+0.25`, `+1.5`, etc.) so that the sign of the offset determines whether the half/quarter step sits above or below the current order of magnitude. Previously `+0.5` and `-0.5` produced identical results (a latent bug); now `+0.5` rounds toward one-OoM-larger steps and `-0.5` rounds toward current-OoM steps. The default offset (`-0.5`) is bytewise-unchanged, so callers on the default path are unaffected.
+
+### Added
+
+- **Feature 2:** Value-OoM floor. After rounding, the magnitude of the result is at least `10^floor(log10(|value|))` — i.e. a tens-of-millions value can never collapse to 0. Prevents the "small number simplifies to a bigger value than a bigger number" inversion that motivated this release.
+- **Feature 3:** "No-coarser-than-x" floor for fractional offsets with `|trunc(offset)| >= 1`. The floor is gated by an internal `X_FLOOR_THRESHOLD` constant (default `1`), not exposed on the public signature.
+
+### Internal
+
+- `X_FLOOR_THRESHOLD` is a module-level constant in `js/round_dynamic.js`. Tests exercise the alternate value by re-evaluating the source in a sandbox.
+
 ## [0.2.5] - 2026-04-24
 
 ### Changed

--- a/js/README.md
+++ b/js/README.md
@@ -65,12 +65,15 @@ Offset is an order-of-magnitude adjustment. Negative = finer precision, positive
 | Offset | Meaning | 87,054,321 rounds to |
 |--------|---------|----------------------|
 | 1 | one OoM coarser | 100,000,000 |
+| 0.5 | half-step toward the next-larger OoM | 100,000,000 |
 | 0 | current OoM | 90,000,000 |
-| -0.5 | half of current OoM | 85,000,000 |
+| -0.5 | half-step within the current OoM (default) | 85,000,000 |
 | -1 | one OoM finer | 87,000,000 |
-| -1.5 | half of one OoM finer | 87,000,000 |
+| -1.5 | half-step within one OoM finer | 87,000,000 |
 
-**Note:** Values between -1 and 1 with the same absolute value produce the same result (e.g., 0.5 and -0.5).
+**Sign convention for fractional offsets:** The sign of the offset chooses the direction of the half-step. `+0.5` rounds to half of the *next-larger* OoM, `-0.5` to half of the *current* OoM. More generally, the step is `|frac(offset)| × 10^(OoM + ceil(offset))`.
+
+**Floor at the value's OoM:** After rounding, the magnitude of the result is at least `10^floor(log10(|value|))`. A tens-of-millions value can never collapse to `0`, regardless of the requested offset.
 
 **Limits:** Offset must be between -20 and 20.
 

--- a/js/tests-googlesheets-tab.md
+++ b/js/tests-googlesheets-tab.md
@@ -9,7 +9,7 @@
 | \=IF(E7=F7, "✓", "✗") | 86543210 | (default) | `=FORMULATEXT(E7)` | `=ROUND_DYNAMIC(B7)` | 85,000,000 |  |  |
 | \=IF(E8=F8, "✓", "✗") | 87654321 | 0 | `=FORMULATEXT(E8)` | `=ROUND_DYNAMIC(B8, C8)` | 90,000,000 |  |  |
 | \=IF(E9=F9, "✓", "✗") | 87654321 | \-1 | `=FORMULATEXT(E9)` | `=ROUND_DYNAMIC(B9, C9)` | 88,000,000 |  |  |
-| \=IF(E10=F10, "✓", "✗") | 87654321 | \-1.5 | `=FORMULATEXT(E10)` | `=ROUND_DYNAMIC(B10, C10)` | 87,500,000 |  |  |
+| \=IF(E10=F10, "✓", "✗") | 87654321 | \-1.5 | `=FORMULATEXT(E10)` | `=ROUND_DYNAMIC(B10, C10)` | 88,000,000 |  |  |
 | \=IF(E11=F11, "✓", "✗") | 87654321 | 1 | `=FORMULATEXT(E11)` | `=ROUND_DYNAMIC(B11, C11)` | 100,000,000 |  |  |
 | \=IF(E12=F12, "✓", "✗") | \-4321 | (default) | `=FORMULATEXT(E12)` | `=ROUND_DYNAMIC(B12)` | \-4,500 |  |  |
 | \=IF(E13=F13, "✓", "✗") | 0.033 | (default) | `=FORMULATEXT(E13)` | `=ROUND_DYNAMIC(B13)` | 0.035 |  |  |

--- a/python/README.md
+++ b/python/README.md
@@ -88,10 +88,15 @@ Same parameters as `round_dynamic`, but operates on a pandas Series.
 | Offset | Meaning | 87,054,321 rounds to |
 |--------|---------|----------------------|
 | 1 | one OoM coarser | 100,000,000 |
+| 0.5 | half-step toward the next-larger OoM | 100,000,000 |
 | 0 | current OoM | 90,000,000 |
-| -0.5 | half of current OoM (default) | 85,000,000 |
+| -0.5 | half-step within the current OoM (default) | 85,000,000 |
 | -1 | one OoM finer | 87,000,000 |
-| -1.5 | half of one OoM finer | 87,000,000 |
+| -1.5 | half-step within one OoM finer | 87,000,000 |
+
+**Sign convention for fractional offsets:** The sign of the offset chooses the direction of the half-step. `+0.5` rounds to half of the *next-larger* OoM, `-0.5` to half of the *current* OoM. More generally, the step is `|frac(offset)| * 10 ** (OoM + ceil(offset))`.
+
+**Floor at the value's OoM:** After rounding, the magnitude of the result is at least `10 ** floor(log10(abs(value)))` — so a tens-of-millions value can never collapse to `0`.
 
 ## Development
 

--- a/python/dynamic_rounding/__init__.py
+++ b/python/dynamic_rounding/__init__.py
@@ -148,20 +148,25 @@ def _round_with_offset(value: float, offset: float) -> float:
     """
     Round a number using the offset model.
 
-    offset = OoM offset + optional fraction
-        0 = current OoM
-        -1 = one OoM finer
-        1 = one OoM coarser
-        0.5 = half of current OoM (same as -0.5)
-        -1.5 = half of one OoM finer
+    Integer offsets:
+        0  -> current OoM
+        -1 -> one OoM finer
+        1  -> one OoM coarser
+
+    Fractional offsets are sign-aware. The step is
+    ``|frac(offset)| * 10 ** (current_mag + ceil(offset))``, so:
+        -0.5 -> half-step within the current OoM    (e.g. 87M -> 85M)
+        +0.5 -> half-step toward the next-larger OoM (e.g. 87M -> 100M)
+        -1.5 -> half-step within one OoM finer       (e.g. 87M -> 87M)
+        +1.5 -> half-step toward two OoMs larger     (e.g. 87M -> 100M after floor)
 
     Sign-aware: rounding is performed on the absolute value, then the sign is
     re-applied. A value-OoM floor prevents results from dropping below the
     current order of magnitude, so a positive input never rounds toward zero
-    past its own OoM. For half-steps with a large integer offset component
-    (|trunc(offset)| >= X_FLOOR_THRESHOLD), an additional x-floor is applied
-    so that a half-step never rounds finer than the corresponding integer
-    offset would.
+    past its own OoM. For fractional offsets with a large integer component
+    (``|trunc(offset)| >= X_FLOOR_THRESHOLD``), an additional x-floor is
+    applied so that a fractional offset never rounds finer than the
+    corresponding integer offset would.
     """
     if value == 0:
         return 0


### PR DESCRIPTION
Implements sprint half-step-floor-docs from docs/sprint-plans/offset-semantics-v2.md.

Log at docs/sprint-logs/offset-semantics-v2-half-step-floor-docs.md.