### PR TITLE
Move sidebar option toggles to the left of their labels

### DIFF
--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -80,7 +80,6 @@
     .toggle-row {
       display: flex;
       align-items: center;
-      justify-content: space-between;
       gap: 8px;
       padding: 5px 0;
     }
@@ -249,62 +248,62 @@
 
   <div class="section" id="optionsSection">
     <div class="toggle-row">
-      <span class="toggle-label">words</span>
       <label class="switch">
         <input type="checkbox" id="includeWords">
         <span class="slider"></span>
       </label>
+      <span class="toggle-label">words</span>
     </div>
     <div class="toggle-row">
-      <span class="toggle-label">currencies</span>
       <label class="switch">
         <input type="checkbox" id="includeCurrency">
         <span class="slider"></span>
       </label>
+      <span class="toggle-label">currencies</span>
     </div>
     <div class="toggle-row">
-      <span class="toggle-label">percentages</span>
       <label class="switch">
         <input type="checkbox" id="includePercent">
         <span class="slider"></span>
       </label>
+      <span class="toggle-label">percentages</span>
     </div>
     <div class="toggle-row">
+      <label class="switch">
+        <input type="checkbox" id="excludeDates">
+        <span class="slider"></span>
+      </label>
       <span class="toggle-label">dates</span>
       <select id="dateGranularity" disabled>
         <option value="year">year</option>
         <option value="decade">decade</option>
         <option value="century">century</option>
       </select>
-      <label class="switch">
-        <input type="checkbox" id="excludeDates">
-        <span class="slider"></span>
-      </label>
     </div>
     <div class="toggle-row">
+      <label class="switch">
+        <input type="checkbox" id="excludeTimes">
+        <span class="slider"></span>
+      </label>
       <span class="toggle-label">times</span>
       <select id="timeGranularity" disabled>
         <option value="hour">hour</option>
         <option value="minute">minute</option>
       </select>
-      <label class="switch">
-        <input type="checkbox" id="excludeTimes">
-        <span class="slider"></span>
-      </label>
     </div>
     <div class="toggle-row">
-      <span class="toggle-label">first row</span>
       <label class="switch">
         <input type="checkbox" id="excludeFirstRow">
         <span class="slider"></span>
       </label>
+      <span class="toggle-label">first row</span>
     </div>
     <div class="toggle-row">
-      <span class="toggle-label">first column</span>
       <label class="switch">
         <input type="checkbox" id="excludeFirstColumn">
         <span class="slider"></span>
       </label>
+      <span class="toggle-label">first column</span>
     </div>
   </div>
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -4200,6 +4200,110 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 
 })();
 
+// =============================================================================
+// Sprint sidebar-pill-left: toggle switch appears left of label in every row
+// =============================================================================
+//
+// Acceptance criteria:
+//   AC1. In every option row the switch (<label class="switch">) comes before
+//        the .toggle-label text node — verified by comparing indexOf positions
+//        of the checkbox <input> vs <span class="toggle-label"> within each row.
+//   AC2. On the dates/times rows the <select id="dateGranularity"> /
+//        <select id="timeGranularity"> is the last element — its index appears
+//        AFTER the .toggle-label in the row substring.
+//   AC3. sidebar.html does NOT contain "row-reverse" anywhere.
+//   AC4. The .toggle-row CSS block does NOT contain "justify-content: space-between".
+
+(function sidebarPillLeft() {
+  const sidebarPath = path.join(__dirname, 'sidebar.html');
+  const sidebarHtml = fs.readFileSync(sidebarPath, 'utf8');
+
+  // Helper: extract the substring of sidebarHtml that covers the .toggle-row
+  // whose checkbox has the given id. We find the opening <div class="toggle-row">
+  // that contains id="<rowId>" and slice up to the matching </div>.
+  function getRowSubstring(rowId) {
+    // Find the checkbox input for this id within the full source.
+    const inputPattern = new RegExp('id=["\']' + rowId + '["\']');
+    const inputIdx = sidebarHtml.search(inputPattern);
+    if (inputIdx === -1) return null;
+
+    // Walk backwards to the nearest <div class="toggle-row"> opening tag.
+    const beforeInput = sidebarHtml.slice(0, inputIdx);
+    const divStart = beforeInput.lastIndexOf('<div class="toggle-row">');
+    if (divStart === -1) return null;
+
+    // Walk forwards to find the matching closing </div>.
+    // We look for the first </div> that closes the outermost .toggle-row div.
+    const fromDiv = sidebarHtml.slice(divStart);
+    // Scan for the first </div> after the opening tag (these rows have no nested divs).
+    const closeIdx = fromDiv.indexOf('</div>');
+    if (closeIdx === -1) return null;
+
+    return fromDiv.slice(0, closeIdx + '</div>'.length);
+  }
+
+  // --- AC1: switch appears before .toggle-label in each option row ---
+  // Rows to check: includeWords, excludeFirstColumn (simple), excludeDates, excludeTimes.
+  const simpleRows = ['includeWords', 'excludeFirstColumn'];
+  for (const id of simpleRows) {
+    const row = getRowSubstring(id);
+    eq(`sidebar-pill-left AC1: row "${id}" exists in sidebar.html`,
+      row !== null, true);
+    if (row !== null) {
+      const inputIdx = row.search(new RegExp('id=["\']' + id + '["\']'));
+      const labelIdx = row.indexOf('<span class="toggle-label">');
+      eq(`sidebar-pill-left AC1: switch input comes before .toggle-label in row "${id}"`,
+        inputIdx < labelIdx, true);
+    }
+  }
+
+  // Also check the date and time rows (they have a <select> too).
+  const complexRows = ['excludeDates', 'excludeTimes'];
+  for (const id of complexRows) {
+    const row = getRowSubstring(id);
+    eq(`sidebar-pill-left AC1: row "${id}" exists in sidebar.html`,
+      row !== null, true);
+    if (row !== null) {
+      const inputIdx = row.search(new RegExp('id=["\']' + id + '["\']'));
+      const labelIdx = row.indexOf('<span class="toggle-label">');
+      eq(`sidebar-pill-left AC1: switch input comes before .toggle-label in row "${id}"`,
+        inputIdx < labelIdx, true);
+    }
+  }
+
+  // --- AC2: <select> is the last element (after .toggle-label) in dates/times rows ---
+  const selectPairs = [
+    { rowId: 'excludeDates',  selectId: 'dateGranularity' },
+    { rowId: 'excludeTimes',  selectId: 'timeGranularity' },
+  ];
+  for (const { rowId, selectId } of selectPairs) {
+    const row = getRowSubstring(rowId);
+    if (row !== null) {
+      const labelIdx  = row.indexOf('<span class="toggle-label">');
+      const selectIdx = row.search(new RegExp('<select[^>]*id=["\']' + selectId + '["\']'));
+      eq(`sidebar-pill-left AC2: <select id="${selectId}"> appears after .toggle-label in row`,
+        selectIdx > labelIdx, true);
+    }
+  }
+
+  // --- AC3: sidebar.html does not use row-reverse ---
+  eq('sidebar-pill-left AC3: sidebar.html does not contain "row-reverse"',
+    sidebarHtml.includes('row-reverse'), false);
+
+  // --- AC4: .toggle-row CSS block does not use justify-content: space-between ---
+  // Find the .toggle-row block by locating ".toggle-row {" and scanning to the closing "}".
+  const toggleRowBlockStart = sidebarHtml.indexOf('.toggle-row {');
+  eq('sidebar-pill-left AC4: .toggle-row CSS block is present in sidebar.html',
+    toggleRowBlockStart !== -1, true);
+  if (toggleRowBlockStart !== -1) {
+    const fromBlock = sidebarHtml.slice(toggleRowBlockStart);
+    const blockClose = fromBlock.indexOf('}');
+    const toggleRowBlock = blockClose !== -1 ? fromBlock.slice(0, blockClose + 1) : fromBlock.slice(0, 200);
+    eq('sidebar-pill-left AC4: .toggle-row CSS block does not contain "justify-content: space-between"',
+      toggleRowBlock.includes('justify-content: space-between'), false);
+  }
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/docs/sprint-logs/pill-exponent-rebind-sidebar-pill-left.md
+++ b/docs/sprint-logs/pill-exponent-rebind-sidebar-pill-left.md
@@ -1,0 +1,17 @@
+# Sprint Log: sidebar-pill-left
+
+**Plan:** docs/sprint-plans/pill-exponent-rebind.md
+**Sprint goal:** Render each sidebar option's toggle switch to the left of its label (checkbox position).
+**Date:** 2026-06-05
+**Result:** Completed
+
+## Attempts
+
+### Attempt 1
+- **Developer:** `chrome-extension/sidebar.html` only. Reordered all 7 `#optionsSection` `.toggle-row`s so `<label class="switch">` precedes `.toggle-label`; on the `dates`/`times` rows kept the granularity `<select>` as the last child (switch · label · select). Removed `justify-content: space-between` from `.toggle-row`, relying on `.toggle-label { flex-grow: 1 }` to fill width and push the select right. No element ids changed; master `enabled` switch untouched. No `flex-direction: row-reverse`.
+- **Tests:** adversarial source-structure block added (13 assertions): switch-before-label per row, select-after-label on date/time rows, no `row-reverse`, no `space-between`. Result: **617 passed, 0 failed**.
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:** Pure presentation change; verified by source-structure assertions (the Node harness has no live sidebar DOM). Branch is off `main`, so it carries the pre-rename ids `excludeDates`/`excludeTimes`; the `invert-datetime-pills` sprint renames these on its own branch. A merge conflict in `sidebar.html` between the two is expected and is the user's to resolve at merge time (per plan's decoupling note).
+
+## PR
+(opened to main — see PR link in run summary)


### PR DESCRIPTION
Plan: docs/sprint-plans/pill-exponent-rebind.md

Layout-only change in `chrome-extension/sidebar.html`: each option row now places its toggle switch before the label (checkbox position). The granularity `<select>` on the dates/times rows stays right-aligned. No ids changed; master `enabled` switch untouched.

## Acceptance criteria
- [x] In all option rows the switch appears left of the label.
- [x] On the dates/times rows the granularity dropdown remains right-aligned.
- [x] Element ids unchanged; `node chrome-extension/tests.js` passes (617 passed, 0 failed).

## Reviewer notes
Presentation-only; verified via source-structure assertions (13 added). This branch is based on `main` and therefore carries the pre-rename `excludeDates`/`excludeTimes` ids; a `sidebar.html` merge conflict with the `invert-datetime-pills` PR is expected and resolved at merge time.