### PR TITLE
plan: toggle-positioning (+ skill and README updates)

### DIFF
--- a/.agent/skills/sprint-plan/SKILL.md
+++ b/.agent/skills/sprint-plan/SKILL.md
@@ -72,6 +72,7 @@ Apply these principles when proposing or defending design and process choices. C
 - **Trunk-Based Development** — small, incremental commits to `main` or short-lived feature branches merged frequently. The sprint-stack model is built around this: every sprint is a small short-lived feature branch, merged on its own merits, with no long-running parallel branches accumulating drift.
 - **Pre-merge Testing** — all validation (tests, linters, security scans) must pass before a commit is merged. Sprint-stack's reviewer subagent and the repo's CI together enforce this for every sprint PR.
 - **Squash and Merge** — squash branch commits so each merge brings in exactly one functional, test-passing set of changes. Aligns with the sprint-stack pattern where each sprint contributes one logical unit to main.
+- **Named constants over magic numbers** — when a sprint introduces a numeric or string literal that has a meaning beyond its raw value, define it once as a named constant and reuse the name everywhere it applies. Before adding a new literal, check whether an existing constant in the touched files already means the same thing and reuse it. A literal that appears in only one place can stay literal; the rule kicks in when the same value carries meaning across multiple call sites, or when a future sprint is likely to need it.
 
 If the repo has detectable patterns, align with them. If not, propose, with reasoning.
 
@@ -130,6 +131,8 @@ Per sprint, in the markdown structure shown below. The execution skill parses th
 - **Complexity:** S | M | L
 - **Dev notes:** <pitfalls, patterns to follow, libraries to use>
 ```
+
+When a sprint introduces a new named constant or consolidates an existing literal, list the constant(s) and their home file in **Dev notes**. No need to inventory every call site — the executing sprint will find them. Example: `TOGGLE_WIDTH_PX`, `TOGGLE_HEIGHT_PX`, `TOGGLE_EDGE_GAP_PX` in `chrome-extension/content.js`.
 
 Sprint commits do not touch version files. Versioning is handled at merge time by the GitHub Action probed for in Phase 2.
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,43 @@
-# Dynamic Rounding
+# Make data readable
 
-Numbers can tell a story. But *too many* numbers make the story hard to see.
+Data can tell rich stories, but too much detail can make it hard to see the patterns.   
 
-For example, this monthly revenue tells a clear pattern:
-
+For example:
 > Jan-Dec:  $31,311.28, $38,080.94, $45,291.38, $45,090.27, $47,709.54, $41,400.09, $24,923.26, $25,303.28, $41,200.80, $43,098.42, $42,210.11, $32,892.62
 
-But the pattern is buried inside the numbers.  Somewhat paradoxically, getting rid of the numbers makes the story leap out: this is a cyclical business tied to the academic calendar, with revenue dropping during summer and winter breaks.
+Removing the precise values helps the pattern jump out:
 
 <p align="center">
  <img src="docs/media/revenue_chart1.png" alt="chart showing revenue" width="400">
+ <br>
+  <sup> Revenue drops during summer and winter breaks (pattern) - a business cycle tied to the academic calendar (meaning). </sup>
 </p>
 
-We are curious creatures. Our minds constantly look for connections, and seek meaning in patterns.  We do this unconsciously — no graphing tools or BI tools required. But when data gets too detailed, our brains start simplifying it, searching for the structure; and through the structure, the message.
+Our brains unconsciously look for structure and trends, then interpret them for meaning.
 
-For example, this population table is structured around ranked size,: 'Dallas/Fort Worth is roughly the size of Chicago or Houston ... should probably rank #5.'
-
+Consider these presentations:
 
 <p align="center">
  <img src="docs/media/wikipedia_population.png" alt="chart showing revenue" width = "600">
  <br>
-  <sup> Which presentation makes the story easier to see?</sup>
+  <sup> A message: Dallas/Fort Worth is about the size of Chicago or Houston ... visually, it belongs with the largest metropolitan areas in the top-5.</sup>
 </p>
 
-Our *eyes* get the image on the left but our *brains* see the one on the right; this library works accelerates that natural process.
+Our eyes receive the image on the left, but our brains see the one on the right. This library makes data more readable by accelerating the way people naturally recognize patterns and extract meaning.
 
-Computers are great at giving us hyper-accurate data - but that works against us; this library works with us.
-
-There are many ways to making data interpretable, and they sometimes require time and  technical skill. This introduces a more natural approach: **declarative simplification**.  
 
 ## Implementations
 
 | Platform | Location | Install |
 | :---- | :---- | :---- |
-| Chrome Extension | [chrome-extension/](https://www.google.com/search?q=./chrome-extension/) | [Load unpacked](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) |
 | Google Sheets | [js/](https://www.google.com/search?q=./js/) | [Copy template](https://docs.google.com/spreadsheets/d/1GdHvYk3dVzJErrGH7yDULW6srM0gaHeYMGMn3k0-GY4) |
 | Python | [python/](https://www.google.com/search?q=./python/) | pip install dynamic-rounding |
+| Chrome Extension | [chrome-extension/](https://www.google.com/search?q=./chrome-extension/) | [Load unpacked](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) |
 
-## Examples
+## Quick Examples
 
-### Chrome Extension and Google Sheets plugin
-
-<video src="docs/media/dynamic_rounding_demo6.mov" width="100%" controls></video>
+### Chrome Extension
+![alt-text](docs//dynamic_rounding_Screen.gif)
 
 see [Chrome Extension README](chrome-extension/README.md)
 
@@ -64,16 +60,6 @@ see [Chrome Extension README](chrome-extension/README.md)
 
 --- 
 
-## Features
-
-1. **Declarative rounding**:  relative to magnitude  
-2. **Range operations**: preserves structures of arrays, lists, or grids  
-3. **Iteration**: use the relative rounding approach that is best for your data  
-4. **Adaptive precision**: Simplify smaller numbers more aggressively while preserving precision in larger ones.  
-5. **Robust**: passes through non-numerics, handles negatives and decimals, ignores non-numerics, tolerates different number formats
-
----
-
 ## Documentation
 
 * [Design Doc](https://www.google.com/search?q=./docs/design.md) — Algorithm and concepts  
@@ -84,109 +70,6 @@ see [Chrome Extension README](chrome-extension/README.md)
 ## License
 
 MIT
-
-
-<br><br><br><br>
-
-# Discussion 
-
-## Simplifying data: declarative  vs. imperative
-
-A traditional way to simplify data is to round it.
-
-Rounding is sometimes helpful but it's a blunt tool that can obscure the story as easily as reveal it.  Consider this before-and-after - the after is more clear but the story has been destroyed.
-
-| original value | \=ROUND(A2, \-6) |
-| :---- | :---- |
-| 7,514,321 | 8,000,000 |
-| 7,464,329 | 7,000,000 |
-| *difference* | *difference* |
-| **49,992** | **1,000,000** |
-
-*In the original table it was hard to read the story (that the comparison is nearly identical).  In the simplified table it's easy to read -- the wrong story (that the numbers are very far apart).* 
-
-This library is a way to reveal the story in data. e.g.
-
-| original value | `=round_dynamic(a2:a3)` |
-| :---- | :---- |
-| 7,514,321 | 7,500,000 |
-| 7,464,329 | 7,500,000 |
-| *difference* | *difference* |
-| **49,992** | **≈ 0** |
-
-*The simplified numbers tell the actual story: these two numbers really are 'about the same'.*
-
-## Choosing a lens
-
-Every dataset is different and a tool for simplifying it has to be flexible enough to look at it in different ways while hunting for the story in it.  The users of this library can dial the lens, ratcheting it up or down, by adjusting a single parameter.  This is the 'declarative' part of the library - the user declares a lens for the entire dataset, one parameter: an **offset** from the number's **order of magnitude**.
-
-### Declarating a lens
-
-Depending on the situation, a number like **87,054,321** may be interpreted differently: it could mean anything from 'unimportant' to 'unfathomably large'.  This library lets users step the lens up or down until the numbers say something meaningful.
-
-
-| lens (i.e. a simplified representation of the data) | Declarative lens: round this number to the… | Imperative command: round this number to the…  |
-| :---- | :---- | :---- |
-| 100,000,000 | … next larger order of magnitude <br> <br> `=round_dynamic(A1, 1)` | … nearest hundred million <br> <br> `=ROUND(A1 / 100000000, 0) * 100000000` |
-| 100,000,000 | … halfway between the next-larger and two-larger orders[^safety] <br> <br> `=round_dynamic(A1, 1.5)` | … nearest 500 million, with a 100-million safety net <br> <br> `=MAX(MROUND(A1, 500000000), MROUND(A1, 100000000))` |
-| 100,000,000 | … half-step toward the next-larger order <br> <br> `=round_dynamic(A1, 0.5)` | … nearest 50 million <br> <br> `=mround(A1, 50000000)` |
-| 90,000,000 | … current order of magnitude  <br> <br> `=round_dynamic(A1, 0)` | … nearest 10 million  <br> <br> `=round(A1, -7)` |
-| 85,000,000 | … half-step within the current order  <br> <br> `=round_dynamic(A1, -0.5)` | … nearest 5 million  <br> <br> `=mround(A1, 5000000)` |
-| 87,000,000 | … one order finer  <br> <br> `=round_dynamic(A1, -1)` | … nearest million  <br> <br> `=round(A1, -6)` |
-
-[^safety]: With offset `1.5`, the requested step is 500 million. Applied to 87,054,321 alone, that step would round all the way down to zero — which would hide the fact that the number is in the tens of millions. To prevent that, the result is never smaller than what `=round_dynamic(A1, 1)` produces, which is 100,000,000. The same safety net applies to any offset whose whole-number part is 1 or larger.
-
-
-Each setting emphasizes different relationships in the data.  The goal is not precision — it is interpretability.
-
-The sign of a fractional offset tells the function which way to step. A positive `+0.5` rounds to half of the **next-larger** order of magnitude; a negative `-0.5` rounds to half of the **current** order. This generalizes to any non-integer offset: the step size is `|frac(offset)| × 10^(OoM + ceil(offset))`.
-
-### Floor at the value's order of magnitude
-
-Rounding can never collapse a number below its own order of magnitude. For any value, the simplified result is guaranteed to have a magnitude of at least `10^floor(log10(|value|))`, with sign preserved.
-
-For example, `=round_dynamic(87054321, 2)` (asking to round to the nearest hundred million) returns **10,000,000**, not `0`. A tens-of-millions value never simplifies to zero, regardless of how aggressive the requested offset is. This keeps ordering intuitive when a dataset spans many magnitudes.
-
-### Backward compatibility
-
-The default offset (`-0.5`) is unchanged: every call that relies on the default — single mode or dataset mode — produces the exact same value it did before. Callers that explicitly pass a *positive* non-integer offset (`+0.5`, `+0.25`, `+1.5`, etc.) will see different values than in earlier versions: positive fractional offsets previously produced the same result as their negative counterparts (a latent bug), and now correctly step toward the next-larger order of magnitude.
-
-
-## Simplifying ranges
-
-The declarative nature makes simplifying data less fiddly.  But it starts to shine when used to simplify entire ranges of data in one step.
-
-| original matrix |  |      | \=ROUND\_DYNAMIC(A2:B9) |  |
-| --- | --- | --- | --- | --- |
-| col 1 | col2 |    --->    | col 1 | col2 |
-| 87,054,321 | 129,972,101 |  | 85,000,000 | 150,000,000 |
-| 84,654,321 | 126,388,901 |  | 85,000,000 | 150,000,000 |
-| 22,484.49 | 33,569.34 |  | 20,000 | 35,000 |
-| 2,484.49 | 3,709.34 |  | 2,500 | 3,500 |
-| \-22,484.72 | \-33,569.69 |  | \-20,000 | \-35,000 |
-| 36.10% | 53.90% |  | 35% | 55% |
-| \-2.80% | \-4.18% |  | \-3% | \-4% |
-
-
-## Adaptive precision
-
-Smaller values can be simplified more aggressively without affecting the overall structure of the data.
-
-In this example, the largest values are rounded to the nearest half order of magnitude `(0.5)`, while smaller values are rounded more.
-
-
-| original value | `=round_dynamic(A1:A7, -0.5, 0)` | notes |
-| :---- | :---- | :---- |
-| 87,054,321 | 85,000,000 | In this data, the largest numbers are ‘tens of millions’.  They get simplified by being rounded to the nearest ***half*** order of magnitude.  <br><br> This lighter touch preserves more fidelity to the original value. |
-| 84,654,321 | 85,000,000 |  |
-| 23,484.49 | 20,000 | Any number smaller than ‘tens of millions’ are simplified by being to the full order of magnitude. <br><br> In this case the number is ‘tens of thousands’ and it gets rounded to the nearest ten thousand. <br><br> More aggressive rounding of smaller numbers improves readability (signal) while minimizing impact on the fidelity of the dataset as a whole. |
-| \-23,484.72 | \-20,000 |  |
-| 2,484.49 | 2,000 | number in the thousands → nearest thousand |
-| 36% | 40% | a decimal (0.36) in ‘tenths’ → nearest ten percent |
-| \-2.8% | \-3% |  |
-
-This balance preserves structure in large numbers while improving overall readability, especially in larger and more complicated datasets.
-
 
 
 <br><br><br><br>

--- a/docs/sprint-plans/toggle-positioning.md
+++ b/docs/sprint-plans/toggle-positioning.md
@@ -53,7 +53,23 @@ const top = rect.top + scrollY - TOGGLE_HEIGHT_PX - TOGGLE_EDGE_GAP_PX;
 
 *Principle: simple components — one-line geometric correction in the existing helper, no new abstractions, no new DOM.*
 
-### 3.3 Named constants over magic numbers
+### 3.3 Tradeoff: best-efforts, not a guarantee
+
+Shifting the toggle up trades one failure mode (overlapping row 1) for several others — overlapping content immediately above the table, floating outside a containing card or dialog, disappearing under a sticky page header, or rendering off-screen if the table's top is at the viewport edge. None of these can be fully avoided by a fixed upward shift, since the extension has no model of the host page's layout.
+
+**Decision (per user direction):** accept this as a best-efforts fix. Some overlap is preferable to introducing host-page DOM mutations (e.g. right-padding row 1) or runtime heuristics (e.g. conditional shifting based on detected whitespace), both of which would create ongoing technical debt without eliminating the underlying risk.
+
+Apply one minimal defensive guard: clamp `top` so the toggle is never rendered above the current scroll position. This is a single `Math.max` with no new branches, no DOM changes, and no heuristics — it only kicks in at the viewport edge:
+
+```js
+const top = Math.max(scrollY, rect.top + scrollY - TOGGLE_HEIGHT_PX - TOGGLE_EDGE_GAP_PX);
+```
+
+Other risks (collisions with content above the table, container clipping, sticky-header coverage) are accepted as-is.
+
+*Principle: minimize design-time coupling — the fix touches only the extension's own positioning math; host-page DOM and CSS are not modified.*
+
+### 3.4 Named constants over magic numbers
 
 The current code embeds `36`, `20`, `14`, `3`, and `2` as bare literals across both `positionToggle` (JS) and `ensureToggleStyleInjected` (CSS template string). These values carry semantic meaning (toggle width, toggle height, knob diameter, knob inset, edge gap) and are used in multiple call sites — the CSS template and the JS positioning math must stay in lockstep, since the JS subtracts the toggle's width and height to align it with the table edge.
 
@@ -90,11 +106,12 @@ flowchart TD
 
 ### fix-toggle-overlap
 
-- **Goal:** Stop the per-table toggle from overlapping the first row of its table by positioning it fully above the table edge, and consolidate the toggle's geometry into named constants.
-- **Scope:** `chrome-extension/content.js` only. Update `positionToggle` to subtract `TOGGLE_HEIGHT_PX + TOGGLE_EDGE_GAP_PX` when computing `top`. Define the constants listed in §3.3 at module scope. Replace the literal occurrences of `36`, `20`, `14`, `3`, and `2` in `positionToggle` and the CSS template in `ensureToggleStyleInjected` with the named constants (using template-string interpolation for the CSS).
-- **Out of scope:** Any visual restyling beyond the vertical shift. Toggle behavior, accessibility wiring, host-page click suppression, the `MutationObserver` / `ResizeObserver` plumbing — all unchanged. `manifest.json` version bump (handled at merge by the workflow).
+- **Goal:** Stop the per-table toggle from overlapping the first row of its table by positioning it above the table edge (best-efforts, with a clamp to keep it on-screen), and consolidate the toggle's geometry into named constants.
+- **Scope:** `chrome-extension/content.js` only. Update `positionToggle` to compute `top` as `Math.max(scrollY, rect.top + scrollY - TOGGLE_HEIGHT_PX - TOGGLE_EDGE_GAP_PX)`. Define the constants listed in §3.4 at module scope. Replace the literal occurrences of `36`, `20`, `14`, `3`, and `2` in `positionToggle` and the CSS template in `ensureToggleStyleInjected` with the named constants (using template-string interpolation for the CSS).
+- **Out of scope:** Any visual restyling beyond the vertical shift. Mitigations for the residual risks listed in §3.3 (overlap with content above the table, container clipping, sticky-header coverage) — explicitly accepted as best-efforts. Toggle behavior, accessibility wiring, host-page click suppression, the `MutationObserver` / `ResizeObserver` plumbing — all unchanged. `manifest.json` version bump (handled at merge by the workflow).
 - **Acceptance criteria:**
-  - The toggle's bottom edge sits `TOGGLE_EDGE_GAP_PX` above the table's top edge. No part of the toggle overlaps row 1.
+  - When the table's top is below the current scroll position, the toggle's bottom edge sits `TOGGLE_EDGE_GAP_PX` above the table's top edge and no part of the toggle overlaps row 1.
+  - When the table's top is at or above the current scroll position, the toggle is clamped to the top of the viewport rather than rendered off-screen.
   - The toggle's horizontal position is unchanged (still anchored to the table's right edge with the existing 2px overhang).
   - `node chrome-extension/tests.js` passes.
   - Manual: load the unpacked extension, open the Word Count dialog in Google Docs, confirm the numbers in column 2 are no longer obscured.

--- a/docs/sprint-plans/toggle-positioning.md
+++ b/docs/sprint-plans/toggle-positioning.md
@@ -1,0 +1,116 @@
+# Sprint Plan: Toggle Positioning Fix
+
+**Created:** 2026-06-01
+**Base branch:** main
+**Slug:** toggle-positioning
+
+## 1. Repo Survey
+
+Monorepo with three implementations of Dynamic Rounding (`js/`, `python/`, `chrome-extension/`). This plan targets `chrome-extension/` only.
+
+The per-table toggle switch was added by the `auto-table-toggle` sprint (see `docs/sprint-plans/auto-table-toggle.md`). It is created in `chrome-extension/content.js` and positioned as an absolutely-positioned `<label>` appended to `document.body`, aligned to each tracked table's `getBoundingClientRect()`.
+
+Relevant code:
+
+- `positionToggle(table, labelEl)` — `content.js:203-222`. Computes the toggle's `left` and `top` from the table rect; the current expression hard-codes `36`, `2`, and `-2`.
+- `ensureToggleStyleInjected()` — `content.js:151-201`. Injects the toggle CSS. `width: 36px; height: 20px;` for `.dr-ext-toggle`, plus a 14px slider knob with 3px inset.
+
+No bundler, no framework, vanilla JS only.
+
+## 2. Repo Conventions
+
+- **Version files:**
+  - `chrome-extension/manifest.json` — `version` key, 1-4 dot-separated integers.
+  - `python/pyproject.toml` — semver in `version =` line.
+  - `js/CHANGELOG.md` — informational only.
+- **Test command:** `node chrome-extension/tests.js`
+- **Lint / Format / Build:** none configured.
+- **Branch naming:** `fix/<label>` for bug fixes (per `CLAUDE.md`); never `claude/`.
+- **Commit convention:** plain prefixed (`fix: …`, `chore: …`, `Sprint <label>: …` for sprint-stack commits).
+- **PR template:** none.
+- **Version-bump workflow:** detected at `.github/workflows/bump-version.yml` — triggers on `pull_request: types: [closed]` with `if: github.event.pull_request.merged == true`, bumps `chrome-extension/manifest.json` patch when files under `chrome-extension/**` change. Sprint commits in this plan do **not** modify `manifest.json`.
+
+## 3. Design
+
+### 3.1 The bug
+
+In `positionToggle` (`content.js:217-221`):
+
+```js
+const left = rect.right + scrollX - 36 + 2;
+const top  = rect.top   + scrollY - 2;
+```
+
+The toggle is 20px tall. `top = rect.top - 2` puts only 2px of the toggle above the table; the remaining 18px overlays the first row, which obscures right-aligned content in the first row (e.g. the "214" word count in the Google Docs Word Count dialog, which is rendered as a table).
+
+### 3.2 Fix
+
+Shift the toggle up by its own height so it sits fully above the table, leaving the existing 2px gap between the toggle's bottom and the table's top edge.
+
+```js
+const top = rect.top + scrollY - TOGGLE_HEIGHT_PX - TOGGLE_EDGE_GAP_PX;
+```
+
+*Principle: simple components — one-line geometric correction in the existing helper, no new abstractions, no new DOM.*
+
+### 3.3 Named constants over magic numbers
+
+The current code embeds `36`, `20`, `14`, `3`, and `2` as bare literals across both `positionToggle` (JS) and `ensureToggleStyleInjected` (CSS template string). These values carry semantic meaning (toggle width, toggle height, knob diameter, knob inset, edge gap) and are used in multiple call sites — the CSS template and the JS positioning math must stay in lockstep, since the JS subtracts the toggle's width and height to align it with the table edge.
+
+**Decision:** introduce module-level constants at the top of `content.js`, used by both the CSS template (via string interpolation) and the positioning math:
+
+- `TOGGLE_WIDTH_PX = 36`
+- `TOGGLE_HEIGHT_PX = 20`
+- `TOGGLE_KNOB_PX = 14`
+- `TOGGLE_KNOB_INSET_PX = 3`
+- `TOGGLE_EDGE_GAP_PX = 2`
+
+The knob's `translateX(16px)` when checked is `TOGGLE_WIDTH_PX - TOGGLE_KNOB_PX - 2 * TOGGLE_KNOB_INSET_PX` — express it that way so resizing the toggle doesn't desync the knob travel.
+
+*Principle: named constants over magic numbers — the values appear in both the JS positioning math and the CSS template, so the constant defines the single source of truth and the geometry stays consistent if the toggle is later resized.*
+
+*Alternative considered:* CSS custom properties (`--dr-toggle-width`) read via `getComputedStyle`. Rejected — adds a runtime read on the hot positioning path with no real benefit; module-level JS constants are interpolated once into the CSS template and reused directly.
+
+## 4. Sprint List & Dependency Graph
+
+### Sprint List
+
+1. **fix-toggle-overlap** — Shift the per-table toggle fully above the table and replace toggle-geometry magic numbers with named constants. Depends on: none.
+
+### Dependency Graph
+
+```mermaid
+flowchart TD
+    base[main]
+    s1["fix-toggle-overlap<br/>Position toggle above the table; extract geometry constants"]
+    base --> s1
+```
+
+## 5. Sprint Definitions
+
+### fix-toggle-overlap
+
+- **Goal:** Stop the per-table toggle from overlapping the first row of its table by positioning it fully above the table edge, and consolidate the toggle's geometry into named constants.
+- **Scope:** `chrome-extension/content.js` only. Update `positionToggle` to subtract `TOGGLE_HEIGHT_PX + TOGGLE_EDGE_GAP_PX` when computing `top`. Define the constants listed in §3.3 at module scope. Replace the literal occurrences of `36`, `20`, `14`, `3`, and `2` in `positionToggle` and the CSS template in `ensureToggleStyleInjected` with the named constants (using template-string interpolation for the CSS).
+- **Out of scope:** Any visual restyling beyond the vertical shift. Toggle behavior, accessibility wiring, host-page click suppression, the `MutationObserver` / `ResizeObserver` plumbing — all unchanged. `manifest.json` version bump (handled at merge by the workflow).
+- **Acceptance criteria:**
+  - The toggle's bottom edge sits `TOGGLE_EDGE_GAP_PX` above the table's top edge. No part of the toggle overlaps row 1.
+  - The toggle's horizontal position is unchanged (still anchored to the table's right edge with the existing 2px overhang).
+  - `node chrome-extension/tests.js` passes.
+  - Manual: load the unpacked extension, open the Word Count dialog in Google Docs, confirm the numbers in column 2 are no longer obscured.
+  - Manual: visit any host page with multiple data tables; confirm toggles still appear in the correct place and the knob still travels the full width when toggled.
+- **Depends on:** none
+- **Complexity:** S
+- **Dev notes:** New named constants `TOGGLE_WIDTH_PX`, `TOGGLE_HEIGHT_PX`, `TOGGLE_KNOB_PX`, `TOGGLE_KNOB_INSET_PX`, `TOGGLE_EDGE_GAP_PX` defined at module scope in `chrome-extension/content.js`. The CSS in `ensureToggleStyleInjected` must be converted from a static template literal to one that interpolates the constants; the knob's checked-state `translateX` is derived as `TOGGLE_WIDTH_PX - TOGGLE_KNOB_PX - 2 * TOGGLE_KNOB_INSET_PX` rather than hard-coded `16px`.
+
+## 6. Open Questions
+
+None.
+
+## 7. Out of Scope (Separate Sprint-Stack)
+
+None.
+
+## Decisions Log
+
+- 2026-06-01: Initial draft generated by sprint-plan skill.


### PR DESCRIPTION
## Summary

- **`plan/toggle-positioning`**: sprint plan to fix the per-table toggle overlapping row 1 of its table 
- Shifts the toggle above the table by `TOGGLE_HEIGHT_PX + TOGGLE_EDGE_GAP_PX`, clamps `top` to `scrollY` so it never goes off-screen, and consolidates toggle geometry literals (`36`, `20`, `14`, `3`, `2`) into named constants in `chrome-extension/content.js`. 
- Accepted as a best-efforts fix: prefer a fix that works most of the time rather than a strong intervention which creates more technical debt and requires further work.
- **`chore`**: adds a "Named constants over magic numbers" delivery principle to `.agent/skills/sprint-plan/SKILL.md`, plus a short Dev-notes guidance line for sprints that introduce or consolidate constants.
- **`docs`**: rewrites the README intro around pattern recognition.

## Test plan

- [ ] Review the sprint plan at `docs/sprint-plans/toggle-positioning.md`.
- [ ] Confirm the SKILL.md addition reads correctly in context.
- [ ] Confirm the README intro renders correctly on GitHub.
- [ ] Merge → then run `/sprint-stack toggle-positioning` to execute the fix.