### PR TITLE
Skip <sup> exponent digits during inline number simplification

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -766,6 +766,29 @@ function roundTable(table, options) {
           // Whole-cell link check: if the entire visible text is inside <a> tags, skip.
           if (isCellWholeLink(cell)) {
             rowInfo.push({ mode: 'skip' });
+          } else if (cell.querySelector && cell.querySelector('sup')) {
+            // The cell contains a <sup> element: the flattened text mixes base and exponent
+            // digits (e.g. "10<sup>12</sup>" -> innerText "1012").  Route through the
+            // inline-extraction path so superscript masking can protect the exponent.
+            if (opts.includeWords) {
+              let matches = extractNumbersInText(text);
+              matches = filterLinkMatches(cell, matches);
+              const quoteRanges = getQuoteMaskedRanges(text);
+              if (quoteRanges.length > 0) {
+                matches = matches.filter(m => !overlapsQuoteRange(quoteRanges, m.index, m.index + m.numStr.length));
+              }
+              const superRanges = getSuperscriptRanges(cell);
+              if (superRanges.length > 0) {
+                matches = matches.filter(m => !overlapsQuoteRange(superRanges, m.index, m.index + m.numStr.length));
+              }
+              if (matches.length > 0) {
+                rowInfo.push({ mode: 'extracted', matches });
+              } else {
+                rowInfo.push({ mode: 'skip' });
+              }
+            } else {
+              rowInfo.push({ mode: 'skip' });
+            }
           } else {
             rowInfo.push({ mode: 'pure', num });
           }
@@ -775,6 +798,10 @@ function roundTable(table, options) {
           const quoteRanges = getQuoteMaskedRanges(text);
           if (quoteRanges.length > 0) {
             matches = matches.filter(m => !overlapsQuoteRange(quoteRanges, m.index, m.index + m.numStr.length));
+          }
+          const superRanges = getSuperscriptRanges(cell);
+          if (superRanges.length > 0) {
+            matches = matches.filter(m => !overlapsQuoteRange(superRanges, m.index, m.index + m.numStr.length));
           }
           if (matches.length > 0) {
             rowInfo.push({ mode: 'extracted', matches });
@@ -1013,6 +1040,7 @@ const MONTH_NAMES = '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-
 
 // Regex constants for date candidate normalization
 const SUPERSCRIPT_DIGITS = '⁰¹²³⁴⁵⁶⁷⁸⁹';
+const SUPERSCRIPT_TAG = 'SUP';
 const FOOTNOTE_MARKERS = '*†‡';
 const DATE_NOISE_CLASS = `[\\s${SUPERSCRIPT_DIGITS}${FOOTNOTE_MARKERS}]`;
 const LEADING_DATE_NOISE_RE = new RegExp(`^${DATE_NOISE_CLASS}+`);
@@ -1239,6 +1267,65 @@ function roundTimeText(text, granularity) {
   if (m[3]) result += ':00';
   result += displayAmpm;
   return result === trimmed ? null : result;
+}
+
+/**
+ * Returns an array of {start, end} half-open index ranges corresponding to text that is
+ * physically inside a <sup> element (or an element whose computed vertical-align is 'super')
+ * within the given cell.  The indices are into the same string the number extractor sees —
+ * the concatenation of all text nodes in document order, which matches cell.textContent
+ * (and cell.innerText for ordinary in-flow content).
+ *
+ * Approach: walk the cell's text nodes via document.createTreeWalker, keeping a running
+ * cursor.  For each text node, if any ancestor up to (but not including) the cell is a
+ * <sup> element (or has verticalAlign 'super'), record {start: cursor, end: cursor + len}.
+ *
+ * Guards:
+ * - If document.createTreeWalker is unavailable, returns [].
+ * - getComputedStyle is only called when typeof getComputedStyle === 'function', so the
+ *   helper never throws in the Node test harness.
+ * @param {Element} cell
+ * @returns {{start: number, end: number}[]}
+ */
+function getSuperscriptRanges(cell) {
+  if (!cell || typeof document === 'undefined' || typeof document.createTreeWalker !== 'function') {
+    return [];
+  }
+  const ranges = [];
+  const treeWalker = document.createTreeWalker(cell, NodeFilter.SHOW_TEXT, null, false);
+  let cursor = 0;
+  let node;
+  while ((node = treeWalker.nextNode())) {
+    const len = node.nodeValue ? node.nodeValue.length : 0;
+    if (len > 0) {
+      // Check if any ancestor up to (not including) cell is a <sup> element.
+      let isSup = false;
+      let ancestor = node.parentNode || node.parentElement;
+      while (ancestor && ancestor !== cell) {
+        if (ancestor.tagName === SUPERSCRIPT_TAG) {
+          isSup = true;
+          break;
+        }
+        // Also check computed verticalAlign, but only when getComputedStyle is available
+        // (it may be absent in the Node test harness).
+        if (!isSup && typeof getComputedStyle === 'function') {
+          try {
+            const style = getComputedStyle(ancestor);
+            if (style && style.verticalAlign === 'super') {
+              isSup = true;
+              break;
+            }
+          } catch (e) { /* ignore */ }
+        }
+        ancestor = ancestor.parentNode || ancestor.parentElement;
+      }
+      if (isSup) {
+        ranges.push({ start: cursor, end: cursor + len });
+      }
+    }
+    cursor += len;
+  }
+  return ranges;
 }
 
 /**

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -4200,6 +4200,363 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint exclude-exponents: <sup>-aware number masking
+// ---------------------------------------------------------------------------
+//
+// Helpers for building mock cells that contain <sup> children.
+//
+// The developer's getSuperscriptRanges(cell) walks document.createTreeWalker
+// text nodes and checks parentNode/parentElement upward for tagName === 'SUP'.
+// The roundTable branch guard uses cell.querySelector('sup') to decide whether
+// a cell needs <sup>-aware handling.
+//
+// makeSuperscriptCell(segments) builds a mock cell where each segment is
+//   { text: string, inSup: boolean }.
+// The resulting cell:
+//   - cell.innerText / cell.textContent: concatenation of all segment texts
+//   - cell._textNodes: list of mock text nodes; nodes with inSup:true have
+//     parentNode.tagName === 'SUP'; others have parentNode === cell
+//   - cell.querySelector('sup'): returns a truthy object when any inSup:true
+//     segment exists; null otherwise
+//   - cell.querySelectorAll('a'): returns [] (no anchors, so filterLinkMatches
+//     keeps all matches)
+// ---------------------------------------------------------------------------
+
+function makeSuperscriptCell(segments) {
+  const hasSup = segments.some(s => s.inSup);
+  const fullText = segments.map(s => s.text).join('');
+
+  const cell = {
+    innerText: fullText,
+    textContent: fullText,
+    innerHTML: fullText,   // good-enough stub; replaceTextPreservingHTML may use it
+    classList: {
+      _classes: [],
+      add(cls) { this._classes.push(cls); },
+      contains(cls) { return this._classes.includes(cls); },
+    },
+    dataset: {},
+    title: '',
+    tagName: 'TD',
+    // querySelectorAll('a') → no anchors so filterLinkMatches is a no-op
+    querySelectorAll: (sel) => sel === 'a' ? [] : [],
+    // querySelector('sup') → truthy iff any segment is inside <sup>
+    querySelector: (sel) => sel === 'sup' && hasSup ? { tagName: 'SUP' } : null,
+  };
+
+  // Build mock text nodes in document order.
+  // Each node has parentNode whose ancestor chain reaches 'cell'.
+  // For inSup nodes: parentNode is a fake <sup> element whose parentNode is cell.
+  // For plain nodes: parentNode is cell itself (so the while-loop terminates).
+  const textNodes = segments.map(seg => {
+    let parentNode;
+    if (seg.inSup) {
+      // A fake <sup> element: tagName matches SUPERSCRIPT_TAG ('SUP'), parent is cell
+      const supEl = { tagName: 'SUP', parentNode: cell, parentElement: cell };
+      parentNode = supEl;
+    } else {
+      // Direct child of the cell — the ancestor walk hits cell immediately and stops
+      parentNode = cell;
+    }
+    return {
+      nodeValue: seg.text,
+      parentNode,
+      parentElement: parentNode,
+    };
+  });
+
+  cell._textNodes = textNodes;
+  return cell;
+}
+
+// Override createTreeWalker to dispatch on _textNodes when present (same
+// contract as withLinkCreateTreeWalker but aware of superscript nodes).
+function withSupCreateTreeWalker(fn) {
+  global.document.createTreeWalker = function(cell) {
+    const nodes = cell._textNodes ? [...cell._textNodes] : [];
+    if (nodes.length === 0 && cell.innerText) {
+      // Fallback: single text node, parent is cell (no <sup> ancestor)
+      nodes.push({ nodeValue: cell.innerText, parentNode: cell, parentElement: cell });
+    }
+    return {
+      nextNode() { return nodes.shift() || null; }
+    };
+  };
+  try { fn(); } finally { delete global.document.createTreeWalker; }
+}
+
+// Standard opts for the exponent tests.  includeWords: true is required to
+// engage the <sup> extraction path (the guard at line ~773 of content.js).
+const supTestOpts = {
+  enabled: true,
+  includeWords: true,
+  includeCurrency: true,
+  includePercent: true,
+  excludeFirstRow: false,
+  excludeFirstColumn: false,
+  excludeDates: true,
+  excludeTimes: false,
+  offsetTop: -0.5,
+  offsetOther: -0.5,
+  numTop: 1,
+  rangeExpr: '',
+};
+
+// ---------------------------------------------------------------------------
+// AC4 (getSuperscriptRanges direct unit tests)
+// ---------------------------------------------------------------------------
+(function supAC4_directUnitTests() {
+  // AC4a: cell with NO <sup> — getSuperscriptRanges must return []
+  withSupCreateTreeWalker(function() {
+    const plainCell = makeSuperscriptCell([{ text: '1012', inSup: false }]);
+    const ranges = getSuperscriptRanges(plainCell);
+    eq('sup AC4a: getSuperscriptRanges returns [] for cell with no <sup>',
+      ranges, []);
+  });
+
+  // AC4b: cell built as "10" + <sup>"12"</sup> → range covers indices 2..4
+  // (cursor starts at 0; "10" is 2 chars, so "12" runs from 2 to 4)
+  withSupCreateTreeWalker(function() {
+    const cell = makeSuperscriptCell([
+      { text: '10', inSup: false },
+      { text: '12', inSup: true },
+    ]);
+    const ranges = getSuperscriptRanges(cell);
+    eq('sup AC4b: getSuperscriptRanges returns one range for <sup>12</sup>',
+      ranges.length, 1);
+    eq('sup AC4b: range start is 2 (after "10")',
+      ranges[0].start, 2);
+    eq('sup AC4b: range end is 4 (covers "12")',
+      ranges[0].end, 4);
+  });
+
+  // AC4c: cell "20 × 10" + <sup>"15"</sup> → range covers indices 7..9
+  withSupCreateTreeWalker(function() {
+    const cell = makeSuperscriptCell([
+      { text: '20 × 10', inSup: false },  // "20 × 10" = 7 chars
+      { text: '15', inSup: true },
+    ]);
+    const ranges = getSuperscriptRanges(cell);
+    eq('sup AC4c: getSuperscriptRanges on "20 × 10<sup>15</sup>" returns one range',
+      ranges.length, 1);
+    eq('sup AC4c: range start is 7',
+      ranges[0].start, 7);
+    eq('sup AC4c: range end is 9',
+      ranges[0].end, 9);
+  });
+
+  // AC4d: cell with unicode-minus negative exponent "~ 10" + <sup>"−32"</sup> + " sec"
+  // "~ 10" = 4 chars, "−32" (unicode minus U+2212 is 1 char) = 3 chars → range [4, 7)
+  withSupCreateTreeWalker(function() {
+    const cell = makeSuperscriptCell([
+      { text: '~ 10', inSup: false },
+      { text: '−32', inSup: true },   // "−32"
+      { text: ' sec', inSup: false },
+    ]);
+    const ranges = getSuperscriptRanges(cell);
+    eq('sup AC4d: getSuperscriptRanges on "~ 10<sup>−32</sup> sec" returns one range',
+      ranges.length, 1);
+    eq('sup AC4d: range start is 4',
+      ranges[0].start, 4);
+    eq('sup AC4d: range end is 7',
+      ranges[0].end, 7);
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC1: Whole-cell exponent cell — 10<sup>12</sup> → innerText "1012"
+// The exponent digits "12" must NOT be altered after roundTable runs.
+// ---------------------------------------------------------------------------
+(function supAC1_wholeCellExponent() {
+  withSupCreateTreeWalker(function() {
+    // "10<sup>12</sup>" → flattened innerText "1012"
+    // segments: "10" (plain) + "12" (in <sup>)
+    const cell = makeSuperscriptCell([
+      { text: '10', inSup: false },
+      { text: '12', inSup: true },
+    ]);
+
+    const table = {
+      rows: [{ cells: [cell] }],
+      querySelector: () => null,
+      dataset: {},
+    };
+
+    roundTable(table, supTestOpts);
+
+    // The exponent "12" must not have been touched — cell.innerText must still
+    // contain "12" at the sup position (indices 2..4 of the flattened text).
+    const supNode = cell._textNodes[1];
+    eq('sup AC1: exponent text node "12" is unchanged after roundTable',
+      supNode.nodeValue, '12');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC2a: "20 × 10<sup>15</sup>" — the "15" exponent must not be rounded.
+// ---------------------------------------------------------------------------
+(function supAC2a_positiveExponent() {
+  withSupCreateTreeWalker(function() {
+    // innerText: "20 × 1015" (7 + 2 chars)
+    const cell = makeSuperscriptCell([
+      { text: '20 × 10', inSup: false },
+      { text: '15', inSup: true },
+    ]);
+
+    const table = {
+      rows: [{ cells: [cell] }],
+      querySelector: () => null,
+      dataset: {},
+    };
+
+    roundTable(table, supTestOpts);
+
+    const supNode = cell._textNodes[1];
+    eq('sup AC2a: exponent "15" in "20 × 10<sup>15</sup>" is unchanged',
+      supNode.nodeValue, '15');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC2b: "20 × 10<sup>−12</sup> s" — unicode-minus negative exponent preserved.
+// ---------------------------------------------------------------------------
+(function supAC2b_negativeExponentWithUnit() {
+  withSupCreateTreeWalker(function() {
+    const cell = makeSuperscriptCell([
+      { text: '20 × 10', inSup: false },
+      { text: '−12', inSup: true },   // "−12"
+      { text: ' s', inSup: false },
+    ]);
+
+    const table = {
+      rows: [{ cells: [cell] }],
+      querySelector: () => null,
+      dataset: {},
+    };
+
+    roundTable(table, supTestOpts);
+
+    const supNode = cell._textNodes[1];
+    eq('sup AC2b: exponent "−12" in "20 × 10<sup>−12</sup> s" is unchanged',
+      supNode.nodeValue, '−12');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC2c: "~ 10<sup>−32</sup> sec" — the "−32" exponent must not be rounded.
+// ---------------------------------------------------------------------------
+(function supAC2c_negativeExponentTildeForm() {
+  withSupCreateTreeWalker(function() {
+    const cell = makeSuperscriptCell([
+      { text: '~ 10', inSup: false },
+      { text: '−32', inSup: true },   // "−32"
+      { text: ' sec', inSup: false },
+    ]);
+
+    const table = {
+      rows: [{ cells: [cell] }],
+      querySelector: () => null,
+      dataset: {},
+    };
+
+    roundTable(table, supTestOpts);
+
+    const supNode = cell._textNodes[1];
+    eq('sup AC2c: exponent "−32" in "~ 10<sup>−32</sup> sec" is unchanged',
+      supNode.nodeValue, '−32');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC2d: "6 × 10<sup>9</sup>" — the "9" exponent must not be rounded.
+// ---------------------------------------------------------------------------
+(function supAC2d_singleDigitExponent() {
+  withSupCreateTreeWalker(function() {
+    const cell = makeSuperscriptCell([
+      { text: '6 × 10', inSup: false },
+      { text: '9', inSup: true },
+    ]);
+
+    const table = {
+      rows: [{ cells: [cell] }],
+      querySelector: () => null,
+      dataset: {},
+    };
+
+    roundTable(table, supTestOpts);
+
+    const supNode = cell._textNodes[1];
+    eq('sup AC2d: exponent "9" in "6 × 10<sup>9</sup>" is unchanged',
+      supNode.nodeValue, '9');
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// AC3: Mixed cell — exponent protected, non-exponent number still eligible.
+//
+// Cell: "From inflation (~ 10<sup>−32</sup> sec) – 1234 ka"
+// The "1234" is not inside <sup> so it goes through the normal extraction path.
+// We use 1234 (magnitude 3) with default offsetTop=-0.5 which at max_mag=3
+// should round 1234 → ~1000 (or similar). The key assertion is:
+//   (a) the "−32" exponent node is unchanged, AND
+//   (b) the "1234" text node IS modified (i.e. rounded/simplified).
+// ---------------------------------------------------------------------------
+(function supAC3_mixedCellExponentProtectedNonExponentRounded() {
+  withSupCreateTreeWalker(function() {
+    // segments: prefix, exponent (sup), suffix with large number
+    const cell = makeSuperscriptCell([
+      { text: 'From inflation (~ 10', inSup: false },
+      { text: '−32', inSup: true },             // "−32"
+      { text: ' sec) – 1234 ka', inSup: false }, // "– 1234 ka"
+    ]);
+
+    const table = {
+      rows: [{ cells: [cell] }],
+      querySelector: () => null,
+      dataset: {},
+    };
+
+    roundTable(table, supTestOpts);
+
+    // The exponent node must be untouched
+    const supNode = cell._textNodes[1];
+    eq('sup AC3: exponent "−32" in mixed cell is unchanged',
+      supNode.nodeValue, '−32');
+
+    // The non-exponent part must have been processed — assert the cell was
+    // marked as rounded (dr-ext-rounded), which only happens when formattedValue
+    // differs from originalValue (i.e. "1234" was simplified).
+    eq('sup AC3: mixed cell is marked dr-ext-rounded (non-exponent 1234 was simplified)',
+      cell.classList.contains('dr-ext-rounded'), true);
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// Extra: getSuperscriptRanges returns [] when document.createTreeWalker is absent
+// ---------------------------------------------------------------------------
+(function supExtra_noTreeWalker() {
+  const savedWalker = global.document.createTreeWalker;
+  delete global.document.createTreeWalker;
+  const cell = makeSuperscriptCell([{ text: '10', inSup: false }, { text: '12', inSup: true }]);
+  const ranges = getSuperscriptRanges(cell);
+  eq('sup extra: getSuperscriptRanges returns [] when createTreeWalker is unavailable',
+    ranges, []);
+  if (savedWalker !== undefined) global.document.createTreeWalker = savedWalker;
+})();
+
+// ---------------------------------------------------------------------------
+// Extra: getSuperscriptRanges returns [] for a null/undefined cell argument
+// ---------------------------------------------------------------------------
+(function supExtra_nullCell() {
+  withSupCreateTreeWalker(function() {
+    eq('sup extra: getSuperscriptRanges(null) returns []',
+      getSuperscriptRanges(null), []);
+    eq('sup extra: getSuperscriptRanges(undefined) returns []',
+      getSuperscriptRanges(undefined), []);
+  });
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/docs/sprint-logs/pill-exponent-rebind-exclude-exponents.md
+++ b/docs/sprint-logs/pill-exponent-rebind-exclude-exponents.md
@@ -1,0 +1,17 @@
+# Sprint Log: exclude-exponents
+
+**Plan:** docs/sprint-plans/pill-exponent-rebind.md
+**Sprint goal:** Skip exponent numbers (digits inside `<sup>`) during inline-number simplification so values like `10^12`, `6×10^9`, `~ 10^−32 sec` pass through unchanged.
+**Date:** 2026-06-05
+**Result:** Completed
+
+## Attempts
+
+### Attempt 1
+- **Developer:** In `chrome-extension/content.js`: new helper `getSuperscriptRanges(cell)` (walks descendant text nodes via `document.createTreeWalker`, marking ranges whose ancestor chain contains a `<sup>` or `getComputedStyle(...).verticalAlign === 'super'`, guarded against missing `getComputedStyle`/`createTreeWalker` for the Node harness); new named constant `SUPERSCRIPT_TAG = 'SUP'` next to `SUPERSCRIPT_DIGITS`. Wired the mask into the inline-extraction branch (mirroring the existing quote-mask filter exactly) and added an intercept in the would-be `mode: 'pure'` branch: when `cell.querySelector('sup')` is truthy the cell is routed through the inline path so the exponent mask applies, preventing whole-cell `10<sup>12</sup>` (flattened to `"1012"`) from being numerically rounded.
+- **Tests:** adversarial pass added 10 IIFE blocks / 20 assertions across all four ACs (whole-cell exponent, `N × 10^M` with positive and unicode-minus negative exponents, mixed cell with non-`<sup>` number still simplified, direct unit tests of `getSuperscriptRanges` returning correct `{start,end}` ranges and `[]` for the empty cases). Result: **624 passed, 0 failed** (604 baseline + 20 new).
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:** Implementation mirrors the established `getQuoteMaskedRanges`/`overlapsQuoteRange` pattern, keeping the skip surgical — the mantissa/base outside the `<sup>` remains roundable. Both code paths a `<sup>`-bearing cell can take (inline-extraction and would-be-pure) are guarded. Tests use a new `makeSuperscriptCell` helper modeled on the existing `linkCell` harness pattern; ranges asserted directly against the flattened-text indices.
+
+## PR
+(opened to main — see PR link in run summary)


### PR DESCRIPTION
Plan: docs/sprint-plans/pill-exponent-rebind.md

Adds DOM-aware exponent exclusion so values like `10^12`, `6 × 10^9`, `~ 10^-32 sec` (rendered as `10<sup>12</sup>` etc.) pass through unchanged. The mantissa/base outside the `<sup>` and ordinary inline numbers in the same cell are still simplified normally — the skip is surgical.

New helper `getSuperscriptRanges(cell)` walks descendant text nodes and returns `{start,end}` ranges whose ancestor chain contains a `<sup>` (or `verticalAlign: super`), mirroring the existing quote-mask pattern. Filter is applied both in the inline-extraction branch and in an intercept ahead of the would-be `mode: 'pure'` branch (so a whole-cell `10<sup>12</sup>` is not rounded as the flattened number `1012`).

## Acceptance criteria
- [x] Whole-cell `N<sup>M</sup>` is not rounded.
- [x] In `N × 10<sup>M</sup>...`, the exponent `M` is not rounded (positive and unicode-minus negatives).
- [x] A non-`<sup>` number in the same cell is still simplified.
- [x] `getSuperscriptRanges` returns `[]` for cells without `<sup>` and the correct ranges otherwise.
- [x] `node chrome-extension/tests.js` passes (624 passed, 0 failed).

## Reviewer notes
No bugs found. Mock cells in the new tests follow the existing `linkCell` harness pattern; `getComputedStyle`/`createTreeWalker` are both guarded so the helper never throws in the Node harness.