### PR TITLE
Make date/time sidebar toggles mean 'simplify this type' instead of 'exclude it'

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -749,7 +749,7 @@ function roundTable(table, options) {
         rowInfo.push({ mode: 'skip' });
       } else if (isWholeCellQuoted) {
         rowInfo.push({ mode: 'skip' });
-      } else if (opts.excludeDates === false && isDateLike(trimmed)) {
+      } else if (opts.simplifyDates && isDateLike(trimmed)) {
         const ambig = parseAmbiguousNumericDate(trimmed);
         if (ambig !== null) {
           rowInfo.push({ mode: 'date', ambiguous: ambig });
@@ -758,7 +758,7 @@ function roundTable(table, options) {
           const parsed = parseDateLike(trimmed);
           rowInfo.push({ mode: 'date', month: parsed.month, day: parsed.day, year: parsed.year });
         }
-      } else if (opts.excludeTimes === false && isTimeLike(trimmed)) {
+      } else if (opts.simplifyTimes && isTimeLike(trimmed)) {
         rowInfo.push({ mode: 'time' });
       } else {
         const num = toNumber(text);
@@ -1002,8 +1002,6 @@ function getExclusionReason(text, columnIndex, options, rowIndex) {
   if (options.excludeFirstColumn && columnIndex === 0) return 'firstColumn';
   if (typeof text !== 'string') return null;
   const t = text.trim();
-  if (options.excludeDates && isDateLike(t)) return 'dates';
-  if (options.excludeTimes && isTimeLike(t)) return 'times';
   if (!options.includePercent && /%/.test(t)) return 'percent';
   if (!options.includeCurrency && /[$€£¥₹]/.test(t)) return 'currency';
   return null;

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -749,17 +749,25 @@ function roundTable(table, options) {
         rowInfo.push({ mode: 'skip' });
       } else if (isWholeCellQuoted) {
         rowInfo.push({ mode: 'skip' });
-      } else if (opts.simplifyDates && isDateLike(trimmed)) {
-        const ambig = parseAmbiguousNumericDate(trimmed);
-        if (ambig !== null) {
-          rowInfo.push({ mode: 'date', ambiguous: ambig });
+      } else if (isDateLike(trimmed)) {
+        // Date-like cells must never fall through to numeric rounding (a bare
+        // year like "2018" parses as a number). Simplify when the toggle is on,
+        // otherwise leave the cell untouched.
+        if (!opts.simplifyDates) {
+          rowInfo.push({ mode: 'skip' });
         } else {
-          // Unambiguous: parse now and store the resolved fields
-          const parsed = parseDateLike(trimmed);
-          rowInfo.push({ mode: 'date', month: parsed.month, day: parsed.day, year: parsed.year });
+          const ambig = parseAmbiguousNumericDate(trimmed);
+          if (ambig !== null) {
+            rowInfo.push({ mode: 'date', ambiguous: ambig });
+          } else {
+            // Unambiguous: parse now and store the resolved fields
+            const parsed = parseDateLike(trimmed);
+            rowInfo.push({ mode: 'date', month: parsed.month, day: parsed.day, year: parsed.year });
+          }
         }
-      } else if (opts.simplifyTimes && isTimeLike(trimmed)) {
-        rowInfo.push({ mode: 'time' });
+      } else if (isTimeLike(trimmed)) {
+        // Same guard for time-like cells.
+        rowInfo.push(opts.simplifyTimes ? { mode: 'time' } : { mode: 'skip' });
       } else {
         const num = toNumber(text);
         if (num !== null) {

--- a/chrome-extension/defaults.js
+++ b/chrome-extension/defaults.js
@@ -12,8 +12,8 @@ const DR_DEFAULTS = {
   includePercent: true,
   excludeFirstRow: false,
   excludeFirstColumn: false,
-  excludeDates: true,
-  excludeTimes: false,
+  simplifyDates: true,
+  simplifyTimes: false,
   dateGranularity: 'decade',
   timeGranularity: 'hour',
   // Concrete numeric defaults (Variant F UI always sends concrete numbers, never

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -277,7 +277,7 @@
         <option value="century">century</option>
       </select>
       <label class="switch">
-        <input type="checkbox" id="excludeDates">
+        <input type="checkbox" id="simplifyDates">
         <span class="slider"></span>
       </label>
     </div>
@@ -288,7 +288,7 @@
         <option value="minute">minute</option>
       </select>
       <label class="switch">
-        <input type="checkbox" id="excludeTimes">
+        <input type="checkbox" id="simplifyTimes">
         <span class="slider"></span>
       </label>
     </div>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -15,8 +15,8 @@ const CHECKBOX_TO_SETTING = {
   includePercent: 'includePercent',
   excludeFirstRow: 'excludeFirstRow',
   excludeFirstColumn: 'excludeFirstColumn',
-  excludeDates: 'excludeDates',
-  excludeTimes: 'excludeTimes'
+  simplifyDates: 'simplifyDates',
+  simplifyTimes: 'simplifyTimes'
 };
 
 const dateGranularityEl = document.getElementById('dateGranularity');
@@ -264,10 +264,10 @@ function updateDisabledState() {
   // Granularity dropdown only matters when the row's toggle is on
   // (i.e. that type's cells are bucketed by the selected granularity).
   if (dateGranularityEl) {
-    dateGranularityEl.disabled = !document.getElementById('excludeDates').checked;
+    dateGranularityEl.disabled = !document.getElementById('simplifyDates').checked;
   }
   if (timeGranularityEl) {
-    timeGranularityEl.disabled = !document.getElementById('excludeTimes').checked;
+    timeGranularityEl.disabled = !document.getElementById('simplifyTimes').checked;
   }
 }
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -4205,6 +4205,490 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint invert-datetime-pills: simplifyDates / simplifyTimes boolean wiring
+//
+// Acceptance criteria verified here:
+//   AC1: simplifyDates=true  → date cell IS rounded (dr-ext-rounded added, text changed)
+//   AC2: simplifyDates=false → date cell is left UNCHANGED (no class, same text)
+//   AC3: simplifyTimes=true  → time cell IS simplified (dr-ext-rounded added, text changed)
+//   AC4: simplifyTimes=false → time cell is left UNCHANGED
+//   AC5: sidebar.js updateDisabledState wires dateGranularity.disabled to !simplifyDates
+//        and timeGranularity.disabled to !simplifyTimes (static source analysis only —
+//        the test harness has no sidebar DOM path so live execution is not possible).
+// ---------------------------------------------------------------------------
+
+// --- AC1: simplifyDates=true → date cell is rounded ---
+// Use a bare year "2018" with decade granularity: roundDateText("2018","decade")="2020",
+// so the cell text must change and dr-ext-rounded must be added.
+(function invertPills_AC1_simplifyDatesTrue() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+    ]]);
+    const opts = {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: true, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: ''
+    };
+    roundTable(table, opts);
+    const cell = table.rows[0].cells[0];
+    eq('invert-pills AC1: simplifyDates=true — date cell gets dr-ext-rounded class',
+      cell.classList.contains('dr-ext-rounded'), true);
+    eq('invert-pills AC1: simplifyDates=true — date cell text is changed (2018→2020)',
+      cell.innerText, '2020');
+  });
+})();
+
+// --- AC2: simplifyDates=false → date cell is left unchanged ---
+// Same "2018" cell, same decade granularity, but simplifyDates=false.
+// The cell must NOT be rounded — text stays "2018", no class added.
+(function invertPills_AC2_simplifyDatesFalse() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+    ]]);
+    const opts = {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: ''
+    };
+    roundTable(table, opts);
+    const cell = table.rows[0].cells[0];
+    eq('invert-pills AC2: simplifyDates=false — date cell does NOT get dr-ext-rounded',
+      cell.classList.contains('dr-ext-rounded'), false);
+    eq('invert-pills AC2: simplifyDates=false — date cell text is unchanged',
+      cell.innerText, '2018');
+  });
+})();
+
+// AC1/AC2 parity check with ISO date "2024-03-14" (decade granularity → "2020")
+(function invertPills_AC1_AC2_isoDate() {
+  withCreateTreeWalker(function() {
+    // simplifyDates=true branch
+    const tableOn = makeMockTable([[{ tag: 'td', text: '2024-03-14' }]]);
+    roundTable(tableOn, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: true, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cellOn = tableOn.rows[0].cells[0];
+    eq('invert-pills AC1 (ISO date): simplifyDates=true — ISO date rounded',
+      cellOn.classList.contains('dr-ext-rounded'), true);
+  });
+
+  withCreateTreeWalker(function() {
+    // simplifyDates=false branch — same input
+    const tableOff = makeMockTable([[{ tag: 'td', text: '2024-03-14' }]]);
+    roundTable(tableOff, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cellOff = tableOff.rows[0].cells[0];
+    eq('invert-pills AC2 (ISO date): simplifyDates=false — ISO date NOT rounded',
+      cellOff.classList.contains('dr-ext-rounded'), false);
+    eq('invert-pills AC2 (ISO date): simplifyDates=false — ISO date text unchanged',
+      cellOff.innerText, '2024-03-14');
+  });
+})();
+
+// --- AC3: simplifyTimes=true → time cell IS simplified ---
+// "14:30" with hour granularity → roundTimeText returns "15:00" (half-hour rounds up).
+(function invertPills_AC3_simplifyTimesTrue() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '14:30' },
+    ]]);
+    const opts = {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: true,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: ''
+    };
+    roundTable(table, opts);
+    const cell = table.rows[0].cells[0];
+    eq('invert-pills AC3: simplifyTimes=true — time cell gets dr-ext-rounded class',
+      cell.classList.contains('dr-ext-rounded'), true);
+    eq('invert-pills AC3: simplifyTimes=true — time cell text is changed (14:30→15:00)',
+      cell.innerText, '15:00');
+  });
+})();
+
+// --- AC4: simplifyTimes=false → time cell is left UNCHANGED ---
+// Same "14:30" cell; with simplifyTimes=false the cell must stay as-is.
+(function invertPills_AC4_simplifyTimesFalse() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '14:30' },
+    ]]);
+    const opts = {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: ''
+    };
+    roundTable(table, opts);
+    const cell = table.rows[0].cells[0];
+    eq('invert-pills AC4: simplifyTimes=false — time cell does NOT get dr-ext-rounded',
+      cell.classList.contains('dr-ext-rounded'), false);
+    eq('invert-pills AC4: simplifyTimes=false — time cell text is unchanged',
+      cell.innerText, '14:30');
+  });
+})();
+
+// AC3/AC4 parity check with "3:45 PM" (hour granularity → "4:00 PM")
+(function invertPills_AC3_AC4_twelveHour() {
+  withCreateTreeWalker(function() {
+    // simplifyTimes=true
+    const tableOn = makeMockTable([[{ tag: 'td', text: '3:45 PM' }]]);
+    roundTable(tableOn, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: true,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cellOn = tableOn.rows[0].cells[0];
+    eq('invert-pills AC3 (12-hr): simplifyTimes=true — "3:45 PM" rounded',
+      cellOn.classList.contains('dr-ext-rounded'), true);
+    eq('invert-pills AC3 (12-hr): simplifyTimes=true — text changed to "4:00 PM"',
+      cellOn.innerText, '4:00 PM');
+  });
+
+  withCreateTreeWalker(function() {
+    // simplifyTimes=false — same input must be untouched
+    const tableOff = makeMockTable([[{ tag: 'td', text: '3:45 PM' }]]);
+    roundTable(tableOff, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cellOff = tableOff.rows[0].cells[0];
+    eq('invert-pills AC4 (12-hr): simplifyTimes=false — "3:45 PM" NOT rounded',
+      cellOff.classList.contains('dr-ext-rounded'), false);
+    eq('invert-pills AC4 (12-hr): simplifyTimes=false — text unchanged',
+      cellOff.innerText, '3:45 PM');
+  });
+})();
+
+// --- AC5: sidebar.js updateDisabledState wires granularity dropdowns to toggles ---
+// The harness has no live sidebar DOM, so we verify via static source analysis.
+// We assert:
+//   (a) updateDisabledState references dateGranularity.disabled and !simplifyDates
+//   (b) updateDisabledState references timeGranularity.disabled and !simplifyTimes
+// This proves the boolean is wired the correct way round in the sidebar source.
+(function invertPills_AC5_sidebarDisabledStateStaticAnalysis() {
+  const sidebarSrc = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
+
+  // dateGranularity.disabled must be set to !simplifyDates (true when OFF, false when ON)
+  eq('invert-pills AC5: sidebar.js sets dateGranularity.disabled = !simplifyDates',
+    /dateGranularityEl\.disabled\s*=\s*!document\.getElementById\(['"]simplifyDates['"]\)\.checked/.test(sidebarSrc),
+    true);
+
+  // timeGranularity.disabled must be set to !simplifyTimes
+  eq('invert-pills AC5: sidebar.js sets timeGranularity.disabled = !simplifyTimes',
+    /timeGranularityEl\.disabled\s*=\s*!document\.getElementById\(['"]simplifyTimes['"]\)\.checked/.test(sidebarSrc),
+    true);
+
+  // updateDisabledState function must still exist (not deleted or renamed)
+  eq('invert-pills AC5: sidebar.js defines updateDisabledState',
+    /function updateDisabledState\b/.test(sidebarSrc), true);
+})();
+
+// --- Old keys (excludeDates / excludeTimes) must be absent from content.js and defaults.js ---
+// These were renamed to simplifyDates/simplifyTimes in this sprint.
+// If the old names are still present as property assignments or conditions, the
+// inversion is incomplete and rounding behaviour would be controlled by the wrong key.
+(function invertPills_oldKeysAbsent() {
+  const contentSrc = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+  const defaultsSrc = fs.readFileSync(path.join(__dirname, 'defaults.js'), 'utf8');
+  const sidebarSrc  = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
+
+  // "excludeDates" and "excludeTimes" must not appear as identifiers in any of these files.
+  eq('invert-pills regression: content.js does not reference excludeDates',
+    /\bexcludeDates\b/.test(contentSrc), false);
+  eq('invert-pills regression: content.js does not reference excludeTimes',
+    /\bexcludeTimes\b/.test(contentSrc), false);
+  eq('invert-pills regression: defaults.js does not reference excludeDates',
+    /\bexcludeDates\b/.test(defaultsSrc), false);
+  eq('invert-pills regression: defaults.js does not reference excludeTimes',
+    /\bexcludeTimes\b/.test(defaultsSrc), false);
+  eq('invert-pills regression: sidebar.js does not reference excludeDates',
+    /\bexcludeDates\b/.test(sidebarSrc), false);
+  eq('invert-pills regression: sidebar.js does not reference excludeTimes',
+    /\bexcludeTimes\b/.test(sidebarSrc), false);
+
+  // Conversely, simplifyDates and simplifyTimes MUST appear in each file.
+  eq('invert-pills regression: content.js references simplifyDates',
+    /\bsimplifyDates\b/.test(contentSrc), true);
+  eq('invert-pills regression: content.js references simplifyTimes',
+    /\bsimplifyTimes\b/.test(contentSrc), true);
+  eq('invert-pills regression: defaults.js references simplifyDates',
+    /\bsimplifyDates\b/.test(defaultsSrc), true);
+  eq('invert-pills regression: defaults.js references simplifyTimes',
+    /\bsimplifyTimes\b/.test(defaultsSrc), true);
+  eq('invert-pills regression: sidebar.js references simplifyDates',
+    /\bsimplifyDates\b/.test(sidebarSrc), true);
+  eq('invert-pills regression: sidebar.js references simplifyTimes',
+    /\bsimplifyTimes\b/.test(sidebarSrc), true);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint invert-datetime-pills: adversarial tests
+//
+// These tests are written from the SPEC, not the implementation.
+// Adversarial focus: prove the boolean polarity is correct (true=simplify,
+// false=leave alone) across a wider set of inputs and combinations that the
+// developer's own tests did not exercise.
+// ---------------------------------------------------------------------------
+
+// --- ADV-AC1: century granularity also works when simplifyDates=true ---
+// A different granularity than the developer tested (decade) to ensure the
+// boolean wiring is not granularity-specific.
+(function invertPills_adv_AC1_century() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: true, simplifyTimes: false,
+      dateGranularity: 'century', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cell = table.rows[0].cells[0];
+    eq('ADV AC1 (century): simplifyDates=true — 2018 rounded to 2000',
+      cell.innerText, '2000');
+    eq('ADV AC1 (century): simplifyDates=true — cell gets dr-ext-rounded',
+      cell.classList.contains('dr-ext-rounded'), true);
+  });
+})();
+
+// --- ADV-AC2: century granularity, simplifyDates=false — year must NOT be rounded ---
+// Adversarial: if the implementation only guards the decade path, century would leak.
+(function invertPills_adv_AC2_century() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'century', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cell = table.rows[0].cells[0];
+    eq('ADV AC2 (century): simplifyDates=false — cell does NOT get dr-ext-rounded',
+      cell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV AC2 (century): simplifyDates=false — text unchanged (2018)',
+      cell.innerText, '2018');
+  });
+})();
+
+// --- ADV-AC2: mixed table — date cell left alone while numeric cell rounds ---
+// A date-like year appears alongside a large number.
+// simplifyDates=false: the year must not be rounded even though max_mag is
+// computed from the real number in the same table.
+(function invertPills_adv_AC2_mixedTable() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+      { tag: 'td', text: '8,584,629' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const dateCell = table.rows[0].cells[0];
+    eq('ADV AC2 (mixed): simplifyDates=false — date cell NOT rounded even with large sibling',
+      dateCell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV AC2 (mixed): simplifyDates=false — date cell text unchanged (2018)',
+      dateCell.innerText, '2018');
+    // Numeric cell SHOULD still be rounded (control: proves roundTable ran)
+    const numCell = table.rows[0].cells[1];
+    eq('ADV AC2 (mixed): numeric sibling 8,584,629 IS rounded (control)',
+      numCell.classList.contains('dr-ext-rounded'), true);
+  });
+})();
+
+// --- ADV-AC3/AC4: isolation — simplifyTimes=true with simplifyDates=false ---
+// Time cell must be simplified; a date cell in the same row must be left alone.
+// This catches any incorrect coupling between the two boolean flags.
+(function invertPills_adv_AC3_timesOnDatesOff() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '14:30' },
+      { tag: 'td', text: '2018' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: true,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const timeCell = table.rows[0].cells[0];
+    const dateCell = table.rows[0].cells[1];
+    eq('ADV AC3/AC4 isolation: simplifyTimes=true — time cell IS rounded',
+      timeCell.classList.contains('dr-ext-rounded'), true);
+    eq('ADV AC3/AC4 isolation: simplifyTimes=true — time cell text changed (14:30→15:00)',
+      timeCell.innerText, '15:00');
+    eq('ADV AC3/AC4 isolation: simplifyDates=false — date cell NOT rounded',
+      dateCell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV AC3/AC4 isolation: simplifyDates=false — date cell text unchanged (2018)',
+      dateCell.innerText, '2018');
+  });
+})();
+
+// --- ADV-AC1/AC4: isolation — simplifyDates=true with simplifyTimes=false ---
+// Date cell must be simplified; a time cell in the same row must be left alone.
+(function invertPills_adv_AC1_datesOnTimesOff() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+      { tag: 'td', text: '14:30' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: true, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const dateCell = table.rows[0].cells[0];
+    const timeCell = table.rows[0].cells[1];
+    eq('ADV AC1/AC4 isolation: simplifyDates=true — date cell IS rounded',
+      dateCell.classList.contains('dr-ext-rounded'), true);
+    eq('ADV AC1/AC4 isolation: simplifyDates=true — date cell text changed (2018→2020)',
+      dateCell.innerText, '2020');
+    eq('ADV AC4/AC1 isolation: simplifyTimes=false — time cell NOT rounded',
+      timeCell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV AC4/AC1 isolation: simplifyTimes=false — time cell text unchanged (14:30)',
+      timeCell.innerText, '14:30');
+  });
+})();
+
+// --- ADV-AC4: time cell with simplifyTimes=false is not treated as a pure number ---
+// "14:30" is not parseable by toNumber (returns null), so with simplifyTimes=false
+// AND includeWords=false, the cell must be fully skipped.
+// Adversarial: confirm there is no fallthrough that rounds the time as a numeric value.
+// (Note: includeWords=true would extract 14 and 30 independently — that is a separate
+// feature path. Here we test the pure numeric exclusion path only.)
+(function invertPills_adv_AC4_timeNotTreatedAsNumber() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '14:30' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const cell = table.rows[0].cells[0];
+    eq('ADV AC4: 14:30 with simplifyTimes=false and includeWords=false — not rounded',
+      cell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV AC4: 14:30 with simplifyTimes=false and includeWords=false — text unchanged',
+      cell.innerText, '14:30');
+  });
+})();
+
+// --- ADV: DR_DEFAULTS has correct polarity ---
+// simplifyDates must default to true (simplify by default).
+// simplifyTimes must default to false (do not simplify by default).
+// This is the direct spec requirement for the "inverted" rename: the default
+// behavior (dates simplified, times not) must be encoded correctly.
+(function invertPills_adv_defaults() {
+  eq('ADV defaults: DR_DEFAULTS.simplifyDates is true (dates simplified by default)',
+    DR_DEFAULTS.simplifyDates, true);
+  eq('ADV defaults: DR_DEFAULTS.simplifyTimes is false (times not simplified by default)',
+    DR_DEFAULTS.simplifyTimes, false);
+  // Old keys must be absent from DR_DEFAULTS
+  eq('ADV defaults: DR_DEFAULTS has no excludeDates key',
+    Object.prototype.hasOwnProperty.call(DR_DEFAULTS, 'excludeDates'), false);
+  eq('ADV defaults: DR_DEFAULTS has no excludeTimes key',
+    Object.prototype.hasOwnProperty.call(DR_DEFAULTS, 'excludeTimes'), false);
+})();
+
+// --- ADV-AC1/AC3: both simplifyDates=true and simplifyTimes=true — both simplified ---
+// Confirm both flags can be active simultaneously without one suppressing the other.
+(function invertPills_adv_bothTrue() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+      { tag: 'td', text: '14:30' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: true, simplifyTimes: true,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const dateCell = table.rows[0].cells[0];
+    const timeCell = table.rows[0].cells[1];
+    eq('ADV both=true: date cell IS rounded (2018→2020)',
+      dateCell.classList.contains('dr-ext-rounded'), true);
+    eq('ADV both=true: date cell text changed to 2020',
+      dateCell.innerText, '2020');
+    eq('ADV both=true: time cell IS rounded (14:30→15:00)',
+      timeCell.classList.contains('dr-ext-rounded'), true);
+    eq('ADV both=true: time cell text changed to 15:00',
+      timeCell.innerText, '15:00');
+  });
+})();
+
+// --- ADV-AC2/AC4: both simplifyDates=false and simplifyTimes=false — neither simplified ---
+// The fully-off state: no date or time cell gets rounded.
+(function invertPills_adv_bothFalse() {
+  withCreateTreeWalker(function() {
+    const table = makeMockTable([[
+      { tag: 'td', text: '2018' },
+      { tag: 'td', text: '14:30' },
+    ]]);
+    roundTable(table, {
+      enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
+      excludeFirstRow: false, excludeFirstColumn: false,
+      simplifyDates: false, simplifyTimes: false,
+      dateGranularity: 'decade', timeGranularity: 'hour',
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1, rangeExpr: ''
+    });
+    const dateCell = table.rows[0].cells[0];
+    const timeCell = table.rows[0].cells[1];
+    eq('ADV both=false: date cell NOT rounded',
+      dateCell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV both=false: date cell text unchanged (2018)',
+      dateCell.innerText, '2018');
+    eq('ADV both=false: time cell NOT rounded',
+      timeCell.classList.contains('dr-ext-rounded'), false);
+    eq('ADV both=false: time cell text unchanged (14:30)',
+      timeCell.innerText, '14:30');
+  });
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -372,7 +372,7 @@ eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
 
 (function exclusionFirstColumn() {
   const opts = Object.assign({}, {
-    excludeWords: true, excludeDates: false, excludeTimes: false,
+    excludeWords: true, simplifyDates: false, simplifyTimes: false,
     excludeFirstColumn: true, excludePercent: false, excludeCurrency: false
   });
   eq('exclude: first column with flag on', getExclusionReason('anything', 0, opts), 'firstColumn');
@@ -380,18 +380,22 @@ eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
 })();
 
 (function exclusionDates() {
-  const opts = { excludeDates: true };
-  eq('exclude: year cell when excludeDates=true',
-    getExclusionReason('2018', 1, opts), 'dates');
-  eq('exclude: non-date cell when excludeDates=true',
+  // Dates/times are no longer exclusion reasons — getExclusionReason never returns
+  // 'dates' or 'times' regardless of simplifyDates/simplifyTimes setting.
+  const opts = { simplifyDates: true };
+  eq('exclude: year cell with simplifyDates=true is NOT excluded (returns null)',
+    getExclusionReason('2018', 1, opts), null);
+  eq('exclude: non-date cell with simplifyDates=true returns null',
     getExclusionReason('1,234', 1, opts), null);
-  eq('exclude: year cell when excludeDates=false',
-    getExclusionReason('2018', 1, { excludeDates: false }), null);
+  eq('exclude: year cell with simplifyDates=false is NOT excluded (returns null)',
+    getExclusionReason('2018', 1, { simplifyDates: false }), null);
 })();
 
 (function exclusionTimes() {
-  eq('exclude: time cell when excludeTimes=true',
-    getExclusionReason('14:30', 1, { excludeTimes: true }), 'times');
+  // Times are no longer an exclusion reason — simplifyTimes only controls the
+  // classification pass, not getExclusionReason.
+  eq('exclude: time cell with simplifyTimes=true is NOT excluded (returns null)',
+    getExclusionReason('14:30', 1, { simplifyTimes: true }), null);
 })();
 
 (function exclusionPercent() {
@@ -495,18 +499,19 @@ eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
     getExclusionReason('45%', 1, {}), 'percent');
 })();
 
-// First-match-wins priority: firstRow beats firstColumn beats dates beats times beats percent beats currency
+// First-match-wins priority: firstRow beats firstColumn beats percent beats currency
+// (dates/times are no longer exclusion reasons)
 (function exclusionPriority() {
   const opts = {
-    excludeFirstRow: true, excludeFirstColumn: true, excludeDates: true, excludeTimes: true,
+    excludeFirstRow: true, excludeFirstColumn: true, simplifyDates: true, simplifyTimes: true,
     includePercent: false, includeCurrency: false
   };
   eq('priority: first row wins even when value is a date',
     getExclusionReason('2018', 0, opts, 0), 'firstRow');
   eq('priority: first column wins even when value is a date (non-zero row)',
     getExclusionReason('2018', 0, opts, 1), 'firstColumn');
-  eq('priority: dates beats percent for a year value',
-    getExclusionReason('2018', 1, opts, 1), 'dates');
+  eq('priority: year value not excluded when only first-row/col flags set (dates no longer excluded)',
+    getExclusionReason('2018', 1, opts, 1), null);
 })();
 
 // --- Sprint B: per-type granularity ---
@@ -878,7 +883,7 @@ function withCreateTreeWalker(fn) {
       { tag: 'td', text: '200'  },
     ]]);
     const opts = {
-      enabled: true, excludeWords: true, excludeDates: true, excludeTimes: true,
+      enabled: true, excludeWords: true, simplifyDates: false, simplifyTimes: false,
       excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: 'A'
@@ -907,7 +912,7 @@ function withCreateTreeWalker(fn) {
       { tag: 'td', text: '200'   },
     ]]);
     const opts = {
-      enabled: true, excludeWords: true, excludeDates: true, excludeTimes: true,
+      enabled: true, excludeWords: true, simplifyDates: false, simplifyTimes: false,
       excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: 'A'
@@ -934,7 +939,7 @@ function withCreateTreeWalker(fn) {
       { tag: 'td', text: '200'  },
     ]]);
     const opts = {
-      enabled: true, excludeWords: true, excludeDates: false, excludeTimes: false,
+      enabled: true, excludeWords: true, simplifyDates: true, simplifyTimes: true,
       excludeFirstColumn: true, excludePercent: false, excludeCurrency: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: ''
@@ -1195,7 +1200,7 @@ function withLinkCreateTreeWalker(fn) {
       dataset: {},
     };
     const opts = {
-      enabled: true, excludeWords: true, excludeDates: true, excludeTimes: true,
+      enabled: true, excludeWords: true, simplifyDates: false, simplifyTimes: false,
       excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: '',
@@ -1280,7 +1285,7 @@ function withLinkCreateTreeWalker(fn) {
       dataset: {},
     };
     const opts = {
-      enabled: true, excludeWords: true, excludeDates: true, excludeTimes: true,
+      enabled: true, excludeWords: true, simplifyDates: false, simplifyTimes: false,
       excludeFirstColumn: false, includePercent: false, includeCurrency: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: '',
@@ -1400,7 +1405,7 @@ function withLinkCreateTreeWalker(fn) {
       { tag: 'td', text: '42' },  // this one should round (control)
     ]]);
     const opts = {
-      enabled: true, includeWords: true, excludeDates: false, excludeTimes: false,
+      enabled: true, includeWords: true, simplifyDates: false, simplifyTimes: false,
       excludeFirstColumn: false, includePercent: true, includeCurrency: true,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: ''
@@ -1664,7 +1669,7 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     const opts = {
       enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
       excludeFirstRow: false, excludeFirstColumn: false,
-      excludeDates: true, excludeTimes: true,
+      simplifyDates: false, simplifyTimes: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: ''
     };
@@ -1686,7 +1691,7 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     const opts = {
       enabled: true, includeWords: false, includeCurrency: false, includePercent: false,
       excludeFirstRow: false, excludeFirstColumn: false,
-      excludeDates: true, excludeTimes: true,
+      simplifyDates: false, simplifyTimes: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: ''
     };
@@ -2808,7 +2813,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       const tbl = makeMockTable([[{ tag: 'td', text }]]);
       tbl.rows[0].cells[0].querySelectorAll = () => [];
       roundTable(tbl, {
-        enabled: true, excludeDates: false, excludeTimes: true,
+        enabled: true, simplifyDates: true, simplifyTimes: false,
         excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
         includeWords: false, excludeFirstRow: false,
         offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
@@ -2835,7 +2840,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       const tbl = makeMockTable([[{ tag: 'td', text: cellText }]]);
       tbl.rows[0].cells[0].querySelectorAll = () => [];
       roundTable(tbl, {
-        enabled: true, excludeDates: false, excludeTimes: true,
+        enabled: true, simplifyDates: true, simplifyTimes: false,
         excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
         includeWords: false, excludeFirstRow: false,
         offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
@@ -2885,7 +2890,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 (function dateRoundColumnAutoDetect() {
   withCreateTreeWalker(function() {
 
-    // Helper: run roundTable with excludeDates:false and return cell text array.
+    // Helper: run roundTable with simplifyDates:true and return cell text array.
     function runDateTable(rowsSpec, gran) {
       const tbl = makeMockTable(rowsSpec);
       // Add querySelectorAll stub to all cells
@@ -2895,7 +2900,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
         }
       }
       roundTable(tbl, {
-        enabled: true, excludeDates: false, excludeTimes: true,
+        enabled: true, simplifyDates: true, simplifyTimes: false,
         excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
         includeWords: false, excludeFirstRow: false,
         offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
@@ -2958,7 +2963,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       const tbl = makeMockTable([[{ tag: 'td', text }]]);
       tbl.rows[0].cells[0].querySelectorAll = () => [];
       roundTable(tbl, {
-        enabled: true, excludeDates: false, excludeTimes: true,
+        enabled: true, simplifyDates: true, simplifyTimes: false,
         excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
         includeWords: false, excludeFirstRow: false,
         offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
@@ -2975,7 +2980,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     const tbl = makeMockTable([[{ tag: 'td', text: '14 March' }]]);
     tbl.rows[0].cells[0].querySelectorAll = () => [];
     roundTable(tbl, {
-      enabled: true, excludeDates: false, excludeTimes: true,
+      enabled: true, simplifyDates: true, simplifyTimes: false,
       excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
       includeWords: false, excludeFirstRow: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
@@ -3002,7 +3007,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     const tbl = makeMockTable([[{ tag: 'td', text: '2020' }]]);
     tbl.rows[0].cells[0].querySelectorAll = () => [];
     roundTable(tbl, {
-      enabled: true, excludeDates: false, excludeTimes: true,
+      enabled: true, simplifyDates: true, simplifyTimes: false,
       excludeFirstColumn: false, excludePercent: false, excludeCurrency: false,
       includeWords: false, excludeFirstRow: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
@@ -4062,10 +4067,10 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     DR_DEFAULTS.includeCurrency, true);
   eq('sidebar-tidyup AC3: DR_DEFAULTS.includePercent is true',
     DR_DEFAULTS.includePercent, true);
-  eq('sidebar-tidyup AC3: DR_DEFAULTS.excludeDates is true',
-    DR_DEFAULTS.excludeDates, true);
-  eq('sidebar-tidyup AC3: DR_DEFAULTS.excludeTimes is false',
-    DR_DEFAULTS.excludeTimes, false);
+  eq('sidebar-tidyup AC3: DR_DEFAULTS.simplifyDates is true',
+    DR_DEFAULTS.simplifyDates, true);
+  eq('sidebar-tidyup AC3: DR_DEFAULTS.simplifyTimes is false',
+    DR_DEFAULTS.simplifyTimes, false);
   eq('sidebar-tidyup AC3: DR_DEFAULTS.excludeFirstRow is false',
     DR_DEFAULTS.excludeFirstRow, false);
   eq('sidebar-tidyup AC3: DR_DEFAULTS.excludeFirstColumn is false',
@@ -4080,7 +4085,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   // element with class "switch" enclosing the input.
   const optionInputIds = [
     'includeWords', 'includeCurrency', 'includePercent',
-    'excludeDates', 'excludeTimes', 'excludeFirstRow', 'excludeFirstColumn'
+    'simplifyDates', 'simplifyTimes', 'excludeFirstRow', 'excludeFirstColumn'
   ];
   for (const id of optionInputIds) {
     // Match <label class="switch"> ... <input ... id="<id>"> ... </label>

--- a/docs/sprint-logs/pill-exponent-rebind-invert-datetime-pills.md
+++ b/docs/sprint-logs/pill-exponent-rebind-invert-datetime-pills.md
@@ -1,0 +1,23 @@
+# Sprint Log: invert-datetime-pills
+
+**Plan:** docs/sprint-plans/pill-exponent-rebind.md
+**Sprint goal:** Make the `dates`/`times` sidebar toggles mean "simplify this type (and enable its granularity dropdown)" instead of "exclude it."
+**Date:** 2026-06-05
+**Result:** Completed
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Renamed `excludeDates`/`excludeTimes` → `simplifyDates`/`simplifyTimes` across `defaults.js` (new defaults `simplifyDates: true`, `simplifyTimes: false`), `sidebar.html` (checkbox ids), `sidebar.js` (`CHECKBOX_TO_SETTING` + `updateDisabledState`), and `content.js` (classification branches inverted to truthy `simplify*`; date/time exclusion branches removed from `getExclusionReason`). Renamed stale key references in `tests.js`.
+- **Tests:** adversarial pass added 9 blocks / 20 assertions covering the four toggle-polarity criteria. Result: 10 failures.
+- **Reviewer verdict:** BLOCK
+- **Reviewer notes:** Removing the date/time branches from `getExclusionReason` while only simplifying on a truthy flag left a gap: with `simplifyDates: false` a date-like cell (e.g. bare year `"2018"`) fell through to the numeric branch and was rounded to `"2,000"`. Date/time cells must be skipped when their toggle is off, never treated as plain numbers.
+
+### Attempt 2
+- **Developer (orchestrator fix):** In `content.js` `roundTable`, detect date-like / time-like cells *unconditionally*; simplify when the toggle is on, otherwise push `mode: 'skip'`. Guarantees date/time cells never reach numeric rounding regardless of toggle state.
+- **Tests:** `node chrome-extension/tests.js` → **663 passed, 0 failed** (including all adversarial cases from attempt 1).
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:** AC5 (sidebar dropdown disabled-state) is verified by static source assertion only — the Node harness has no live sidebar DOM. Acceptable; matches the existing sidebar test convention.
+
+## PR
+(opened to main — see PR link in run summary)


### PR DESCRIPTION
Plan: docs/sprint-plans/pill-exponent-rebind.md

Inverts and renames the date/time controls: `excludeDates`/`excludeTimes` -> `simplifyDates`/`simplifyTimes`. Toggle on = simplify that type and enable its granularity dropdown; toggle off = leave those cells untouched. New defaults: `simplifyDates: true`, `simplifyTimes: false`.

## Acceptance criteria
- [x] With `simplifyDates: true`, a date cell is rounded to the chosen granularity; the dropdown is enabled.
- [x] With `simplifyDates: false`, the date cell is unchanged and the dropdown disabled (symmetric for times).
- [x] No `excludeDates`/`excludeTimes` remains in `chrome-extension/` or `tests.js`.
- [x] `node chrome-extension/tests.js` passes (663 passed, 0 failed).

## Reviewer notes
Adversarial tests caught a regression: with `simplifyDates: false`, a bare-year cell (e.g. `2018`) fell through to numeric rounding. Fixed by detecting date/time-like cells unconditionally and skipping them when their toggle is off. AC for the sidebar dropdown disabled-state is covered by static source assertion (the Node harness has no live sidebar DOM).