### PR TITLE
feat(sidebar): live preview band with sample rounding

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -13,13 +13,9 @@ const NUMBER_IN_TEXT_REGEX_GLOBAL = /-?\d[\d,]*(?:\.\d+)?/g;
 const DEFAULT_OFFSET_TOP = -0.5;
 const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
-const EPSILON = 1e-9;
-// Threshold for the "no-coarser-than-x" floor in half-step rounding. When the
-// integer part of a half-step offset has |trunc(offset)| >= X_FLOOR_THRESHOLD,
-// the result is also floored at roundWithOffset(|num|, trunc(offset)). Module-
-// level constant (not exposed via any public function signature) so the team
-// can later loosen it without an API change.
-const X_FLOOR_THRESHOLD = 1;
+// EPSILON, X_FLOOR_THRESHOLD, roundWithOffset, and roundCellSetAware live in
+// rounding.js (loaded by manifest content_scripts ahead of this file) so the
+// sidebar can call the same arithmetic for its preview band.
 
 // Toggle geometry constants
 const TOGGLE_DOT_PX = 10;
@@ -84,6 +80,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'SIDEBAR_OPENED') {
     if (lastRightClickedTable) {
       requestSidebarSettingsAndApply(lastRightClickedTable);
+      // Tell the sidebar its cached preview samples are stale; it will re-pull
+      // GET_PREVIEW_SAMPLES against the now-current targeted table.
+      try {
+        chrome.runtime.sendMessage({ action: 'PREVIEW_SAMPLES_CHANGED' });
+      } catch (e) {
+        // sidebar may not be open yet; harmless
+      }
     } else {
       console.debug("Dynamic Rounding: No table targeted. Right-click a table cell first.");
     }
@@ -93,6 +96,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'APPLY_SIDEBAR_SETTINGS') {
     if (lastRightClickedTable) {
       applySidebarRounding(lastRightClickedTable, request.settings || DR_DEFAULTS);
+    }
+    return;
+  }
+
+  if (request.action === 'GET_PREVIEW_SAMPLES') {
+    if (lastRightClickedTable) {
+      const payload = extractPreviewSamples(lastRightClickedTable);
+      sendResponse(payload);
+    } else {
+      sendResponse({ samples: null, maxMag: null });
     }
     return;
   }
@@ -600,6 +613,95 @@ function resetTable(table) {
   }
   delete table.dataset.drShowingOriginal;
   syncSwitchForTable(table);
+}
+
+// --- Preview-band sample extraction (consumed by sidebar via IPC) ---
+
+// Walk every <td> in the table and return its trimmed text + parsed number, but
+// only for cells whose entire content parses as a single number (mode 'pure'
+// in roundTable's classifier). Cells matched only via includeWords / dates /
+// times are intentionally skipped here — they're deferred to a future sprint.
+function collectNumericCells(table) {
+  const out = [];
+  const rows = table.rows ? Array.from(table.rows) : [];
+  for (const row of rows) {
+    const cells = row.cells ? Array.from(row.cells) : [];
+    for (const cell of cells) {
+      if (cell.tagName !== 'TD') continue;
+      const text = cell.innerText || cell.textContent || '';
+      const trimmed = typeof text === 'string' ? text.trim() : '';
+      if (!trimmed) continue;
+      if (isDateLike(trimmed) || isTimeLike(trimmed)) continue;
+      if (/^(19|20)\d{2}$/.test(trimmed)) continue;
+      const num = toNumber(trimmed);
+      if (num === null || num === 0 || !isFinite(num)) continue;
+      out.push({ text: trimmed, num });
+    }
+  }
+  return out;
+}
+
+// Pick up to 2 large-magnitude + 3 smaller-magnitude representative samples
+// for the sidebar preview band. Bucketed by magnitude (floor(log10|num|)) so
+// the band shows the actual offset_top vs offset_other split that
+// roundCellSetAware will apply to the table.
+function extractPreviewSamples(table) {
+  const cells = collectNumericCells(table);
+  if (cells.length === 0) {
+    return { samples: { top: [], bottom: [] }, maxMag: null };
+  }
+  const numTop = DR_DEFAULTS.numTop || 1;
+
+  const byMag = new Map();
+  let maxMag = null;
+  for (const c of cells) {
+    const mag = Math.floor(Math.log10(Math.abs(c.num)));
+    if (maxMag === null || mag > maxMag) maxMag = mag;
+    if (!byMag.has(mag)) byMag.set(mag, []);
+    byMag.get(mag).push(c);
+  }
+
+  // Top band: cells whose magnitude is within numTop of maxMag (i.e. cells
+  // that roundCellSetAware will route to offset_top). Pick up to 2; prefer
+  // distinct magnitudes.
+  const topMags = Array.from(byMag.keys())
+    .filter(m => (maxMag - m) < numTop)
+    .sort((a, b) => b - a);
+  const top = [];
+  for (const m of topMags) {
+    if (top.length >= 2) break;
+    top.push(byMag.get(m)[0]);
+  }
+  if (top.length < 2 && topMags.length > 0) {
+    // Same magnitude has multiple cells — fill from the top bucket.
+    const bucket = byMag.get(topMags[0]);
+    for (let i = 1; i < bucket.length && top.length < 2; i++) {
+      top.push(bucket[i]);
+    }
+  }
+
+  // Bottom band: remaining magnitudes, one per bucket, descending. If <3
+  // distinct buckets remain, fill from the largest remaining bucket.
+  const bottomMags = Array.from(byMag.keys())
+    .filter(m => (maxMag - m) >= numTop)
+    .sort((a, b) => b - a);
+  const bottom = [];
+  for (const m of bottomMags) {
+    if (bottom.length >= 3) break;
+    bottom.push(byMag.get(m)[0]);
+  }
+  if (bottom.length < 3 && bottomMags.length > 0) {
+    const bucket = byMag.get(bottomMags[0]);
+    for (let i = 1; i < bucket.length && bottom.length < 3; i++) {
+      bottom.push(bucket[i]);
+    }
+  }
+
+  const toRow = c => ({ original: c.text, num: c.num });
+  return {
+    samples: { top: top.map(toRow), bottom: bottom.map(toRow) },
+    maxMag,
+  };
 }
 
 function roundTable(table, options) {
@@ -1286,80 +1388,7 @@ function findMaxMagnitude(numericRange) {
   return max_mag;
 }
 
-function roundCellSetAware(value, num, max_mag, offset_top, offset_other, num_top) {
-  if (value === "" || value === null) return "";
-
-  if (num === null) return value;
-  if (num === 0) return 0;
-
-  const current_mag = Math.floor(Math.log10(Math.abs(num)));
-
-  let offset = offset_other;
-  if (max_mag !== null && (max_mag - current_mag) < num_top) {
-    offset = offset_top;
-  }
-
-  return roundWithOffset(num, offset);
-}
-
-/**
- * Rounds a number using the offset model.
- *
- * Step formula:
- *   integer offset:      step = 10^(current_mag + offset)
- *   fractional offset:   step = f * 10^(current_mag + ceil(offset))
- *                        where f = |offset - trunc(offset)| in (0, 1)
- *
- * Examples for v=87,054,321 (current_mag = 7):
- *   offset = +2   -> step = 1e9       -> raw = 0
- *   offset = +1.5 -> step = 5e8       -> raw = 0
- *   offset = +1   -> step = 1e8       -> raw = 100,000,000
- *   offset = +0.5 -> step = 5e7       -> raw = 100,000,000
- *   offset =  0   -> step = 1e7       -> raw = 90,000,000
- *   offset = -0.5 -> step = 5e6       -> raw = 85,000,000
- *   offset = -1   -> step = 1e6       -> raw = 87,000,000
- *   offset = -1.5 -> step = 5e5       -> raw = 87,000,000
- *   offset = -2   -> step = 1e5       -> raw = 87,100,000
- *
- * Floors applied after raw rounding:
- *   Feature 2: result >= 10^current_mag (value-OoM floor, always on)
- *   Feature 3: when offset is non-integer and |trunc(offset)| >= X_FLOOR_THRESHOLD,
- *              also floor at roundWithOffset(|num|, trunc(offset)).
- */
-function roundWithOffset(num, offset) {
-  if (num === 0) return 0;
-
-  const sign = num < 0 ? -1 : 1;
-  const absnum = Math.abs(num);
-  const current_mag = Math.floor(Math.log10(absnum));
-
-  let target_mag;
-  let step;
-  if (Number.isInteger(offset)) {
-    target_mag = current_mag + offset;
-    step = Math.pow(10, target_mag);
-  } else {
-    target_mag = current_mag + Math.ceil(offset);
-    const f = Math.abs(offset - Math.trunc(offset));
-    step = f * Math.pow(10, target_mag);
-  }
-
-  const raw = Math.round(absnum / step + EPSILON) * step;
-  const floor_oom = Math.pow(10, current_mag);
-  let result = Math.max(raw, floor_oom);
-
-  if (!Number.isInteger(offset) && Math.abs(Math.trunc(offset)) >= X_FLOOR_THRESHOLD) {
-    const x_int = Math.trunc(offset);
-    const floor_x = roundWithOffset(absnum, x_int);
-    result = Math.max(result, floor_x);
-  }
-
-  if (result >= 10 || result % 1 === 0) {
-    result = Math.round(result);
-  }
-
-  return sign * result;
-}
+// roundCellSetAware and roundWithOffset live in rounding.js.
 
 function toNumber(value) {
   if (typeof value === "number") {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -19,6 +19,7 @@
       ],
       "js": [
         "defaults.js",
+        "rounding.js",
         "content.js"
       ]
     }

--- a/chrome-extension/rounding.js
+++ b/chrome-extension/rounding.js
@@ -1,0 +1,117 @@
+/**
+ * DynamicRounding shared rounding helpers
+ *
+ * Loaded by both content.js (page context, via manifest content_scripts) and
+ * sidebar.js (extension side-panel context, via <script> tag). Must remain
+ * framework-free and side-effect-free: no chrome.*, no DOM access. All
+ * symbols land on the global object of whichever script loads this file.
+ */
+
+const EPSILON = 1e-9;
+// Threshold for the "no-coarser-than-x" floor in half-step rounding. When the
+// integer part of a half-step offset has |trunc(offset)| >= X_FLOOR_THRESHOLD,
+// the result is also floored at roundWithOffset(|num|, trunc(offset)).
+const X_FLOOR_THRESHOLD = 1;
+
+function roundWithOffset(num, offset) {
+  if (num === 0) return 0;
+
+  const sign = num < 0 ? -1 : 1;
+  const absnum = Math.abs(num);
+  const current_mag = Math.floor(Math.log10(absnum));
+
+  let target_mag;
+  let step;
+  if (Number.isInteger(offset)) {
+    target_mag = current_mag + offset;
+    step = Math.pow(10, target_mag);
+  } else {
+    target_mag = current_mag + Math.ceil(offset);
+    const f = Math.abs(offset - Math.trunc(offset));
+    step = f * Math.pow(10, target_mag);
+  }
+
+  const raw = Math.round(absnum / step + EPSILON) * step;
+  const floor_oom = Math.pow(10, current_mag);
+  let result = Math.max(raw, floor_oom);
+
+  if (!Number.isInteger(offset) && Math.abs(Math.trunc(offset)) >= X_FLOOR_THRESHOLD) {
+    const x_int = Math.trunc(offset);
+    const floor_x = roundWithOffset(absnum, x_int);
+    result = Math.max(result, floor_x);
+  }
+
+  if (result >= 10 || result % 1 === 0) {
+    result = Math.round(result);
+  }
+
+  // Strip IEEE-754 float noise from sub-unit steps (e.g. 11 * 0.1 = 1.1000…01).
+  result = Number(result.toPrecision(12));
+
+  return sign * result;
+}
+
+function roundCellSetAware(value, num, max_mag, offset_top, offset_other, num_top) {
+  if (value === "" || value === null) return "";
+
+  if (num === null) return value;
+  if (num === 0) return 0;
+
+  const current_mag = Math.floor(Math.log10(Math.abs(num)));
+
+  let offset = offset_other;
+  if (max_mag !== null && (max_mag - current_mag) < num_top) {
+    offset = offset_top;
+  }
+
+  return roundWithOffset(num, offset);
+}
+
+/**
+ * Compute the step that roundWithOffset would use for the given num + offset.
+ * Used by the sidebar preview band to render "(5k)" / "(0.25)" alongside the
+ * rounded value, without duplicating the rounding formula.
+ */
+function stepForOffset(num, offset) {
+  if (num === 0) return 0;
+  const current_mag = Math.floor(Math.log10(Math.abs(num)));
+  if (Number.isInteger(offset)) {
+    return Math.pow(10, current_mag + offset);
+  }
+  const f = Math.abs(offset - Math.trunc(offset));
+  return f * Math.pow(10, current_mag + Math.ceil(offset));
+}
+
+/**
+ * Human-readable step label for the preview band.
+ *   5000     -> "5k"
+ *   500      -> "500"
+ *   2500000  -> "2.5M"
+ *   2.5      -> "2.5"
+ *   0.25     -> "0.25"
+ */
+function formatStep(step) {
+  if (!isFinite(step) || step === 0) return "0";
+  const abs = Math.abs(step);
+  if (abs >= 1e9) return trimNum(step / 1e9) + "B";
+  if (abs >= 1e6) return trimNum(step / 1e6) + "M";
+  if (abs >= 1e3) return trimNum(step / 1e3) + "k";
+  if (abs >= 1) return trimNum(step);
+  // Sub-integer: show as a decimal, dropping any trailing zeros.
+  return trimNum(step);
+}
+
+function trimNum(n) {
+  // Up to 3 significant digits, but avoid scientific notation for the values
+  // formatStep actually produces (steps are powers of 10 or half-decades).
+  const rounded = Math.round(n * 1000) / 1000;
+  let s = String(rounded);
+  if (s.indexOf("e") !== -1) {
+    s = rounded.toFixed(10);
+  }
+  // Trim trailing zeros after a decimal point.
+  if (s.indexOf(".") !== -1) {
+    s = s.replace(/0+$/, "").replace(/\.$/, "");
+  }
+  return s;
+}

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -145,6 +145,9 @@
       font-variant-numeric: tabular-nums;
     }
     .label-row .lbl { color: #5f6368; }
+    .label-row .lbl.top { color: #1a73e8; }
+    .label-row .lbl.bot { color: #b3623d; }
+    #sliderBlock.linked .label-row .lbl.bot { color: #9aa0a6; }
     .label-row .val { color: #202124; font-variant-numeric: tabular-nums; }
     .dual-wrap {
       position: relative;
@@ -188,6 +191,35 @@
     .dual-thumb.bot.linked { background: #9aa0a6; }
     .dual-thumb:focus-visible { outline: 2px solid #1a73e8; outline-offset: 2px; }
     .section.disabled .dual-thumb { cursor: not-allowed; }
+    /* Preview band: 2 samples above slider, 3 below (variant F).
+       Grid + display:contents pairs so the "→" column aligns vertically
+       and the whole band is centered horizontally under the slider. */
+    .results-band {
+      display: grid;
+      grid-template-columns: auto auto auto auto;
+      justify-content: center;
+      column-gap: 6px;
+      row-gap: 2px;
+      align-items: baseline;
+      font-size: 12px;
+      color: #3c4043;
+      font-variant-numeric: tabular-nums;
+      padding: 2px 0;
+    }
+    .results-band .pair { display: contents; }
+    .results-band .from {
+      color: #5f6368;
+      text-align: right;
+      white-space: normal;
+    }
+    .results-band .arrow { color: #5f6368; text-align: center; }
+    .results-band .num { color: #202124; text-align: right; }
+    .results-band .step { color: #5f6368; text-align: left; }
+    .results-band .empty {
+      color: #80868b;
+      font-style: italic;
+      text-align: center;
+    }
     #rangeExpr {
       width: 100%;
       box-sizing: border-box;
@@ -291,9 +323,9 @@
     <summary>Advanced</summary>
     <div class="slider-block" id="sliderBlock">
       <div class="label-row">
-        <span class="lbl">largest numbers</span>
-        <span class="val" id="topReadout">−0.5</span>
+        <span class="lbl top" id="topLabel">largest numbers: −0.5</span>
       </div>
+      <div class="results-band" id="topBand"></div>
       <div class="dual-wrap" id="dualWrap">
         <div class="dual-track"></div>
         <div class="dual-ticks" aria-hidden="true">
@@ -307,15 +339,16 @@
              aria-label="largest numbers offset" aria-valuemin="-1" aria-valuemax="1" aria-valuenow="-0.5"></div>
       </div>
       <div class="label-row">
-        <span class="lbl">all other numbers</span>
-        <span class="val" id="botReadout">−0.5</span>
+        <span class="lbl bot" id="botLabel">all other numbers: −0.5</span>
       </div>
+      <div class="results-band" id="botBand"></div>
     </div>
   </details>
 
   <div class="status" id="status"></div>
 
   <script src="defaults.js"></script>
+  <script src="rounding.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -27,12 +27,13 @@ const rangeExprEl = document.getElementById('rangeExpr');
 const STOPS = [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
 const DEFAULT_OFFSET = -0.5;
 
+const sliderBlockEl = document.getElementById('sliderBlock');
 const dualWrap = document.getElementById('dualWrap');
 const topThumb = document.getElementById('topThumb');
 const botThumb = document.getElementById('botThumb');
 const trackEl = dualWrap ? dualWrap.querySelector('.dual-track') : null;
-const topReadout = document.getElementById('topReadout');
-const botReadout = document.getElementById('botReadout');
+const topLabelEl = document.getElementById('topLabel');
+const botLabelEl = document.getElementById('botLabel');
 
 let topVal = DEFAULT_OFFSET;
 let botVal = DEFAULT_OFFSET;
@@ -61,10 +62,94 @@ function renderSliders() {
   topThumb.style.left = pct(topVal) + '%';
   botThumb.style.left = pct(botVal) + '%';
   botThumb.classList.toggle('linked', linked);
-  if (topReadout) topReadout.textContent = fmtOffset(topVal);
-  if (botReadout) botReadout.textContent = fmtOffset(botVal);
+  if (sliderBlockEl) sliderBlockEl.classList.toggle('linked', linked);
+  if (topLabelEl) topLabelEl.textContent = 'largest numbers: ' + fmtOffset(topVal);
+  if (botLabelEl) botLabelEl.textContent = 'all other numbers: ' + fmtOffset(botVal);
   if (topThumb) topThumb.setAttribute('aria-valuenow', String(topVal));
   if (botThumb) botThumb.setAttribute('aria-valuenow', String(botVal));
+  renderPreviewBands();
+}
+
+// ----- Preview band -----
+const topBandEl = document.getElementById('topBand');
+const botBandEl = document.getElementById('botBand');
+const PREVIEW_NUM_TOP = 1;
+let cachedSamples = null;
+let cachedMaxMag = null;
+
+function formatNumberWithCommas(n) {
+  if (typeof n !== 'number' || !isFinite(n)) return String(n);
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+  const intPart = Math.floor(abs);
+  const frac = abs - intPart;
+  const intStr = String(intPart).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  if (frac === 0) return sign + intStr;
+  const fracStr = String(frac).slice(1).replace(/0+$/, '');
+  return sign + intStr + (fracStr === '.' ? '' : fracStr);
+}
+
+function renderBand(el, rows, offset) {
+  if (!el) return;
+  if (!rows || rows.length === 0) {
+    el.innerHTML = '';
+    return;
+  }
+  el.innerHTML = '';
+  for (const row of rows) {
+    const pair = document.createElement('div');
+    pair.className = 'pair';
+
+    const from = document.createElement('span');
+    from.className = 'from';
+    from.textContent = row.original;
+    pair.appendChild(from);
+
+    const arrow = document.createElement('span');
+    arrow.className = 'arrow';
+    arrow.textContent = '→';
+    pair.appendChild(arrow);
+
+    const numEl = document.createElement('span');
+    numEl.className = 'num';
+    const rounded = roundWithOffset(row.num, offset);
+    numEl.textContent = formatNumberWithCommas(rounded);
+    pair.appendChild(numEl);
+
+    const stepEl = document.createElement('span');
+    stepEl.className = 'step';
+    stepEl.textContent = '(' + formatStep(stepForOffset(row.num, offset)) + ')';
+    pair.appendChild(stepEl);
+
+    el.appendChild(pair);
+  }
+}
+
+function renderPreviewBands() {
+  if (!topBandEl || !botBandEl) return;
+  if (!cachedSamples) {
+    renderBand(topBandEl, null);
+    renderBand(botBandEl, null);
+    return;
+  }
+  renderBand(topBandEl, cachedSamples.top, topVal);
+  renderBand(botBandEl, cachedSamples.bottom, botVal);
+}
+
+function fetchPreviewSamples() {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (!tabs[0]) return;
+    chrome.tabs.sendMessage(tabs[0].id, { action: 'GET_PREVIEW_SAMPLES' }, (response) => {
+      if (chrome.runtime.lastError || !response) {
+        cachedSamples = null;
+        cachedMaxMag = null;
+      } else {
+        cachedSamples = response.samples;
+        cachedMaxMag = response.maxMag;
+      }
+      renderPreviewBands();
+    });
+  });
 }
 
 function decouple() {
@@ -246,6 +331,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       statusEl.textContent = '';
       delete statusEl.dataset.source;
     }
+  } else if (request.action === 'PREVIEW_SAMPLES_CHANGED') {
+    fetchPreviewSamples();
   }
 });
 
@@ -277,6 +364,10 @@ function applyDefaultsToUI() {
   renderSliders();
 }
 applyDefaultsToUI();
+
+// Pull samples from whichever table the user has right-clicked. If no table
+// was targeted, content.js returns nulls and the bands render the prompt.
+fetchPreviewSamples();
 
 // Defensively clear rangeExpr so browser autofill can never leak a stale value
 // into a hidden field and silently constrain content.js output.

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -44,8 +44,9 @@ global.Node = { ELEMENT_NODE: 1 };
 // We also expose the per-table toggle infrastructure declared with const/let
 // inside the eval'd code so the auto-table-toggle test section can access them.
 const defaultsCode = fs.readFileSync(path.join(__dirname, 'defaults.js'), 'utf8');
+const roundingCode = fs.readFileSync(path.join(__dirname, 'rounding.js'), 'utf8');
 const code = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
-eval(defaultsCode + '\n' + code + `
+eval(defaultsCode + '\n' + roundingCode + '\n' + code + `
 globalThis.DR_DEFAULTS = DR_DEFAULTS;
 // Expose toggle infrastructure for tests
 globalThis.tableToggles = tableToggles;
@@ -64,6 +65,10 @@ globalThis.runToggleAction = runToggleAction;
 globalThis.toggleOriginalValues = toggleOriginalValues;
 globalThis.injectTableToggles = injectTableToggles;
 globalThis.isDataTable = isDataTable;
+globalThis.collectNumericCells = collectNumericCells;
+globalThis.extractPreviewSamples = extractPreviewSamples;
+globalThis.formatStep = formatStep;
+globalThis.stepForOffset = stepForOffset;
 // Expose new toggle geometry constants (all are const, so direct assignment works)
 globalThis.TOGGLE_DOT_PX = TOGGLE_DOT_PX;
 globalThis.TOGGLE_PILL_WIDTH_PX = TOGGLE_PILL_WIDTH_PX;
@@ -1577,9 +1582,10 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     /defaults\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
   eq('sidebar-defaults: sidebar.js applies DR_DEFAULTS to the UI on load',
     /applyDefaultsToUI[\s\S]*DR_DEFAULTS/.test(sidebarJsSource), true);
-  eq('sidebar-defaults: manifest content_scripts loads defaults.js before content.js',
+  eq('sidebar-defaults: manifest content_scripts loads defaults.js, rounding.js, content.js in order',
     manifest.content_scripts[0].js[0] === 'defaults.js' &&
-    manifest.content_scripts[0].js[1] === 'content.js', true);
+    manifest.content_scripts[0].js[1] === 'rounding.js' &&
+    manifest.content_scripts[0].js[2] === 'content.js', true);
 
   // AC3: Section heading contains <em>Include</em> followed by " numbers in cells containing:"
   eq('sidebar-defaults: section-heading has <em>Include</em> with correct text',
@@ -3127,13 +3133,14 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   // Re-eval content.js with X_FLOOR_THRESHOLD = 0 to confirm the x-floor
   // gates on the constant. We sandbox the patched source so the eq()
   // assertions below don't disturb the live extension globals.
-  const src = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
-  const patched = src.replace(
+  const roundingSrc = fs.readFileSync(path.join(__dirname, 'rounding.js'), 'utf8');
+  const contentSrc = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+  const patchedRounding = roundingSrc.replace(
     /const X_FLOOR_THRESHOLD = 1;/,
     'const X_FLOOR_THRESHOLD = 0;'
   );
   eq('x-floor flip: source contains X_FLOOR_THRESHOLD declaration',
-    patched.includes('const X_FLOOR_THRESHOLD = 0;'), true);
+    patchedRounding.includes('const X_FLOOR_THRESHOLD = 0;'), true);
 
   const sandbox = {
     chrome: global.chrome,
@@ -3147,7 +3154,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   };
   const vm = require('vm');
   const ctx = vm.createContext(sandbox);
-  vm.runInContext(patched + '\nthis.__roundWithOffset = roundWithOffset;', ctx);
+  vm.runInContext(patchedRounding + '\n' + contentSrc + '\nthis.__roundWithOffset = roundWithOffset;', ctx);
   const patchedRound = sandbox.__roundWithOffset;
 
   eq('x-floor flip: rd(17054321, 0.5) === 20000000 with X_FLOOR_THRESHOLD=0',
@@ -3866,6 +3873,122 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     ptBody.includes('TOGGLE_DOT_OVERLAP_PX'), true);
   eq('expanding-toggle: TOGGLE_DOT_OVERHANG_PX referenced in positionToggle',
     ptBody.includes('TOGGLE_DOT_OVERHANG_PX'), true);
+})();
+
+// =============================================================================
+// Sprint sidebar-preview-band: formatStep, collectNumericCells, extractPreviewSamples
+// =============================================================================
+
+(function previewBand_formatStep() {
+  eq('formatStep: 5000 -> "5k"', formatStep(5000), '5k');
+  eq('formatStep: 500 -> "500"', formatStep(500), '500');
+  eq('formatStep: 2_500_000 -> "2.5M"', formatStep(2500000), '2.5M');
+  eq('formatStep: 1e9 -> "1B"', formatStep(1e9), '1B');
+  eq('formatStep: 2.5 -> "2.5"', formatStep(2.5), '2.5');
+  eq('formatStep: 0.25 -> "0.25"', formatStep(0.25), '0.25');
+  eq('formatStep: 1 -> "1"', formatStep(1), '1');
+  eq('formatStep: 0 -> "0"', formatStep(0), '0');
+})();
+
+(function previewBand_stepForOffset() {
+  // offset = 0 on a 5-digit number -> step = 10^4 = 10000
+  eq('stepForOffset(27136, 0) = 10000', stepForOffset(27136, 0), 10000);
+  // offset = -0.5 on a 5-digit number -> f=0.5, target_mag=4, step = 0.5*1e4
+  eq('stepForOffset(27136, -0.5) = 5000', stepForOffset(27136, -0.5), 5000);
+  // offset = -1 -> step = 10^(4-1) = 1000
+  eq('stepForOffset(27136, -1) = 1000', stepForOffset(27136, -1), 1000);
+  // num=0 -> 0
+  eq('stepForOffset(0, -0.5) = 0', stepForOffset(0, -0.5), 0);
+})();
+
+(function previewBand_collectNumericCells() {
+  // Build a small stub table; only the pure-number cells should appear.
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  function thCell(text) {
+    return { tagName: 'TH', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [
+      { cells: [thCell('Header'), thCell('Year')] },
+      { cells: [tdCell('Apples'), tdCell('27,136')] },
+      { cells: [tdCell('Pears'),  tdCell('4,080')] },
+      { cells: [tdCell('Empty'),  tdCell('')] },
+      { cells: [tdCell('Word'),   tdCell('hello')] },
+    ],
+  };
+  const cells = collectNumericCells(table);
+  eq('collectNumericCells: returns 2 numeric cells', cells.length, 2);
+  eq('collectNumericCells: first cell text', cells[0].text, '27,136');
+  eq('collectNumericCells: first cell num', cells[0].num, 27136);
+  eq('collectNumericCells: second cell num', cells[1].num, 4080);
+})();
+
+(function previewBand_extractPreviewSamples_buckets() {
+  // 5 cells across 5 distinct magnitudes: 1e7, 1e6, 1e4, 1e2, 1e1.
+  // num_top = 1 (DR_DEFAULTS) -> top band picks the highest magnitude only
+  // (others differ from max_mag by >= 1). To exercise the 2-row top band,
+  // give it two cells at the same top magnitude.
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [
+      { cells: [tdCell('27,000,000'), tdCell('18,000,000')] }, // both mag 7
+      { cells: [tdCell('4,080'),  tdCell('312')] },             // mag 3, 2
+      { cells: [tdCell('56')] },                                // mag 1
+    ],
+  };
+  const result = extractPreviewSamples(table);
+  eq('extractPreviewSamples: maxMag is 7', result.maxMag, 7);
+  eq('extractPreviewSamples: top band has 2 rows', result.samples.top.length, 2);
+  eq('extractPreviewSamples: top[0] is 27M', result.samples.top[0].num, 27000000);
+  eq('extractPreviewSamples: top[1] is 18M', result.samples.top[1].num, 18000000);
+  eq('extractPreviewSamples: bottom band has 3 rows', result.samples.bottom.length, 3);
+  eq('extractPreviewSamples: bottom[0] is 4080', result.samples.bottom[0].num, 4080);
+  eq('extractPreviewSamples: bottom[1] is 312', result.samples.bottom[1].num, 312);
+  eq('extractPreviewSamples: bottom[2] is 56', result.samples.bottom[2].num, 56);
+})();
+
+(function previewBand_extractPreviewSamples_largeMagOnly() {
+  // All cells in the top magnitude bucket -> bottom band ends up empty.
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [{ cells: [tdCell('27,000,000'), tdCell('18,000,000'), tdCell('45,000,000')] }],
+  };
+  const result = extractPreviewSamples(table);
+  eq('extractPreviewSamples (all-top): top has 2 rows', result.samples.top.length, 2);
+  eq('extractPreviewSamples (all-top): bottom is empty', result.samples.bottom.length, 0);
+})();
+
+(function previewBand_extractPreviewSamples_emptyTable() {
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [{ cells: [tdCell('hello'), tdCell('world')] }],
+  };
+  const result = extractPreviewSamples(table);
+  eq('extractPreviewSamples (empty): maxMag null', result.maxMag, null);
+  eq('extractPreviewSamples (empty): top length 0', result.samples.top.length, 0);
+  eq('extractPreviewSamples (empty): bottom length 0', result.samples.bottom.length, 0);
+})();
+
+(function previewBand_manifestLoadsRoundingJs() {
+  const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest.json'), 'utf8'));
+  eq('manifest content_scripts loads rounding.js between defaults.js and content.js',
+    manifest.content_scripts[0].js[1], 'rounding.js');
+})();
+
+(function previewBand_sidebarHtmlHasBands() {
+  const sidebarHtml = fs.readFileSync(path.join(__dirname, 'sidebar.html'), 'utf8');
+  eq('sidebar.html has #topBand', /<div[^>]*id="topBand"/.test(sidebarHtml), true);
+  eq('sidebar.html has #botBand', /<div[^>]*id="botBand"/.test(sidebarHtml), true);
+  eq('sidebar.html loads rounding.js before sidebar.js',
+    /rounding\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
 })();
 
 // --- Report ---


### PR DESCRIPTION
## Summary

Adds a live preview band above and below the dual-thumb slider in the sidebar's Advanced section. It pulls representative cells from whichever table the user right-clicked and shows `original → rounded (step)` for each, so the user can see exactly what the current offset will do before applying.

Bundled with the band:

- **Shared rounding helpers** extracted into `rounding.js`, loaded by both `content.js` and `sidebar.js` so the preview uses the same arithmetic as the table replacement (no drift risk).
- **Float-noise fix**: `roundWithOffset` now strips IEEE-754 trailing-digit artifacts (e.g. `11 * 0.1 = 1.1000…01`) via `toPrecision(12)`. This was visible in the preview band but the same artifact would have shipped to the actual table for any sub-unit step. Real bug, not just cosmetic.
- **Sample filter**: skip date-/time-/4-digit-year-shaped cells when picking preview rows (best-effort).
- **Label polish**: offset value rendered inline (`largest numbers: −0.5`), color-matched to the corresponding thumb (blue for top, rust for bottom, greying out when linked).
- **Arrow alignment**: `display: contents` grid (variant F layout) so the `→` column lines up vertically and sits roughly under the slider's center tick.

## Tested

- `node tests.js` — 559/0
- Spot-checked `roundWithOffset` for sub-unit cases: `1.1 / −1 → 1.1`, `2.2 / −1 → 2.2`, `0.3 / −2 → 0.3` (previously `1.10000000000000009` etc.)

## Manual tests

- [ ] Reload the unpacked extension
- [ ] Right-click a table containing a mix of large numbers, small numbers, years (e.g. `2024`), and dates → open sidebar → expand Advanced
- [ ] Top band shows ≤2 largest-magnitude samples; bottom shows ≤3 smaller ones; no year/date/time rows
- [ ] Drag top thumb → `largest numbers: <offset>` updates inline; top band re-renders
- [ ] Drag bottom thumb (decouples) → bottom label turns rust; relink (drag back) → grey
- [ ] Sub-unit step case: target a column with values like `1.1`, `2.2` and pick an offset that produces step `0.1` — verify clean `1.1` / `2.2` in both preview and the actual table
- [ ] Arrows form a vertical column roughly aligned with the slider's middle tick
- [ ] Empty bands (sidebar opened before any right-click) render nothing; status row still says "Right-click a table first, then reopen the sidebar."