### PR TITLE
fix: defer initial toggle positioning by 150ms

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -309,7 +309,9 @@ function createToggleForTable(table) {
 
   (document.body || document.documentElement).appendChild(button);
 
-  positionToggle(table, button);
+  setTimeout(() => {
+    positionToggle(table, button);
+  }, 150);
 
   // Capture pointer type at pointerdown for use in click handler
   button.addEventListener('pointerdown', (e) => {


### PR DESCRIPTION
Wait for the host SPA to finish entrance animations and centering before measuring the table bounding box for toggle placement.