### PR TITLE
plan: expanding-toggle (replaces the per-table pill switch with a 10×10 dot that expands on hover/tap)

### DIFF
--- a/.agent/skills/sprint-stack/SKILL.md
+++ b/.agent/skills/sprint-stack/SKILL.md
@@ -80,7 +80,7 @@ Inputs:
 - `git diff <parent>..HEAD`
 - The Design section from the plan
 
-Instruction: implement per scope, stay out of `out_of_scope`, run lint/format if specified, commit per the commit convention. **Do not write tests** — that's the next subagent's job. **Do not modify version files.**
+Instruction: implement per scope, stay out of `out_of_scope`, run lint/format if specified, commit per the commit convention. **Do not write tests** — that's the next subagent's job. **Do not modify version files.** Prefer named constants over inline literals for any value carrying semantic meaning, consistent with the sprint-plan "Named constants over magic numbers" principle, even when the plan's Dev notes do not call this out explicitly.
 
 ### 3. Test-writer subagent (Sonnet) — adversarial
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,5 @@ When the user has provided a PAT in the session, use it directly via the GitHub 
 When no PAT is available, MCP is the only path; try it then, and if it 403s, ask the user for a PAT.
 
 The PAT lives in session memory only — never write it to `.git/config`, `~/.git-credentials`, commit messages, or any tracked file.
+
+**Common leak path:** `git push -u <PAT-URL> <branch>` sets the PAT-bearing URL as the branch's upstream and stores it in `.git/config`. Never use `-u` with an authenticated URL. If pushing for the first time on a branch, either: (a) push without `-u`, or (b) run `git remote set-url origin <https-url-without-PAT>` first and then `git push -u origin <branch>`. After any push using an authenticated URL, run `grep -c x-access-token .git/config` — it must return `0`. If non-zero, `git branch --unset-upstream <branch>` and re-check.

--- a/docs/sprint-plans/expanding-toggle.md
+++ b/docs/sprint-plans/expanding-toggle.md
@@ -1,0 +1,183 @@
+# Sprint Plan: Expanding Toggle
+
+**Created:** 2026-06-01
+**Base branch:** main
+**Slug:** expanding-toggle
+
+## 1. Repo Survey
+
+Monorepo with three implementations of Dynamic Rounding (`js/`, `python/`, `chrome-extension/`). This plan targets `chrome-extension/` only; nothing in `js/`, `python/`, `docs/design.md`, or the Python/Sheets test harnesses is in scope.
+
+The per-table toggle switch was introduced by the `auto-table-toggle` sprint and currently lives in `chrome-extension/content.js`:
+
+- `ensureToggleStyleInjected()` (`content.js:152-201`) injects the CSS for `.dr-ext-toggle` (36×20 pill switch with 14×14 knob).
+- `createToggleForTable(table)` (`content.js:244-291`) builds the DOM as `<label class="dr-ext-toggle"><input type=checkbox><span class="dr-ext-toggle-slider"></span></label>`, appends it to `document.body`, wires a `change` listener that calls `runToggleAction(table)`, attaches a `ResizeObserver` to the table, and registers the input in the `tableToggles` `WeakMap`.
+- `positionToggle(table, labelEl)` (`content.js:203-222`) anchors the toggle to the table's top-right corner using `rect.right - 36 + 2` / `rect.top - 2` (the literal `36/20/14/3/2/16` values are hard-coded across the CSS template and the positioning math).
+- `syncSwitchForTable(table)` (`content.js:144-149`) sets `input.checked = isTableRounded(table)`.
+- `runToggleAction(table)` is the user-visible action: round if not rounded, restore originals if rounded.
+
+This sprint replaces the 36×20 pill switch with an **expanding control** designed and prototyped interactively in `docs/toggle-choices.html` (card #7). At rest the visible part is a 10×10 dot; on hover (mouse) or tap (touch) it expands to a 28×16 compact switch with a sliding knob. The hit area is centered on the dot with 7px of transparent padding on every side, giving a 24×24 minimum tap target without enlarging the visible footprint.
+
+`docs/toggle-choices.html` (added on this plan branch) is the canonical visual spec — the implementing sprint should refer to it for exact CSS values, geometry, and interaction nuances.
+
+Languages: vanilla JS, no bundler, no framework. CSS is injected via `<style>` tags from JS.
+
+## 2. Repo Conventions
+
+- **Version files:**
+  - `chrome-extension/manifest.json` — `version` key, 1-4 dot-separated integers (currently `2.0.0`).
+  - `python/pyproject.toml` — semver in `version =` line.
+  - `js/CHANGELOG.md` — informational only.
+- **Test command:** `node chrome-extension/tests.js`
+- **Lint / Format / Build:** none configured.
+- **Branch naming:** `fix/<label>` for bug fixes, `feature/<label>` for new behavior, `refactor/<label>` for restructuring, per `CLAUDE.md`. Never `claude/`.
+- **Commit convention:** `Sprint <label>: <subject>` for sprint-stack feature/test/log commits; plain `fix:`/`chore:`/`docs:` prefixes elsewhere.
+- **PR template:** none.
+- **Version-bump workflow:** detected at `.github/workflows/bump-version.yml` — triggers on `pull_request: types: [closed]` with `if: github.event.pull_request.merged == true && github.event.pull_request.user.login != 'github-actions[bot]'`, bumps `chrome-extension/manifest.json` patch when files under `chrome-extension/**` change. Sprint commits in this plan do **not** modify `manifest.json`.
+
+## 3. Design
+
+### 3.1 The control: 10px dot at rest, 28×16 compact switch on engagement
+
+The visible part is a **10×10 circular dot** anchored to the table's top-right corner. On engagement (hover for mouse, tap for touch, focus for keyboard) it animates into a **28×16 rounded pill** with a 12×12 white knob whose horizontal position reflects `aria-pressed`. The dot's right edge is the anchored edge: when the dot expands into the pill, the right edge stays put and the pill grows leftward and downward. Color carries the rounded/not-rounded state at rest (off = `#cccccc`, on = `#3d85c6`) so the user can read state without expanding.
+
+*Principle: simple components — one element with two visual states, sharing CSS transitions instead of swapping DOM. Color-as-state at rest means the user does not need to expand to read whether the table is rounded.*
+
+*Alternative considered:* keeping the existing 36×20 pill switch in place but moving it above the table (the design from the prior `toggle-positioning` plan). Rejected because the prior plan's residual risks — the toggle overlapping content above the table, getting clipped by containers, disappearing under sticky headers — are not solvable by a fixed shift. Shrinking the at-rest footprint to a 10×10 dot reduces the overlap to a near-acceptable amount in-corner, and the on-demand expansion provides a full-size hit target only when the user is actively interacting.
+
+### 3.2 Anchor: 8px overlap, 2px overhang (per axis)
+
+The 10×10 dot is anchored such that:
+
+- **Vertical:** 8px of the dot sits *below* the table top edge (inside the table), 2px sits *above* (outside).
+- **Horizontal:** 8px of the dot sits *left of* the table's right edge (inside the table), 2px sits *right of* (outside).
+
+In viewport coordinates:
+
+```
+visible.bottom = rect.top  + scrollY + TOGGLE_DOT_OVERLAP_PX        // = rect.top  + scrollY + 8
+visible.right  = rect.right + scrollX + TOGGLE_DOT_OVERHANG_PX      // = rect.right + scrollX + 2
+```
+
+When the dot expands to the 28×16 pill, the **right edge stays anchored** at `rect.right + scrollX + 2`. The pill therefore grows to the left (leftward expansion happens entirely inside the table). The pill's bottom edge shifts down by `(TOGGLE_PILL_HEIGHT_PX − TOGGLE_DOT_PX) = 6` px relative to the dot's bottom; that temporary intrusion is acceptable because it only happens while the user is engaging.
+
+*Principle: simple interactions — a single anchor (top-right corner of the visible) defines the rest geometry, and CSS handles the rest of the animation.*
+
+### 3.3 Hit area: centered on the dot, 7px transparent buffer on every side
+
+A `<button class="dr-ext-morph">` wraps the visible. The wrapper has `padding: 7px` on every side, giving a **24×24 hit target** around the 10×10 dot at rest. The wrapper is `display: inline-flex; justify-content: flex-end; align-items: flex-start;`, which keeps the visible anchored to the wrapper's top-right corner so the wrapper grows leftward and downward as the visible expands (matching §3.2's anchor).
+
+The buffer must be present on **all four sides**, not only down-left. Earlier prototypes that padded only down-left exhibited two regressions: (i) approaching the dot from the top or right gave no padded entry zone, so the user's pointer hit the visible edge immediately; (ii) the visible's right edge coincided with the wrapper's right edge, so any frame in the expand animation that nudged the visible by ≥1px could push the cursor across the hover boundary and trigger an expand/collapse oscillation ("pointer shudder"). With 7px buffer on every side the cursor always crosses transparent padding before reaching the visible, and the visible's right edge never moves during the expand animation, so hover state is stable.
+
+*Principle: minimize runtime coupling — the hit-target geometry does not depend on host-page layout or live measurements; a single CSS `padding` value plus flex anchoring is enough.*
+
+### 3.4 Mouse vs touch behavior
+
+The control needs two distinct interaction modes:
+
+- **Mouse / trackpad** (devices with `(hover: hover)` and `(pointer: fine)`): hover expands; mouse-out collapses. A click toggles state.
+- **Touch / pen** (devices with `(hover: none)`): there is no hover, so the control uses **tap-to-expand then tap-to-toggle**. The first tap adds an `.expanded` class but does not change state. The second tap (on the already-expanded pill) calls `runToggleAction(table)` and updates `aria-pressed`. The control auto-collapses after `TOUCH_AUTOCOLLAPSE_MS = 3000` ms of no interaction, or immediately when the user taps outside it.
+
+The hover behavior is **CSS-only**, gated by `@media (hover: hover) and (pointer: fine)`. The touch behavior is **JS-only**, gated by `e.pointerType` at `pointerdown` — `'touch'` or `'pen'` triggers the two-tap path, anything else (`'mouse'`, `''`) triggers single-click toggling. Keyboard support comes for free via `:focus-visible`, which mirrors the expanded state; Space/Enter triggers `click`, which the same JS handler intercepts (mouse path: toggle state immediately).
+
+*Principle: segregate by characteristics — input modalities are routed via the media query (CSS) and the captured pointer type (JS), not via user-agent sniffing or device-class guesses.*
+
+### 3.5 Color and named constants
+
+Replace the existing `rgba(66, 133, 244, 1)` accent (`#4285f4`) with the softer `#3d85c6`. The new color is the on-state for the visible body; `#ffffff` remains the knob; `#cccccc` remains the off-state.
+
+The implementing sprint must extract every literal that has cross-site meaning into a module-level constant. The geometry literals appear in both the CSS template (interpolated) and the positioning math, and they must move in lockstep — naming each one is what keeps them aligned.
+
+Constants to introduce at the top of `chrome-extension/content.js`:
+
+- `TOGGLE_DOT_PX = 10` — visible dot diameter at rest
+- `TOGGLE_PILL_WIDTH_PX = 28` — visible pill width when expanded
+- `TOGGLE_PILL_HEIGHT_PX = 16` — visible pill height when expanded
+- `TOGGLE_KNOB_PX = 12` — knob diameter inside the expanded pill
+- `TOGGLE_KNOB_INSET_PX = 2` — knob inset from the pill's left/right edges
+- `TOGGLE_KNOB_TRAVEL_PX = TOGGLE_PILL_WIDTH_PX - TOGGLE_KNOB_PX - 2 * TOGGLE_KNOB_INSET_PX` — derived, not literal
+- `TOGGLE_HIT_PAD_PX = 7` — transparent buffer on every side of the visible
+- `TOGGLE_DOT_OVERLAP_PX = 8` — px of the dot inside the table on the y axis
+- `TOGGLE_DOT_OVERHANG_PX = 2` — px of the dot past the table's right edge on the x axis
+- `TOGGLE_COLOR_ON = '#3d85c6'`
+- `TOGGLE_COLOR_OFF = '#cccccc'`
+- `TOUCH_AUTOCOLLAPSE_MS = 3000`
+
+The CSS template in `ensureToggleStyleInjected` must be converted from a static template literal to one that interpolates these constants, so the JS positioning math and the CSS visual remain in lockstep automatically.
+
+*Principle: named constants over magic numbers — the same values appear in the JS positioning math and the CSS template; defining them once is the only way to keep them consistent.*
+
+### 3.6 Wire-up: same `runToggleAction`, same `syncSwitchForTable`, new DOM
+
+`runToggleAction(table)` (the round / restore pipeline) is unchanged. The integration points change:
+
+- `createToggleForTable(table)` builds the new DOM (`<button class="dr-ext-morph"><span class="dr-ext-morph-visible"><span class="dr-ext-morph-knob"></span></span></button>`) and replaces the `<label>+<input type=checkbox>+<span>` triple.
+- `tableToggles` stores the `<button>` element (not the checkbox input).
+- `syncSwitchForTable(table)` sets `button.setAttribute('aria-pressed', isTableRounded(table) ? 'true' : 'false')` instead of `input.checked = …`.
+- The `click` handler implements §3.4's mouse-vs-touch routing.
+- `keydown` Enter handling (and Space, which Buttons handle natively) calls `click`.
+- The existing `click` / `mousedown` propagation-stoppers stay so host-page handlers do not fire underneath.
+- The `ResizeObserver` and `MutationObserver` wiring is unchanged.
+
+`positionToggle` is rewritten to anchor by the **visible inner element**, not the wrapper button, since the wrapper's padded edges extend beyond the visible. Concretely:
+
+```js
+const padding = TOGGLE_HIT_PAD_PX;
+const wrapperLeft = (rect.right + scrollX + TOGGLE_DOT_OVERHANG_PX) - (TOGGLE_DOT_PX + 2 * padding);
+const wrapperTop  = (rect.top   + scrollY + TOGGLE_DOT_OVERLAP_PX)  - TOGGLE_DOT_PX - padding;
+buttonEl.style.left = wrapperLeft + 'px';
+buttonEl.style.top  = wrapperTop  + 'px';
+```
+
+The visible's `bottom = rect.top + scrollY + TOGGLE_DOT_OVERLAP_PX` and `right = rect.right + scrollX + TOGGLE_DOT_OVERHANG_PX` follow from the wrapper geometry plus the inline-flex anchoring.
+
+*Principle: minimize design-time coupling — the only public touch-point with the host page is still the `<button>` appended to `document.body` and the table-bounding-rect read. Nothing else about the round/restore pipeline changes.*
+
+## 4. Sprint List & Dependency Graph
+
+### Sprint List
+
+1. **expanding-toggle** — Replace the 36×20 pill switch with the 10×10 dot that expands to a 28×16 compact switch on hover/tap, with all geometry consolidated into named constants. Depends on: none.
+
+### Dependency Graph
+
+```mermaid
+flowchart TD
+    base[main]
+    s1["expanding-toggle<br/>Replace pill switch with expanding dot control"]
+    base --> s1
+```
+
+## 5. Sprint Definitions
+
+### expanding-toggle
+
+- **Goal:** Replace the per-table 36×20 pill switch with a 10×10 dot anchored at the table's top-right corner (8px overlap, 2px overhang) that expands into a 28×16 compact switch on mouse hover or touch tap, with a 7px transparent hit-target buffer on every side and the softer `#3d85c6` accent color. The visible control matches `docs/toggle-choices.html` card #7 exactly.
+- **Scope:** `chrome-extension/content.js` only. Update `ensureToggleStyleInjected` to inject the new CSS (template literal that interpolates the geometry constants, including `@media (hover: hover) and (pointer: fine)` for the hover-grow rule). Update `createToggleForTable` to build a `<button class="dr-ext-morph">` with a `<span class="dr-ext-morph-visible">` and `<span class="dr-ext-morph-knob">`, append it to `document.body`, and wire the mouse-vs-touch click handler (see §3.4) plus a global `pointerdown` listener that collapses any expanded touch-mode control when the user taps outside it. Update `syncSwitchForTable` to set `aria-pressed` on the button. Rewrite `positionToggle` per §3.6 so the visible's bottom-right lands at the spec-defined anchor. Introduce the constants listed in §3.5 at module scope and use them everywhere they apply (CSS template interpolation and JS positioning math).
+- **Out of scope:** Any change to `runToggleAction`, `roundTable`, `toggleOriginalValues`, `isTableRounded`, the `MutationObserver` / `ResizeObserver` plumbing, or any file other than `chrome-extension/content.js` and `chrome-extension/tests.js`. The `flashRangePulse`/highlight subsystem is unchanged. `manifest.json` version bump (handled at merge by the workflow). The `docs/toggle-choices.html` demo is the spec, not part of the production code — do not import from it. The original `dr-ext-toggle` class names are removed; no backwards compatibility is preserved.
+- **Acceptance criteria:**
+  - In default (rest) state, the visible part is a 10×10 circular dot anchored such that the bottom edge is `TOGGLE_DOT_OVERLAP_PX` (=8) px below the table's top edge and the right edge is `TOGGLE_DOT_OVERHANG_PX` (=2) px to the right of the table's right edge (both per §3.2).
+  - The dot's fill color is `TOGGLE_COLOR_OFF` (=`#cccccc`) when the table is not rounded and `TOGGLE_COLOR_ON` (=`#3d85c6`) when it is — verified via `aria-pressed` reflecting `isTableRounded(table)`.
+  - The hit target is at least 24×24 around the dot in rest state, achieved via `TOGGLE_HIT_PAD_PX` (=7) transparent padding on every side of the visible.
+  - On `:focus-visible` (keyboard) and on `:hover` when the device matches `@media (hover: hover) and (pointer: fine)`, the visible expands to `TOGGLE_PILL_WIDTH_PX` × `TOGGLE_PILL_HEIGHT_PX` (=28×16) with a `TOGGLE_KNOB_PX` (=12) knob that translates by `TOGGLE_KNOB_TRAVEL_PX` (=`28 − 12 − 2·2 = 12`) px when `aria-pressed="true"`. The visible's right edge does not move during expansion.
+  - On a `click` whose preceding `pointerdown` had `pointerType` of `'touch'` or `'pen'`, a control with no `.expanded` class adds the class and does **not** change `aria-pressed`; a control that already has `.expanded` calls `runToggleAction(table)` and updates `aria-pressed` via `syncSwitchForTable`. On a `click` whose preceding `pointerdown` had any other `pointerType` (including `'mouse'` and `''`), `runToggleAction(table)` is called and `aria-pressed` updates immediately.
+  - `.expanded` is removed automatically after `TOUCH_AUTOCOLLAPSE_MS` (=3000) ms of no interaction with the control, and immediately when a `pointerdown` outside the control is observed.
+  - All toggle-geometry literals (`10`, `28`, `16`, `12`, `2`, `7`, `8`, `3000`) appear exactly once in the source, as the named constants listed in §3.5. The CSS template uses `${…}` interpolation rather than the literals.
+  - `node chrome-extension/tests.js` passes.
+  - Manual: load the unpacked extension, open Google Docs Word Count dialog, confirm the dot sits at the top-right of the table with 8px below the dialog's row 1 edge and 2px past the right edge, hover-grows on the mouse, taps-to-expand on touch, and toggles the rounding pipeline correctly when tapped a second time.
+  - Manual: on a host page with multiple data tables, confirm every tracked table gets a dot, the dots reposition correctly on scroll/resize, and the colour reflects each table's individual rounding state.
+- **Depends on:** none
+- **Complexity:** M
+- **Dev notes:** Constants live at module scope in `chrome-extension/content.js` per §3.5: `TOGGLE_DOT_PX`, `TOGGLE_PILL_WIDTH_PX`, `TOGGLE_PILL_HEIGHT_PX`, `TOGGLE_KNOB_PX`, `TOGGLE_KNOB_INSET_PX`, `TOGGLE_KNOB_TRAVEL_PX` (derived), `TOGGLE_HIT_PAD_PX`, `TOGGLE_DOT_OVERLAP_PX`, `TOGGLE_DOT_OVERHANG_PX`, `TOGGLE_COLOR_ON`, `TOGGLE_COLOR_OFF`, `TOUCH_AUTOCOLLAPSE_MS`. The CSS is the same shape as in `docs/toggle-choices.html` card #7 — copy structure and values from there. The `pointerType` capture must happen at `pointerdown` (not `click`) because `click` events do not carry pointer-type information reliably across browsers. Use `data-pointer-type` on the button to ferry the captured type from `pointerdown` into `click`. The `.expanded` class must be controllable from JS; do not implement the expand-on-touch path via CSS `:active` because that releases on `pointerup`. Existing tests asserting the old `.dr-ext-toggle` CSS classes or the `<input type=checkbox>` DOM will need to be removed or rewritten — they encode the previous design and should not gate the new one.
+
+## 6. Open Questions
+
+None.
+
+## 7. Out of Scope (Separate Sprint-Stack)
+
+None.
+
+## Decisions Log
+
+- 2026-06-01: Initial draft generated by sprint-plan skill, superseding the prior `toggle-positioning` plan (which targeted a positional shift rather than a control swap). The interactive spec lives in `docs/toggle-choices.html` (card #7), added on this plan branch.

--- a/docs/toggle-choices.html
+++ b/docs/toggle-choices.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Dynamic Rounding — toggle control choices</title>
+<style>
+  :root {
+    --on: #3d85c6;
+    --off: #ccc;
+    --ink: #202124;
+    --muted: #5f6368;
+    --line: #e0e0e0;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 32px;
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+    color: var(--ink);
+    background: #fafafa;
+  }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  .sub { color: var(--muted); margin: 0 0 18px; max-width: 760px; }
+
+  /* live controls panel */
+  .panel {
+    position: sticky; top: 0; z-index: 10;
+    background: #fff; border: 1px solid var(--line); border-radius: 12px;
+    padding: 14px 18px; margin: 0 0 24px;
+    display: flex; flex-wrap: wrap; gap: 28px; align-items: center;
+  }
+  .panel .field { display: flex; flex-direction: column; gap: 4px; min-width: 240px; }
+  .panel label { font-size: 12px; color: var(--muted); }
+  .panel .row { display: flex; align-items: center; gap: 10px; }
+  .panel input[type=range] { flex: 1; }
+  .panel output { font-variant-numeric: tabular-nums; font-weight: 600; min-width: 46px; text-align: right; }
+  .panel .hint { font-size: 12px; color: var(--muted); max-width: 360px; }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 20px;
+  }
+  .card {
+    background: #fff;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 18px 18px 16px;
+  }
+  .card h2 { font-size: 15px; margin: 0 0 2px; }
+  .dims { color: var(--muted); font-size: 12px; margin: 0 0 14px; font-variant-numeric: tabular-nums; }
+  .note { color: var(--muted); font-size: 12px; margin: 12px 0 0; }
+  .demos { display: flex; align-items: center; gap: 22px; }
+
+  /* mock table corner so overlap is visible at true scale */
+  .corner {
+    position: relative;
+    width: 150px; height: 64px;
+    border: 1px solid #bbb;
+    border-radius: 2px;
+    background: #fff;
+    overflow: visible;
+  }
+  .corner .cell {
+    position: absolute; right: 8px; top: 6px;
+    font-variant-numeric: tabular-nums; color: var(--ink);
+  }
+  .corner .row2 { top: 28px; }
+  .corner .lbl { left: 8px; color: var(--muted); }
+  /* every control mounts here; top/right are set live by JS, identically for all */
+  .mount { position: absolute; }
+  .swatch { display: flex; align-items: center; justify-content: center; min-width: 56px; }
+
+  /* ---- 1. current pill switch 36x20 ---- */
+  .sw { position: relative; display: inline-block; cursor: pointer; }
+  .sw input { position: absolute; opacity: 0; width: 0; height: 0; }
+  .sw .track {
+    display: block; background: var(--off); border-radius: 999px;
+    transition: background .2s;
+  }
+  .sw .knob {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    background: #fff; border-radius: 50%; box-shadow: 0 1px 2px rgba(0,0,0,.35);
+    transition: left .2s;
+  }
+  .sw input:checked + .track { background: var(--on); }
+
+  .sw-36 .track { width: 36px; height: 20px; }
+  .sw-36 .knob { width: 14px; height: 14px; left: 3px; }
+  .sw-36 input:checked ~ .knob { left: 19px; }
+
+  .sw-28 .track { width: 28px; height: 16px; }
+  .sw-28 .knob { width: 11px; height: 11px; left: 2.5px; }
+  .sw-28 input:checked ~ .knob { left: 14.5px; }
+
+  /* ---- styled checkbox 16x16 ---- */
+  .cb { position: relative; width: 16px; height: 16px; cursor: pointer; display: inline-block; }
+  .cb input { position: absolute; opacity: 0; width: 0; height: 0; }
+  .cb .box {
+    display: block; width: 16px; height: 16px; border: 2px solid var(--off);
+    border-radius: 3px; background: #fff; transition: all .15s;
+  }
+  .cb input:checked + .box { background: var(--on); border-color: var(--on); }
+  .cb .box::after {
+    content: ""; position: absolute; left: 5px; top: 1.5px;
+    width: 4px; height: 8px; border: solid #fff; border-width: 0 2px 2px 0;
+    transform: rotate(45deg) scale(0); transition: transform .15s;
+  }
+  .cb input:checked + .box::after { transform: rotate(45deg) scale(1); }
+
+  /* ---- icon button 16x16 (and 24 hit area) ---- */
+  .ib {
+    width: 16px; height: 16px; border-radius: 50%; border: none; padding: 0;
+    background: var(--off); color: #fff; cursor: pointer; display: inline-flex;
+    align-items: center; justify-content: center; transition: background .15s;
+  }
+  .ib[aria-pressed="true"] { background: var(--on); }
+  .ib svg { width: 10px; height: 10px; display: block; }
+
+  /* ---- knob only 14 ---- */
+  .knobonly {
+    width: 14px; height: 14px; border-radius: 50%; border: 1px solid #999;
+    background: #fff; cursor: pointer; padding: 0; transition: background .15s, border-color .15s;
+  }
+  .knobonly[aria-pressed="true"] { background: var(--on); border-color: var(--on); }
+
+  /* ---- corner dot 10 ---- */
+  .dot {
+    width: 10px; height: 10px; border-radius: 50%; border: none; padding: 0;
+    background: var(--off); cursor: pointer; transition: background .15s;
+  }
+  .dot[aria-pressed="true"] { background: var(--on); }
+
+  /* ---- 7. touch-aware morph: 10px dot → 28×16 compact switch ----
+     Hit area is centered on the visible dot: 7px of transparent padding on
+     every side gives a 24×24 hit target around a 10×10 dot. inline-flex with
+     flex-end + flex-start keeps the visible anchored to the wrapper's top-
+     right corner, so when it expands to 28×16 the right edge stays put (the
+     wrapper grows leftward and downward). The 7px buffer on every side means
+     the cursor crosses transparent padding before hitting the visible — no
+     pointer-shudder when approaching from any direction during the expand
+     animation, since the visible's right edge never moves. */
+  .morph2 {
+    display: inline-flex;
+    justify-content: flex-end;       /* visible at right of content area */
+    align-items: flex-start;         /* visible at top of content area */
+    padding: 7px;                    /* transparent buffer in every direction */
+    background: transparent; border: 0; cursor: pointer;
+    vertical-align: top;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .morph2 .visible {
+    position: relative; display: block;
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--off);
+    transition: width .18s ease, height .18s ease, border-radius .18s ease, background .2s ease;
+  }
+  .morph2[aria-pressed="true"] .visible { background: var(--on); }
+  .morph2 .knob2 {
+    position: absolute; top: 50%; left: 2px; transform: translateY(-50%);
+    width: 12px; height: 12px; border-radius: 50%;
+    background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.35);
+    opacity: 0;
+    transition: opacity .12s ease, left .2s ease;
+  }
+  /* Expanded state: shared rule. Triggered by :hover/:focus-visible on hover
+     devices, by the .expanded class on touch devices. */
+  .morph2.expanded .visible,
+  .morph2:focus-visible .visible {
+    width: 28px; height: 16px; border-radius: 999px;
+  }
+  .morph2.expanded .knob2,
+  .morph2:focus-visible .knob2 { opacity: 1; }
+  .morph2.expanded[aria-pressed="true"] .knob2,
+  .morph2:focus-visible[aria-pressed="true"] .knob2 { left: 14px; }
+  /* Only enable hover-grow on devices that actually have hover (mouse, trackpad)
+     — touch devices fall through to the .expanded class set by JS on tap. */
+  @media (hover: hover) and (pointer: fine) {
+    .morph2:hover .visible {
+      width: 28px; height: 16px; border-radius: 999px;
+    }
+    .morph2:hover .knob2 { opacity: 1; }
+    .morph2:hover[aria-pressed="true"] .knob2 { left: 14px; }
+  }
+
+  .tag { display:inline-block; font-size:11px; padding:1px 6px; border-radius:999px; background:#eef; color:#334; margin-left:6px; }
+  .tag.new { background:#e6f4ea; color:#137333; }
+  .warn { color:#b3261e; }
+  footer { color: var(--muted); font-size:12px; margin-top:28px; max-width:760px; }
+  code { background:#f1f3f4; padding:1px 4px; border-radius:4px; }
+</style>
+</head>
+<body>
+  <h1>Toggle control choices</h1>
+  <p class="sub">Each control is rendered at its <strong>true pixel size</strong>, shown off (left) and on (middle), and mounted on a mock table's top-right corner (right). All seven use the <strong>same anchor</strong>, driven live by the sliders below, so the overlap comparison is apples-to-apples regardless of each control's size.</p>
+
+  <div class="panel">
+    <div class="field">
+      <label for="overlap">Vertical overlap — px of the control sitting below the table's top edge</label>
+      <div class="row">
+        <input type="range" id="overlap" min="-14" max="30" step="1" value="8">
+        <output id="overlapVal">8 px</output>
+      </div>
+    </div>
+    <div class="field">
+      <label for="overhang">Right overhang — px the control extends past the table's right edge</label>
+      <div class="row">
+        <input type="range" id="overhang" min="-6" max="14" step="1" value="2">
+        <output id="overhangVal">2 px</output>
+      </div>
+    </div>
+    <p class="hint">Overlap is measured per control: at <strong>0</strong> the control's bottom edge is flush with the table top; <strong>negative</strong> lifts it fully above (a gap); <strong>positive</strong> pushes it down over row&nbsp;1 by the same number of px for every control.</p>
+  </div>
+
+  <div class="grid">
+
+    <!-- CURRENT -->
+    <div class="card">
+      <h2>1. Pill switch — current <span class="tag">in use</span></h2>
+      <p class="dims">36 × 20 px · tap target 36×20</p>
+      <div class="demos">
+        <div class="swatch">
+          <label class="sw sw-36"><input type="checkbox"><span class="track"></span><span class="knob"></span></label>
+        </div>
+        <div class="swatch">
+          <label class="sw sw-36"><input type="checkbox" checked><span class="track"></span><span class="knob"></span></label>
+        </div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <label class="sw sw-36"><input type="checkbox" checked><span class="track"></span><span class="knob"></span></label>
+          </span>
+        </div>
+      </div>
+      <p class="note">Tallest option → at a given overlap it covers the most of row&nbsp;1. Clear on/off metaphor; comfortable hit area.</p>
+    </div>
+
+    <!-- COMPACT SWITCH -->
+    <div class="card">
+      <h2>2. Compact switch</h2>
+      <p class="dims">28 × 16 px · <span class="warn">tap target below 24px min</span></p>
+      <div class="demos">
+        <div class="swatch">
+          <label class="sw sw-28"><input type="checkbox"><span class="track"></span><span class="knob"></span></label>
+        </div>
+        <div class="swatch">
+          <label class="sw sw-28"><input type="checkbox" checked><span class="track"></span><span class="knob"></span></label>
+        </div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <label class="sw sw-28"><input type="checkbox" checked><span class="track"></span><span class="knob"></span></label>
+          </span>
+        </div>
+      </div>
+      <p class="note">Same metaphor, 4px shorter. Hit area dips under the ~24px guideline unless padded back up.</p>
+    </div>
+
+    <!-- CHECKBOX -->
+    <div class="card">
+      <h2>3. Styled checkbox</h2>
+      <p class="dims">16 × 16 px · tap target 16 (pad to 24)</p>
+      <div class="demos">
+        <div class="swatch">
+          <label class="cb"><input type="checkbox"><span class="box"></span></label>
+        </div>
+        <div class="swatch">
+          <label class="cb"><input type="checkbox" checked><span class="box"></span></label>
+        </div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <label class="cb"><input type="checkbox" checked><span class="box"></span></label>
+          </span>
+        </div>
+      </div>
+      <p class="note">Compact and square. Reads as “select / include” more than “on / off”, which may be fine for “round this table”.</p>
+    </div>
+
+    <!-- ICON BUTTON -->
+    <div class="card">
+      <h2>4. Icon button</h2>
+      <p class="dims">16 × 16 px visual · tap target padded to 24</p>
+      <div class="demos">
+        <div class="swatch">
+          <button class="ib" aria-pressed="false" title="round/unround">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M4 7h16M4 12h10M4 17h7"/></svg>
+          </button>
+        </div>
+        <div class="swatch">
+          <button class="ib" aria-pressed="true" title="round/unround">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M4 7h16M4 12h10M4 17h7"/></svg>
+          </button>
+        </div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <button class="ib" aria-pressed="true" title="round/unround">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M4 7h16M4 12h10M4 17h7"/></svg>
+            </button>
+          </span>
+        </div>
+      </div>
+      <p class="note">Smallest control that still says what it does (an icon hints “numbers / rounding”). Color carries the on/off state.</p>
+    </div>
+
+    <!-- KNOB ONLY -->
+    <div class="card">
+      <h2>5. Knob only</h2>
+      <p class="dims">14 × 14 px · <span class="warn">ambiguous state</span></p>
+      <div class="demos">
+        <div class="swatch"><button class="knobonly" aria-pressed="false" title="toggle"></button></div>
+        <div class="swatch"><button class="knobonly" aria-pressed="true" title="toggle"></button></div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <button class="knobonly" aria-pressed="true" title="toggle"></button>
+          </span>
+        </div>
+      </div>
+      <p class="note">The slider’s circle with no track. Tiny footprint, but on/off is only conveyed by fill color — easy to miss.</p>
+    </div>
+
+    <!-- DOT -->
+    <div class="card">
+      <h2>6. Corner dot</h2>
+      <p class="dims">10 × 10 px · <span class="warn">tiny target, ambiguous</span></p>
+      <div class="demos">
+        <div class="swatch"><button class="dot" aria-pressed="false" title="toggle"></button></div>
+        <div class="swatch"><button class="dot" aria-pressed="true" title="toggle"></button></div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <button class="dot" aria-pressed="true" title="toggle"></button>
+          </span>
+        </div>
+      </div>
+      <p class="note">Minimal indicator. Barely covers row&nbsp;1, but hard to hit and unclear that it’s interactive.</p>
+    </div>
+
+    <!-- HOVER-GROW (touch-aware) -->
+    <div class="card">
+      <h2>7. Touch-aware morph: dot → compact switch <span class="tag new">try it</span></h2>
+      <p class="dims">10 × 10 px visible (24 × 24 hit area) → 28 × 16 px on hover / tap (≥24 × 24 hit area)</p>
+      <div class="demos">
+        <div class="swatch">
+          <button class="morph2" aria-pressed="false" title="toggle"><span class="visible"><span class="knob2"></span></span></button>
+        </div>
+        <div class="swatch">
+          <button class="morph2" aria-pressed="true" title="toggle"><span class="visible"><span class="knob2"></span></span></button>
+        </div>
+        <div class="corner">
+          <span class="cell lbl">Words</span><span class="cell">205</span>
+          <span class="cell lbl row2">Characters</span><span class="cell row2">1497</span>
+          <span class="mount">
+            <button class="morph2" aria-pressed="true" title="toggle"><span class="visible"><span class="knob2"></span></span></button>
+          </span>
+        </div>
+      </div>
+      <p class="note">
+        Visible part is the <strong>10 × 10 dot</strong>, anchored to the table's upper-right corner.
+        Transparent padding extends the hit target into the table to make it ≥ 24 × 24 even when collapsed.
+        <br>
+        <strong>Mouse:</strong> hover-grow into a 28 × 16 compact switch; mouse-out shrinks it back. Pure CSS via <code>@media (hover: hover) and (pointer: fine)</code>.
+        <br>
+        <strong>Touch:</strong> first tap expands; second tap toggles state; auto-collapses after 3&nbsp;s of no interaction, or when you tap outside. Detected via <code>e.pointerType</code> at <code>pointerdown</code>.
+        <br>
+        Keyboard: Tab to focus expands it (<code>:focus-visible</code>); Space/Enter toggles.
+      </p>
+    </div>
+
+  </div>
+
+  <footer>
+    The current extension anchors the control's right edge to the table's right edge and lifts it above the table top. Drag the sliders to see every control move together. Note the practical floor: accessibility guidance puts the minimum tap target around 24&nbsp;px, so visuals smaller than that need invisible padding — which adds the footprint back. <strong>#7 expands on hover/focus</strong>; on touch there is no hover, so it would need a tap-to-expand fallback.
+  </footer>
+
+  <script>
+    // The icon/knob/dot buttons toggle their own state on click.
+    document.querySelectorAll('.ib, .knobonly, .dot').forEach(function (b) {
+      b.addEventListener('click', function () {
+        b.setAttribute('aria-pressed', b.getAttribute('aria-pressed') === 'true' ? 'false' : 'true');
+      });
+    });
+
+    // ---- Card #7: touch-aware morph ----
+    // Mouse: CSS handles hover-grow. Click toggles state.
+    // Touch/pen: first tap expands (no state change); subsequent taps toggle.
+    // Auto-collapse after AUTO_COLLAPSE_MS of no interaction; tap-outside collapses.
+    var AUTO_COLLAPSE_MS = 3000;
+
+    function flipPressed(btn) {
+      btn.setAttribute('aria-pressed', btn.getAttribute('aria-pressed') === 'true' ? 'false' : 'true');
+    }
+    function scheduleCollapse(btn) {
+      clearTimeout(btn._collapseTimer);
+      btn._collapseTimer = setTimeout(function () { btn.classList.remove('expanded'); }, AUTO_COLLAPSE_MS);
+    }
+
+    document.querySelectorAll('.morph2').forEach(function (btn) {
+      // Capture pointer type at pointerdown so we know what triggered the click.
+      btn.addEventListener('pointerdown', function (e) { btn.dataset.pointerType = e.pointerType; });
+
+      btn.addEventListener('click', function () {
+        var isTouch = btn.dataset.pointerType === 'touch' || btn.dataset.pointerType === 'pen';
+        if (isTouch) {
+          if (!btn.classList.contains('expanded')) {
+            // First tap: just expand, don't toggle state yet.
+            btn.classList.add('expanded');
+          } else {
+            // Subsequent tap on the expanded pill: toggle state.
+            flipPressed(btn);
+          }
+          scheduleCollapse(btn);
+        } else {
+          // Mouse / keyboard: click toggles state directly.
+          flipPressed(btn);
+        }
+      });
+    });
+
+    // Tap outside any expanded touch-mode control collapses it immediately.
+    document.addEventListener('pointerdown', function (e) {
+      document.querySelectorAll('.morph2.expanded').forEach(function (btn) {
+        if (!btn.contains(e.target)) btn.classList.remove('expanded');
+      });
+    });
+
+    // Live anchor: position every mounted control identically from the sliders.
+    // overlap = px of the control below the table top edge (measured per control
+    // height, so all controls intrude by the same amount). The mount is positioned
+    // relative to the .corner, whose top-left is the table's top edge.
+    var overlapEl  = document.getElementById('overlap');
+    var overhangEl = document.getElementById('overhang');
+    var overlapOut = document.getElementById('overlapVal');
+    var overhangOut = document.getElementById('overhangVal');
+
+    function apply() {
+      var overlap  = parseFloat(overlapEl.value);
+      var overhang = parseFloat(overhangEl.value);
+      overlapOut.textContent  = overlap + ' px';
+      overhangOut.textContent = overhang + ' px';
+      document.querySelectorAll('.corner .mount').forEach(function (m) {
+        var ctrl = m.firstElementChild;
+        // For controls with a visible inner element (e.g. card #7's morph2 whose
+        // wrapper extends invisibly into the table), anchor by the visible part —
+        // not the padded wrapper — so every card compares apples-to-apples.
+        var visible = ctrl.querySelector('.visible') || ctrl;
+        var rect = visible.getBoundingClientRect();
+        // If the wrapper has transparent padding around the visible (e.g. the
+        // morph2 hit target), measure it so the visible — not the wrapper — lands
+        // at the slider coordinates. For controls 1-6, both paddings are 0.
+        var cs = window.getComputedStyle(ctrl);
+        var padTop = parseFloat(cs.paddingTop) || 0;
+        var padRight = parseFloat(cs.paddingRight) || 0;
+        m.style.top = (overlap - rect.height - padTop) + 'px';
+        m.style.right = (-overhang - padRight) + 'px';
+      });
+    }
+
+    overlapEl.addEventListener('input', apply);
+    overhangEl.addEventListener('input', apply);
+    window.addEventListener('load', apply);
+    apply();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Plan: `docs/sprint-plans/expanding-toggle.md`

## Summary

- Replaces the toggle switch with a less obtrusive **dot** at the table's top-right corner that expands on hover (or touch). At rest the dot's colour communicates rounded/not-rounded state.
- Transparent padding on every side brings it in line with accessibility guidance (24 pixel minimum)
- **Touch vs. mouse** This is the first feature that has mouse-only behaviour (hover).  As such, touch-only behaviour is implemented for the first time (first tap expands without changing state; second tap toggles state. Auto-collapses after inactivity or outside tap.
- demo: see `docs/toggle-choices.html`, card 7