### PR TITLE
docs: grid support research, sprint plan, and skill updates

### DIFF
--- a/.agent/skills/sprint-plan/SKILL.md
+++ b/.agent/skills/sprint-plan/SKILL.md
@@ -114,6 +114,27 @@ flowchart TD
 
 This DAG governs development ordering (sprint-stack executes topologically) and merge ordering (each sprint's PR is based on its parent's branch, so parents must merge first).
 
+## Phase 4b: Sequence for learning; spike when you can't
+
+Phase 4 optimizes for *failure isolation* — independent sprints so one failure doesn't block others. This phase adds a second lens: *learning order*. A plan is a set of bets, and some bets are riskier than others. Identify which sprints would **teach you something that could invalidate a later sprint's design**, and order the stack so that learning lands before the dependent commitment — not after.
+
+Ask, per sprint:
+
+- **What does executing this sprint reveal that we don't already know?** (Real DOM/API shapes, whether an external system behaves as assumed, whether a performance budget holds, whether a write actually persists.) High-information sprints are usually those that first touch the real environment.
+- **Does that revelation bear on a later sprint's architecture?** If a downstream sprint freezes an interface, data model, or write mechanism that an upstream sprint could prove unworkable, that's a *learning-order* dependency even when there's no code dependency.
+
+Two moves follow:
+
+1. **Sequence to pull the risky learning forward.** Where you can reorder so the informative sprint runs before the sprint that bets on its outcome, do so — even if it means a slightly longer dependency chain. A linear chain that surfaces a fatal assumption early beats a wide DAG that discovers it after three sprints are built on it. This trades some Phase-4 independence for de-risking; make the trade explicitly and note it.
+
+2. **If you can't reorder — insert a feasibility spike.** When the riskiest unknown can't be answered by an ordinary sprint (it's upstream of everything, or the real sprint is too expensive to throw away), add a **spike**: a throwaway investigation that answers the open question or validates the riskiest part of the plan, with **no production code**. A spike's acceptance criterion is *"the sprint plan is confirmed or needs amending,"* not a merge. Its deliverable is a recorded verdict — findings plus an explicit "proceed as planned" or "these specific sprints must change."
+
+Mark every sprint downstream of an unresolved spike as **provisional** in the plan, so the executor knows not to treat its design as settled until the spike reports.
+
+**Spikes and plan immutability.** The merged plan is read-only forever (see Phase 6). A spike therefore never edits the sprints it validates *in place*. If the spike confirms the plan, record that in the Decisions Log and proceed. If it invalidates the plan, its verdict becomes the input to a fresh `sprint-plan` revision — a new plan artifact that supersedes the provisional sprints — leaving the original plan and the decision trail intact. Frame the spike's outcome this way in the plan: confirm-in-place, or amend-via-revision.
+
+A spike is a real node in the DAG (rooted at `base`, like any independent sprint) but a special kind: it gates downstream sprints by *information* rather than by code. Show it in the dependency graph with its gated sprints marked provisional.
+
 ## Phase 5: Define each sprint
 
 Per sprint, in the markdown structure shown below. The execution skill parses this section; emit it consistently so parsing is reliable.
@@ -133,6 +154,24 @@ Per sprint, in the markdown structure shown below. The execution skill parses th
 ```
 
 When a sprint introduces a new named constant or consolidates an existing literal, list the constant(s) and their home file in **Dev notes**. No need to inventory every call site — the executing sprint will find them. Example: `TOGGLE_WIDTH_PX`, `TOGGLE_HEIGHT_PX`, `TOGGLE_EDGE_GAP_PX` in `chrome-extension/content.js`.
+
+**Spike sprints** (from Phase 4b) use a variant of this structure — their deliverable is a verdict, not code:
+
+```markdown
+### <label>  (spike)
+
+- **Goal:** <the unknown to resolve / the assumption to validate, and which downstream sprints depend on the answer>
+- **Branch:** none — no production code. Findings recorded in `docs/sprint-logs/<slug>-<label>.md`.
+- **Investigate:** <concrete things to inspect/measure, in the real environment>
+- **Out of scope:** any production code, tests, or source changes
+- **Acceptance criteria:**
+  - Findings recorded for each question.
+  - An explicit verdict: downstream sprints **confirmed as planned**, OR a list of specific amendments needed.
+  - Does not merge code — done-state is the recorded verdict.
+- **Depends on:** none (usually rooted at base)
+- **Complexity:** S (spikes should be cheap; if a spike is large, it's really a sprint)
+- **Dev notes:** keep it genuinely throwaway; note how a negative verdict feeds a plan revision rather than an in-place edit.
+```
 
 Sprint commits do not touch version files. Versioning is handled at merge time by the GitHub Action probed for in Phase 2.
 

--- a/.agent/skills/sprint-stack/SKILL.md
+++ b/.agent/skills/sprint-stack/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sprint-stack
 version: 2
-description: Execute a pre-planned stack of sprints unattended, one at a time. Reads the markdown plan from main (produced by `/sprint-plan` and merged). Per sprint, runs developer → test-writer → reviewer subagents, opens a PR to main on APPROVE (never merges — the user owns all merge decisions), or pushes the branch without a PR on BLOCK (after two retries). DAG-aware: a blocked sprint defers its dependents but the orchestrator continues with independent sprints. Each sprint's log is committed to its feature branch and merged to main with the sprint PR. Never creates session or `claude/` branches. Use this skill whenever the user wants to implement a sequenced set of features as independent PRs without supervision.
+description: Execute a pre-planned stack of sprints unattended, one at a time. Reads the markdown plan from main (produced by `/sprint-plan` and merged). Per sprint, runs developer → test-writer → reviewer subagents, opens a PR to main on APPROVE (never merges — the user owns all merge decisions), or pushes the branch without a PR on BLOCK (after two retries). DAG-aware: a blocked sprint defers its dependents but the orchestrator continues with independent sprints. Spike sprints (no-code feasibility investigations) are not executed — the orchestrator halts at them and hands control to the user, since a spike's verdict is a planning decision; sprints downstream of an unresolved spike are deferred. Each sprint's log is committed to its feature branch and merged to main with the sprint PR. Never creates session or `claude/` branches. Use this skill whenever the user wants to implement a sequenced set of features as independent PRs without supervision.
 ---
 
 You are an orchestrator running a sprint stack unattended. The user is not watching. Sprints execute one at a time, in topological order. Make decisions deterministically. Do not prompt. If a sprint fails, defer its dependents and continue with independents. Never lose work. Produce a clear log at the end.
@@ -29,6 +29,8 @@ No other flags. Resume behavior is automatic: re-invoking with the same slug che
    - Section 5 (Sprint Definitions) contains parseable sprint blocks.
 
 3. **Parse sprint definitions.** Each `### <label>` subsection under "Sprint Definitions" yields one sprint with its goal, scope, out_of_scope, acceptance criteria, depends_on, complexity, and dev_notes. Keep the Design section in context for subagents.
+
+   **Detect spike sprints.** A sprint is a **spike** if its heading carries a `(spike)` marker (`### <label>  (spike)`) or its block declares `Branch: none`. Spikes are not implemented by the subagent pipeline — they are handled by § Spike sprints below. Treat any sprint marked **provisional** in the plan (or whose `depends_on` includes a spike) as gated on that spike's resolution.
 
 4. **Working tree check.** The session's active repo must be on `main` and clean. If not → abort.
 
@@ -59,10 +61,23 @@ No other flags. Resume behavior is automatic: re-invoking with the same slug che
 For each sprint in topological order:
 
 1. **Skip if already merged or PR open** (checked at startup).
-2. **Check dependencies.** If any of this sprint's `depends_on` is Blocked or Deferred in this run, mark this sprint **Deferred** and continue.
-3. **Resolve parent branch.** If `depends_on` is empty or contains only out-of-stack labels → parent = `main`. Otherwise → parent = the most recently completed dependency's `feature/<label>` branch.
-4. **Execute the sprint** (§ Per-sprint execution). Yields Completed, Blocked, or Deferred.
-5. **Continue** to the next sprint regardless of outcome.
+2. **Spike?** If this sprint is a spike → handle per § Spike sprints (yields Confirmed, Pending, or Amend) and continue. Do not run the subagent pipeline on it.
+3. **Check dependencies.** If any of this sprint's `depends_on` is Blocked, Deferred, **Pending (unresolved spike)**, or **Amend** in this run, mark this sprint **Deferred** and continue.
+4. **Resolve parent branch.** If `depends_on` is empty or contains only out-of-stack labels (or resolved spikes, which produce no branch) → parent = `main`. Otherwise → parent = the most recently completed *code* dependency's `feature/<label>` branch.
+5. **Execute the sprint** (§ Per-sprint execution). Yields Completed, Blocked, or Deferred.
+6. **Continue** to the next sprint regardless of outcome.
+
+## Spike sprints
+
+A spike is a no-code feasibility investigation (see sprint-plan Phase 4b). Its deliverable is a **verdict** — "plan confirmed" or "plan needs amending" — not a branch or a PR. The orchestrator **does not execute spikes**, for two reasons: a spike typically requires inspecting a real, live environment the unattended orchestrator cannot reach, and its verdict is a *planning* decision, which (like merges) belongs to the user.
+
+When the loop reaches a spike, resolve its state from a **spike log on `main`** at `docs/sprint-logs/<slug>-<label>.md` — written by the user after they perform the investigation:
+
+- **Log absent → Pending.** Do not execute. Mark the spike **Pending** and halt progression into its downstream sprints (they Defer via step 3). Surface it in the end-of-run summary with explicit next steps (below). This is not a failure — it is a designed hand-off.
+- **Log present, `Result: Confirmed` → the plan stands.** Treat the spike as **resolved** for dependency purposes (it satisfies dependents like a Completed sprint, but produces no branch — dependents whose only unmet dependency was the spike root at `main`). Continue.
+- **Log present, `Result: Amend` → the plan is stale.** The spike found the provisional sprints need redesign. Mark the spike **Amend**, Defer all its downstream sprints, and surface in the summary that the user must run `/sprint-plan` to produce a revised plan before those sprints can execute. Do **not** build on an invalidated plan.
+
+The orchestrator never writes the spike log itself (that would be deciding the verdict). If a spike is Pending, the run simply completes the independent sprints it can and reports the spike as awaiting the user.
 
 ## Per-sprint execution
 
@@ -164,7 +179,8 @@ Re-running `/sprint-stack <slug>`:
 - Sprints with a merged PR → skipped.
 - Sprints with an open PR → skipped (already submitted).
 - Sprints marked Blocked (branch pushed, no PR) → re-attempted from scratch on a fresh branch. The old blocked branch can be deleted after the new one is pushed.
-- Sprints marked Deferred → re-evaluated; if upstream is now Completed they become eligible.
+- Sprints marked Deferred → re-evaluated; if upstream is now Completed (or an upstream spike is now Confirmed) they become eligible.
+- **Spikes** → re-evaluated from the spike log on `main`: absent → still Pending (halt downstream again); `Confirmed` → resolved, downstream proceeds; `Amend` → downstream stays Deferred and the user is reminded to run `/sprint-plan` for a revised plan. A spike is never "retried" by the orchestrator — its progress is entirely the user-written log.
 
 ## End-of-run summary
 
@@ -175,10 +191,19 @@ When the queue drains, post a single message:
 > **Completed:** <count> — <label> → PR #<n>, <label> → PR #<n>, ...
 > **Blocked:** <count> — <label> (branch: feature/<label>), ...
 > **Deferred:** <count> — <label> (waiting on <upstream>), ...
+> **Spikes awaiting you:** <count> — <label>, ...
 >
 > **Merge order:** Root sprints (based on main) can merge in any order. Dependent sprints re-target main automatically after their parent merges.
 >
 > **To resume blocked sprints:** fix on the branch, commit, push, re-run `/sprint-stack <slug>`.
+
+If any spike is **Pending**, include its hand-off block:
+
+> **Spike `<label>` needs you.** It's a no-code investigation I can't run unattended. Do the investigation in § Goal of the spike, then write `docs/sprint-logs/<slug>-<label>.md` on `main` with a `**Result:**` line of either:
+> - `Confirmed` — the plan stands; re-run `/sprint-stack <slug>` and the provisional sprints (<list>) will proceed.
+> - `Amend` — the plan needs changes; run `/sprint-plan` to produce a revised plan, then execute that.
+
+If any spike is **Amend**, state plainly that the downstream sprints (<list>) are on hold pending a revised plan, and do not attempt them.
 
 Then stop.
 
@@ -186,6 +211,7 @@ Then stop.
 
 - **Sprints run one at a time**, in topological order.
 - **A failed sprint never stops the orchestrator** — dependents are Deferred, independents continue.
+- **Spikes are never executed by the orchestrator.** Halt at them, resolve from the user-written spike log on `main`, and defer downstream sprints until the verdict is `Confirmed`. Never write the verdict yourself — it's the user's planning decision.
 - **The skill opens PRs and stops.** Merge decisions belong to the user.
 - **Never wait for PR merges.** Sprint B (depending on A) branches off A's feature branch immediately after A's PR opens — not after it merges.
 - **Never commit to main.** Feature branches are pushed; PRs are opened. Branch protection on main is fully respected.

--- a/docs/research/databricks-grid-detection.md
+++ b/docs/research/databricks-grid-detection.md
@@ -1,0 +1,100 @@
+# Detecting Web-Based Data Grids (Databricks SQL & others)
+
+Research notes on identifying non-standard "data grid" tables in modern web apps,
+prompted by inspecting the Databricks SQL results window. Relevant to the Chrome
+extension's table detection/scraping logic.
+
+## Databricks SQL results structure
+
+The results "table" is **not** a single `<table>` element. It's a virtualized
+grid split into pinned and scrollable parts for high-performance scrolling:
+
+- **Main wrapper**: `.dg--table-wrapper` — `role="table"`
+- **Pinned columns** (e.g. row numbers): `.dg--grid-container.dg--pinned-grid` — `role="grid"`
+- **Scrollable data**: `.dg--grid-container.dg--grid-scroll-container` — `role="grid"`
+
+Targeting cheatsheet:
+
+| Goal | Selector |
+| --- | --- |
+| Entire table area | `.dg--table-wrapper` |
+| Actual data values | inside `.dg--grid-scroll-container` |
+| Row numbers / index | inside `.dg--pinned-grid` |
+
+The `dg--` prefix likely stands for "Data Grid" and is Databricks-specific. To
+reduce false positives, scope to the results pane (e.g. `.results .dg--table-wrapper`)
+and/or require the co-occurrence of a pinned + scrollable container under the same
+parent, optionally paired with a container like `.DataViewTable`.
+
+## Generic heuristics for identifying data grids
+
+These grids often skip the `<table>` tag and sometimes ARIA roles, and only
+render visible rows (virtualization). Detect them structurally:
+
+1. **Repetitive siblings** — a parent with many (>10) children sharing identical
+   class names / DOM structure; uniform row heights and uniform cell widths
+   across rows.
+2. **CSS layout** — `display: grid` (check `grid-template-columns`, e.g.
+   `repeat(5, 1fr)`), or `display: flex` with `flex-direction: column` as the
+   container and flex rows as children.
+3. **Virtualization markers** — rows positioned via `transform: translateY(...)`
+   or `top: ...px` rather than natural flow; `position: absolute` rows inside a
+   relative container; large `scrollHeight` vs small `offsetHeight`.
+4. **Interaction markers** — `wheel`/`scroll` listeners for lazy loading;
+   focusable cells with `tabindex="0"` or `-1` even without ARIA.
+
+### Example detection script
+
+```js
+function findNonStandardTables() {
+  const containers = document.querySelectorAll('div, section');
+  return Array.from(containers).filter(el => {
+    const children = el.children;
+    if (children.length < 5) return false;
+    const styles = window.getComputedStyle(el);
+    const firstChildStyles = window.getComputedStyle(children[0]);
+    const isGrid = styles.display === 'grid';
+    const areChildrenFlex =
+      firstChildStyles.display === 'flex' || firstChildStyles.display === 'grid';
+    const heights = Array.from(children).slice(0, 5).map(c => c.offsetHeight);
+    const isUniform = heights.every(h => h === heights[0] && h > 0);
+    return (isGrid || areChildrenFlex) && isUniform;
+  });
+}
+```
+
+**Most reliable generic pattern:** repetitive `display: flex` rows inside a
+container with a stable scroll height.
+
+## Same pattern across other platforms
+
+The pinned + scrollable split is the industry standard for web SQL editors and
+spreadsheets, not unique to Databricks:
+
+- **AG Grid** (financial dashboards, Bloomberg, J.P. Morgan): pinned
+  `.ag-pinned-left-cols-container`, scrollable `.ag-center-cols-viewport`.
+- **Azure Data Studio / VS Code** (`monaco-workbench`): SlickGrid/Monaco grid
+  with row headers in a separate DOM tree.
+- **Google Sheets / Excel Online**: "Freeze Panes" creates synchronized
+  viewports kept in sync with `transform: translate3d`.
+- **AWS Console** (Cloudscape / `awsui`): `.awsui-table-wrapper`,
+  `.awsui-table-sticky-holder`.
+
+### Distinguishing data grids from layout grids
+
+Data grids (unlike plain CSS `display: grid` layouts) almost always show:
+
+- **Virtualization** — only visible rows rendered; DOM nodes recycled on scroll.
+- **Role attributes** — explicit `role="grid"` / `role="rowgroup"`.
+- **Synchronized scrolling** — scrolling one container programmatically drives
+  `scrollTop` / `scrollLeft` on another.
+
+**Bottom line:** look for the **co-occurrence** of a pinned container and a
+scrollable container within the same parent.
+
+## Open follow-up questions
+
+- How to verify scrolling is synchronized between the pinned and scrollable grids.
+- Which specific ARIA attributes to rely on for robust detection.
+- A script to extract data from both pinned and scrollable sections and stitch
+  rows back together.

--- a/docs/sprint-plans/grid-support.md
+++ b/docs/sprint-plans/grid-support.md
@@ -55,18 +55,41 @@ abstraction, rounding, and virtualization — in dependency order.
 
 ### D1 — Grid discovery (sprint 1 only)
 
-Extend `injectTableToggles`, the MutationObserver, and the right-click handler
-to find ARIA grids alongside native tables.
+The target is **unlabelled** data grids — `<div>`-based tables that use neither
+the `<table>` tag nor ARIA roles. These are the grids the extension misses and
+that no selector can find. Detection is therefore **structural/heuristic
+first**; ARIA roles and library-specific class prefixes (`dg--`, `ag-`) are
+treated as optional accelerators that boost confidence and provide precise
+selectors *when present*, never as a requirement.
 
-**Primary selector:** `[role="grid"], [role="table"]`
+**Primary mechanism — `findDataGrids()` (research doc §2, §4):** scan
+`div`/`section` containers and score each against structural signals:
 
-**Heuristic fallback** (for grids that omit ARIA — see research doc §2):
-- Container has ≥ 5 direct children with uniform `offsetHeight > 0`.
-- Container or children use `display: grid` or `display: flex`.
+1. **Repetitive siblings** — ≥ ~5 direct children with near-identical class
+   names / child structure (candidate rows).
+2. **Uniform geometry** — those children share a uniform `offsetHeight > 0`;
+   their children (candidate cells) share uniform widths across rows.
+3. **Tabular layout** — container uses `display: grid` (multi-column
+   `grid-template-columns`) or `display: flex` column with flex-row children.
+4. **Numeric content** — at least one candidate cell contains a finite parseable
+   number (this is the strongest guard against matching nav menus / card lists).
 
-**False-positive filter (co-occurrence rule):** only promote a heuristic-
-matched container if it has both a "pinned" sibling and a "scrollable" sibling
-under the same parent. ARIA-matched grids bypass this filter.
+A container passing the structural test is treated as a data grid. **No ARIA and
+no `<table>` is required.**
+
+**Optional confidence boosters (used when present, never required):**
+- `role="grid"` / `role="row"` / `role="gridcell"` attributes.
+- Library class prefixes (`dg--`, `ag-`, `awsui-`).
+- Virtualization markers — rows positioned via `transform: translateY(...)` /
+  `position: absolute`, large `scrollHeight` vs small `offsetHeight`.
+- A pinned + scrollable container pair under one parent (the Databricks/AG-Grid
+  split). This raises confidence but is **not** a precondition — single-pane
+  unlabelled grids must still be detected.
+
+**False-positive mitigation:** the gate is *uniform geometry + repetitive
+siblings + numeric cell content*, optionally scoped to a results/scroll context.
+A plain CSS layout grid (no repeating numeric rows) fails the numeric-content
+guard and is rejected. Library hints, when present, further raise confidence.
 
 In sprint 1, a discovered grid gets a toggle button and toggle positioning; no
 rounding is attempted yet. A sentinel class `dr-ext-grid` is added to the root
@@ -88,10 +111,23 @@ GridAdapter(wrapperElement)
   .isVirtualized()  → true
 ```
 
-`getRows()` for `GridAdapter`: collect `[role="row"]` children from the
-scrollable pane; for each, also collect the same-index row from the pinned pane
-(if present); merge cells in DOM order (pinned columns first). This stitching is
-the interface contract — callers never know they are reading two DOM trees.
+`getRows()` for `GridAdapter` identifies rows and cells **structurally**, the
+same way `findDataGrids()` detected the grid — it does not depend on ARIA:
+
+- **Rows** = the repetitive, uniform-height direct children of the grid's
+  scrollable content container.
+- **Cells** = the repetitive children of each row.
+- **ARIA shortcut (when present):** if the grid exposes `[role="row"]` /
+  `[role="gridcell"]`, use those selectors directly — they are faster and more
+  precise than positional enumeration. Fall back to structural child
+  enumeration when roles are absent.
+- **Pinned pane (when present):** for each scrollable row, also collect the
+  same-index row from the pinned pane and merge cells in DOM order (pinned
+  columns first). When there is no pinned pane (single-pane grid), rows come
+  from the one container.
+
+This stitching and structural extraction is the interface contract — callers
+never know whether they are reading one DOM tree or two, labelled or unlabelled.
 
 `NativeTableAdapter.getRows()` wraps `table.rows` / `row.cells` exactly as
 today. All existing behavior is preserved verbatim.
@@ -105,8 +141,8 @@ changed; the adapter is constructed at the call site based on element type.
 Implement `GridAdapter` fully (sprint 2 defines the interface; sprint 3 fills
 in the body). Key concerns:
 
-- `getText()` reads `cell.textContent` (grids use no `<td>`; cells are
-  `[role="gridcell"]` divs).
+- `getText()` reads `cell.textContent` (grids use no `<td>`; cells are plain
+  divs, with or without a `role="gridcell"` attribute).
 - `setText(s)` writes `cell.textContent` and applies `.dr-ext-rounded` just as
   `roundTable` does today — but only to visible (currently-rendered) cells.
 - `resetTable` via the adapter clears `.dr-ext-rounded` only from nodes
@@ -160,51 +196,73 @@ before sprint 2 — the toggle will appear on grids but do nothing until sprint 
 
 ### grid-detection
 
-- **Goal:** Make the extension discover and badge ARIA data grids with the
-  existing toggle button. No rounding happens yet; this sprint validates that
-  discovery and toggle positioning work on real pages (Databricks, AG Grid).
+- **Goal:** Make the extension discover and badge **unlabelled** data grids
+  (div-based tables with no `<table>` tag and no ARIA roles) with the existing
+  toggle button, using a structural/heuristic detector. ARIA roles and library
+  class prefixes are used as optional accelerators when present. No rounding
+  happens yet; this sprint validates that heuristic discovery and toggle
+  positioning work on real pages (Databricks, AG Grid, and at least one
+  unlabelled grid).
 - **Scope — `chrome-extension/content.js`:**
-  - `injectTableToggles` (L434): after the `querySelectorAll('table')` pass,
-    add a second pass: `querySelectorAll('[role="grid"], [role="table"]')`,
-    deduplicating any native `<table>` that also carries the role. For each
-    result, call `createToggleForTable` with a guard that skips elements already
-    carrying `dr-ext-grid` (idempotency).
-  - Heuristic fallback: extract `findNonStandardTables()` (from research doc §4)
-    as a module-level function; call it after the ARIA pass; apply the
-    co-occurrence filter (skip if no pinned+scrollable sibling pair detected).
-  - MutationObserver (L469–494): mirror both passes in the added-node and
-    removed-node branches.
-  - Right-click handler (L49, L71): change `closest('table')` to
-    `closest('table, [role="grid"], [role="table"], .dg--table-wrapper')`.
-  - `createToggleForTable`: add an early guard — if the element is not a
-    `<table>`, skip `isDataTable()` (it will fail on `.rows`) and instead use a
-    lighter check: does the element contain at least one `[role="gridcell"]` or
-    a direct child with `display: flex/grid`? If yes, attach the toggle.
+  - Add a module-level `findDataGrids(root = document)` (based on research doc
+    §4) that returns candidate grid root elements. It scores each `div`/`section`
+    container on: repetitive uniform-height children (rows), uniform-width
+    grandchildren (cells), `display: grid`/`flex` layout, and **at least one
+    cell containing a finite number** (the primary false-positive guard). A
+    container passing the structural test qualifies with no ARIA required.
+  - Confidence boosters (raise score, never required): `role="grid"/"row"/"gridcell"`
+    attributes, library prefixes (`dg--`, `ag-`, `awsui-`), virtualization
+    markers (`transform: translateY`, `position: absolute`, large `scrollHeight`
+    vs small `offsetHeight`), and a pinned + scrollable sibling pair. Define a
+    score threshold; document it inline so it can be tuned against real pages.
+  - `injectTableToggles` (L434): after the `querySelectorAll('table')` pass, run
+    `findDataGrids()`; for each result call `createToggleForTable` with a guard
+    that skips elements already carrying `dr-ext-grid` (idempotency). Also skip
+    any element that *is* or *contains* a native `<table>` already handled.
+  - MutationObserver (L469–494): re-run `findDataGrids(node)` for added nodes;
+    mirror removal handling for grids.
+  - Right-click handler (L49, L71): replace `closest('table')` with a helper
+    `findTargetTable(el)` that returns the nearest `<table>` OR the nearest
+    ancestor carrying `dr-ext-grid` (set during discovery). This avoids relying
+    on a role/class selector that unlabelled grids won't have.
+  - `createToggleForTable`: add an early branch — if the element is not a
+    `<table>`, skip `isDataTable()` (it reads `.rows`) and instead confirm via a
+    lightweight structural check (`findDataGrids` already validated it; re-use
+    the same numeric-content probe). If it passes, attach the toggle.
   - Mark discovered grids with `el.classList.add('dr-ext-grid')`.
   - `positionToggle`: already uses `getBoundingClientRect()`, which works for
     any element — no change needed.
 - **Scope — `chrome-extension/tests.js`:**
-  - Add unit tests for `findNonStandardTables()` against synthetic DOM fixtures:
-    a passing case (ARIA grid), a passing heuristic case (pinned+scrollable),
-    a rejected heuristic case (no co-occurrence), and a layout-grid false
-    positive (single-pane CSS grid, no sibling pair).
+  - Unit tests for `findDataGrids()` against synthetic DOM fixtures:
+    - **Pass — unlabelled grid:** plain `<div>` rows, no roles, uniform height,
+      numeric cells. (This is the headline case.)
+    - **Pass — ARIA grid:** same structure plus `role="grid"`.
+    - **Pass — pinned+scrollable:** Databricks-shaped split.
+    - **Reject — layout grid:** CSS `display: grid` cards with no numeric rows
+      (fails the numeric-content guard).
+    - **Reject — nav menu:** repetitive uniform children but no numbers.
 - **Out of scope:** Any actual rounding of grid contents. The toggle's click
   handler will fire but `roundTable` will no-op (`.rows` is undefined on a
   div) — that is acceptable for this sprint.
 - **Acceptance criteria:**
-  - On a page with `<div role="grid">`, the extension injects a toggle button
-    correctly positioned at the grid's top-right corner.
-  - Right-clicking a cell inside a `[role="grid"]` sets `lastRightClickedTable`
-    to the grid wrapper.
-  - No toggle appears on a plain CSS layout grid lacking the co-occurrence of
-    pinned + scrollable containers.
+  - On a page with an **unlabelled** div-grid (no `<table>`, no `role`), the
+    extension detects it via `findDataGrids()` and injects a correctly
+    positioned toggle button.
+  - The same works for ARIA grids and the Databricks pinned+scrollable shape.
+  - Right-clicking a cell inside a detected grid sets `lastRightClickedTable`
+    to the grid root (via the `dr-ext-grid` ancestor walk).
+  - No toggle appears on a plain CSS layout grid with no numeric data rows.
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** none
-- **Complexity:** S
+- **Complexity:** M _(raised from S — the heuristic scorer and its
+  false-positive tuning are the real work, not a selector query.)_
 - **Dev notes:**
-  - Do not rename `lastRightClickedTable` — the variable's type widens to
-    "table or grid wrapper" but the name change is cosmetic and would touch too
-    many call sites. Document the widened contract in a brief comment.
+  - The numeric-content guard is the single most important false-positive
+    filter — without it the structural heuristic lights up on nav bars, card
+    grids, and toolbars. Keep it mandatory.
+  - Do not rename `lastRightClickedTable` — its type widens to "table or grid
+    root" but renaming would touch too many call sites. Document the widened
+    contract in a comment.
   - Do not bump `manifest.json` version.
 
 ---
@@ -272,12 +330,24 @@ before sprint 2 — the toggle will appear on grids but do nothing until sprint 
 - **Goal:** Implement `GridAdapter.getRows()` so that rounding, reset, and
   preview-sample extraction work on the currently-visible rows of a data grid.
 - **Scope — `chrome-extension/content.js`:**
-  - Implement `GridAdapter.getRows()`:
-    1. Find the scrollable pane: `this.el.querySelector('[role="grid"]:not(.dg--pinned-grid), .dg--grid-scroll-container, .ag-center-cols-viewport')` — fall back to `this.el` if no match.
-    2. Find the pinned pane: `this.el.querySelector('.dg--pinned-grid, .ag-pinned-left-cols-container')` — may be `null`.
-    3. Collect scrollable rows: `Array.from(scrollPane.querySelectorAll(':scope > [role="row"], :scope > * > [role="row"]'))` (one level of indirection for some grid libraries).
-    4. For each scrollable row at index `i`, collect pinned row at the same index (if pinned pane exists): match by `data-row-index` attribute if present, otherwise by DOM index.
-    5. Return row objects: `{ getCells: () => [...pinnedCells, ...scrollableCells].map(cell => ({ getText: () => cell.textContent, setText: (s) => { cell.textContent = s; cell.classList.add('dr-ext-rounded'); cell.dataset.drOriginal = cell.dataset.drOriginal || cell.textContent; }, el: cell, tagName: 'TD' /* normalized */ })) }`.
+  - Implement `GridAdapter.getRows()` — **structural first, ARIA as shortcut:**
+    1. Find the scrollable content container. Prefer known library selectors
+       when present (`.dg--grid-scroll-container`, `.ag-center-cols-viewport`,
+       `[role="grid"]:not(.dg--pinned-grid)`); otherwise pick the descendant
+       holding the repetitive uniform-height children that `findDataGrids`
+       identified. Fall back to `this.el`.
+    2. Find the pinned pane if one exists (`.dg--pinned-grid`,
+       `.ag-pinned-left-cols-container`, or a sibling container with matching
+       row count) — may be `null` for single-pane / unlabelled grids.
+    3. Collect rows. **ARIA shortcut:** if `[role="row"]` elements exist, use
+       them. **Structural fallback (unlabelled grids):** take the repetitive
+       uniform-height direct children of the scroll container as rows.
+    4. For each scrollable row at index `i`, collect the pinned row at the same
+       index (if a pinned pane exists): match by `data-row-index` when present,
+       otherwise by DOM index.
+    5. Cells per row: prefer `[role="gridcell"]` when present; otherwise the
+       row's repetitive child elements (structural). Merge pinned cells first.
+    6. Return row objects: `{ getCells: () => [...pinnedCells, ...scrollableCells].map(cell => ({ getText: () => cell.textContent, setText: (s) => { cell.textContent = s; cell.classList.add('dr-ext-rounded'); cell.dataset.drOriginal = cell.dataset.drOriginal || cell.textContent; }, el: cell, tagName: 'TD' /* normalized */ })) }`.
   - `setText` in `GridAdapter` must store the original value in
     `cell.dataset.drOriginal` before overwriting (for reset), mirroring how
     `NativeTableAdapter` stores it.
@@ -289,9 +359,10 @@ before sprint 2 — the toggle will appear on grids but do nothing until sprint 
   - Update `createToggleForTable` grid path (from sprint 1): now that
     `getRows()` works, replace the stub check with `isDataTable(makeAdapter(el))`.
 - **Scope — `chrome-extension/tests.js`:**
-  - Add tests with synthetic ARIA grid DOM fixtures:
-    - A simple `role="grid"` with two visible `role="row"` children and
-      `role="gridcell"` cells containing numbers: rounding applies.
+  - Add tests with synthetic grid DOM fixtures — both labelled and unlabelled:
+    - **Unlabelled grid** (no roles): plain `<div>` rows/cells with numbers —
+      structural extraction finds rows/cells and rounding applies. (Headline.)
+    - **ARIA grid:** `role="grid"`/`row`/`gridcell` — shortcut path used.
     - A grid with a pinned pane: cell stitching produces correct column order.
     - `resetTable` on a rounded grid restores original values.
     - `extractPreviewSamples` on a grid returns the expected sample structure.
@@ -395,3 +466,10 @@ before sprint 2 — the toggle will appear on grids but do nothing until sprint 
 
 - 2026-06-10: Initial draft. Sprints 1 and 2 are independent; 3 depends on 2;
   4 depends on 3.
+- 2026-06-10: Reoriented detection and extraction around **structural
+  heuristics** for unlabelled grids (the research doc's actual focus). ARIA
+  roles and library class prefixes demoted from required selectors to optional
+  accelerators used when present. Dropped the pinned+scrollable co-occurrence as
+  a hard requirement (single-pane unlabelled grids must still be detected);
+  numeric-content + uniform-geometry is now the primary false-positive guard.
+  Sprint 1 complexity raised S → M.

--- a/docs/sprint-plans/grid-support.md
+++ b/docs/sprint-plans/grid-support.md
@@ -8,26 +8,92 @@
 
 The dynamic-rounding Chrome extension rounds numbers in native HTML `<table>`
 elements. Modern web apps — Databricks SQL, AG Grid dashboards, Azure Data
-Studio, AWS Cloudscape — render query results as virtualized data grids built
-from `<div role="grid">` containers split into **pinned** (frozen columns) and
-**scrollable** panes. These grids are completely invisible to the extension
-today.
+Studio, AWS Cloudscape — render results as **data grids** built from plain
+`<div>` containers, often virtualized (only visible rows exist in the DOM) and
+often split into pinned (frozen columns) and scrollable panes. Many such grids
+carry no `<table>` tag and no ARIA roles at all. These grids are invisible to
+the extension today.
 
-Research is in `docs/research/databricks-grid-detection.md`. The key structural
+Research is in `docs/research/databricks-grid-detection.md`. Key structural
 facts:
 
 - **Databricks SQL:** `.dg--table-wrapper` wraps `.dg--pinned-grid` +
-  `.dg--grid-scroll-container` (both `role="grid"`).
+  `.dg--grid-scroll-container` (both happen to carry `role="grid"`).
 - **AG Grid:** `.ag-pinned-left-cols-container` + `.ag-center-cols-viewport`.
-- Grids use `role="grid"` / `role="row"` / `role="gridcell"` ARIA attributes.
+- Many grids expose **no** roles or recognizable classes — they must be found
+  by structure alone.
 - **Virtualization:** only visible rows are in the DOM; nodes are recycled as
-  the user scrolls — so there is no single "full table" in the DOM at any time.
+  the user scrolls — there is no single "full table" in the DOM at any time.
 
 Every layer of `content.js` is hard-wired to the `<table>` DOM API, so adding
-detection alone is not sufficient. The four sprints below address: discovery,
-abstraction, rounding, and virtualization — in dependency order.
+detection alone is not sufficient. The four sprints below address discovery,
+abstraction, rounding, and virtualization in dependency order.
 
-## 1. Repo Survey
+## 2. Strategy (agreed before planning)
+
+These decisions were worked out up front and shape every sprint:
+
+### S1 — Two extraction paths, four detection signals
+
+There are only **two** ways to *read* a table once found: the native table API
+(`.rows`/`.cells`, handles `colspan`/`th`) and div-walking (everything else).
+Native `<table>` is therefore its own path. ARIA grids and unlabelled grids
+share the div-walk path; they differ only in how they're *detected*.
+
+Detection signals, in decreasing precision / increasing recall:
+`<table>` tag → library class (`dg--`, `ag-`) → ARIA `role` → raw structure.
+The cheap signals are also the precise ones, so they run first and the
+expensive structural heuristic runs last (and rarely).
+
+### S2 — Column structure, not row height, is the heuristic's spine
+
+Row-height uniformity is a **bad** signal: any table with a text column that
+wraps to a second line has variable row heights (most Wikipedia tables, most
+non-numeric Databricks results). The heuristic instead keys on:
+
+- **Consistent cell count** — every candidate row has the same number of
+  children. (Cheap, no geometry.)
+- **Column-width alignment** — cells in the same position share a width;
+  columns line up vertically. (Robust to text wrapping — a column's width is
+  independent of how many lines its text occupies.)
+- **Repetitive row structure** — near-identical class names / child shape.
+- **Numeric content** — at least one cell parses as a finite number. This is
+  the single most important false-positive guard.
+
+Row height is demoted to an optional weak hint, never a requirement.
+
+### S3 — Lazy discovery for unlabelled grids; proactive only where it's free
+
+The structural heuristic measures geometry (`offsetWidth` / `getComputedStyle`),
+which forces synchronous layout and is expensive on large, dynamic pages — which
+are exactly the pages that have these grids. So:
+
+- **Proactive (on page load + cheap MutationObserver passes):** only the cheap
+  signals — `querySelectorAll('table')` and `[role="grid"], [role="table"]`.
+  These badge the toggle dot immediately and cost almost nothing.
+- **Lazy (on right-click only):** the structural heuristic. It does **not**
+  scan the page. It walks **up** from the clicked element, testing a handful of
+  ancestors, and badges the grid the first time the user interacts with it.
+
+Net effect: free dots where the signal is free; on-demand dots for the
+expensive unlabelled case, scoped to the one element the user clicked.
+
+### S4 — Geometry measured last and narrowest
+
+Within the heuristic, cheap checks gate the expensive one: child count → class
+repetition → layout (`display`) → numeric content **first**; only the few
+candidates that survive get their column widths measured. Because lazy discovery
+already limits this to the right-clicked element's ancestors, the geometry probe
+touches a bounded handful of elements, never the page.
+
+### S5 — Debounce re-apply at 100 ms
+
+The sprint-4 re-apply observer batches the row-recycle mutations a virtualized
+grid fires during scroll and reacts at most once per **100 ms**. That is well
+under the ~100 ms "feels instant" threshold yet does ~6× less work than
+per-frame (16 ms) reaction.
+
+## 3. Repo Survey
 
 - Chrome extension (MV3) at `chrome-extension/`: `content.js` (~1800 lines,
   all table logic), `sidebar.js` / `sidebar.html` (options UI), `defaults.js`
@@ -51,49 +117,40 @@ abstraction, rounding, and virtualization — in dependency order.
 - Version bumps: handled by `.github/workflows/bump-version.yml` on merge to
   main; sprint branches must NOT bump versions.
 
-## 2. Design
+## 4. Design
 
-### D1 — Grid discovery (sprint 1 only)
+### D1 — Detection: proactive cheap pass + lazy structural walk-up (sprint 1)
 
-The target is **unlabelled** data grids — `<div>`-based tables that use neither
-the `<table>` tag nor ARIA roles. These are the grids the extension misses and
-that no selector can find. Detection is therefore **structural/heuristic
-first**; ARIA roles and library-specific class prefixes (`dg--`, `ag-`) are
-treated as optional accelerators that boost confidence and provide precise
-selectors *when present*, never as a requirement.
+Two entry points, per strategy S3:
 
-**Primary mechanism — `findDataGrids()` (research doc §2, §4):** scan
-`div`/`section` containers and score each against structural signals:
+**Proactive — `injectTableToggles` + MutationObserver:** keep the existing
+`querySelectorAll('table')` pass and add one cheap selector pass
+`querySelectorAll('[role="grid"], [role="table"]')`. Both badge the toggle dot
+on load. No structural scanning, no geometry. Native tables and ARIA grids are
+covered here.
 
-1. **Repetitive siblings** — ≥ ~5 direct children with near-identical class
-   names / child structure (candidate rows).
-2. **Uniform geometry** — those children share a uniform `offsetHeight > 0`;
-   their children (candidate cells) share uniform widths across rows.
-3. **Tabular layout** — container uses `display: grid` (multi-column
-   `grid-template-columns`) or `display: flex` column with flex-row children.
-4. **Numeric content** — at least one candidate cell contains a finite parseable
-   number (this is the strongest guard against matching nav menus / card lists).
+**Lazy — `looksLikeGrid(el)` on right-click:** the right-click handler walks up
+from the clicked element; at each ancestor it calls `looksLikeGrid`, stopping at
+the **first** ancestor that passes (the tightest grid root). A depth cap (~15
+ancestors / stop at `<body>`) bounds the walk.
 
-A container passing the structural test is treated as a data grid. **No ARIA and
-no `<table>` is required.**
+`looksLikeGrid(el)` applies the S2/S4 cheap-first ladder:
 
-**Optional confidence boosters (used when present, never required):**
-- `role="grid"` / `role="row"` / `role="gridcell"` attributes.
-- Library class prefixes (`dg--`, `ag-`, `awsui-`).
-- Virtualization markers — rows positioned via `transform: translateY(...)` /
-  `position: absolute`, large `scrollHeight` vs small `offsetHeight`.
-- A pinned + scrollable container pair under one parent (the Databricks/AG-Grid
-  split). This raises confidence but is **not** a precondition — single-pane
-  unlabelled grids must still be detected.
+1. **Child count** — ≥ ~5 children (candidate rows). Cheap.
+2. **Repetitive structure** — children share class / child shape. Cheap.
+3. **Consistent cell count** — candidate rows have equal child counts. Cheap.
+4. **Layout** — `getComputedStyle(el).display` is `grid` or `flex` (one read).
+5. **Numeric content** — ≥ 1 cell parses as a finite number. Cheap, mandatory.
+6. **Column-width alignment** — only for candidates surviving 1–5: measure
+   `offsetWidth` of column-0 cells across a few rows; expect uniform widths.
+   This is the only geometry probe, and it runs on a bounded set.
 
-**False-positive mitigation:** the gate is *uniform geometry + repetitive
-siblings + numeric cell content*, optionally scoped to a results/scroll context.
-A plain CSS layout grid (no repeating numeric rows) fails the numeric-content
-guard and is rejected. Library hints, when present, further raise confidence.
+Row height is **not** tested (S2). ARIA role / library class, when present on a
+walked ancestor, short-circuit to "accept" and skip the geometry probe.
 
-In sprint 1, a discovered grid gets a toggle button and toggle positioning; no
-rounding is attempted yet. A sentinel class `dr-ext-grid` is added to the root
-element so later sprints can locate it without re-running discovery.
+Discovered grids are marked `el.classList.add('dr-ext-grid')` so later sprints
+and the right-click handler locate them without re-running detection. In sprint
+1 a discovered grid gets the toggle dot and positioning only — no rounding.
 
 ### D2 — TableAdapter abstraction (sprint 2)
 
@@ -111,66 +168,49 @@ GridAdapter(wrapperElement)
   .isVirtualized()  → true
 ```
 
-`getRows()` for `GridAdapter` identifies rows and cells **structurally**, the
-same way `findDataGrids()` detected the grid — it does not depend on ARIA:
-
-- **Rows** = the repetitive, uniform-height direct children of the grid's
-  scrollable content container.
-- **Cells** = the repetitive children of each row.
-- **ARIA shortcut (when present):** if the grid exposes `[role="row"]` /
-  `[role="gridcell"]`, use those selectors directly — they are faster and more
-  precise than positional enumeration. Fall back to structural child
-  enumeration when roles are absent.
-- **Pinned pane (when present):** for each scrollable row, also collect the
-  same-index row from the pinned pane and merge cells in DOM order (pinned
-  columns first). When there is no pinned pane (single-pane grid), rows come
-  from the one container.
-
-This stitching and structural extraction is the interface contract — callers
-never know whether they are reading one DOM tree or two, labelled or unlabelled.
-
 `NativeTableAdapter.getRows()` wraps `table.rows` / `row.cells` exactly as
-today. All existing behavior is preserved verbatim.
-
-`roundTable`, `resetTable`, `extractPreviewSamples`, and `isDataTable` are
-rewritten to call `adapter.getRows()` instead of `table.rows`. No caller is
-changed; the adapter is constructed at the call site based on element type.
+today — zero behavior change. `GridAdapter.getRows()` is a stub returning `[]`
+in this sprint (sprint 3 fills it in). `roundTable`, `resetTable`,
+`extractPreviewSamples`, and `isDataTable` are rewritten to call
+`adapter.getRows()`; no caller signature changes. A `makeAdapter(el)` factory
+picks the class by `el.tagName === 'TABLE'`.
 
 ### D3 — GridAdapter read/write + visible-row rounding (sprint 3)
 
-Implement `GridAdapter` fully (sprint 2 defines the interface; sprint 3 fills
-in the body). Key concerns:
+`GridAdapter.getRows()` extracts rows/cells **structurally** (S2), with ARIA /
+library selectors as shortcuts when present:
 
-- `getText()` reads `cell.textContent` (grids use no `<td>`; cells are plain
-  divs, with or without a `role="gridcell"` attribute).
-- `setText(s)` writes `cell.textContent` and applies `.dr-ext-rounded` just as
-  `roundTable` does today — but only to visible (currently-rendered) cells.
-- `resetTable` via the adapter clears `.dr-ext-rounded` only from nodes
-  currently in the DOM; sprint 4 handles persistence across scroll.
+- **Rows** = repetitive children of the scrollable content container (or
+  `[role="row"]` when present).
+- **Cells** = repetitive children of each row (or `[role="gridcell"]`).
+- **Pinned pane**, when present, is stitched per row by `data-row-index` (or DOM
+  index) with pinned columns first. Single-pane grids skip this.
+
+`setText` writes `cell.textContent` and adds `.dr-ext-rounded`. **Original
+values are keyed by logical (rowIndex, colIndex)** in a per-grid Map (see Open
+Question on recycling), not stored solely on the cell node. Rounding applies
+only to currently-visible rows.
 
 ### D4 — Virtualization re-apply observer (sprint 4)
 
-When a grid is rounded, attach a `MutationObserver` to each scroll container
-that watches for `childList` changes (row recycling). On each mutation, re-run
-the rounding pass for newly-added rows, using the stored `tableOptions`
-WeakMap entry for the grid's wrapper element. Unrounded grids get no observer.
+When a virtualized grid is rounded, attach a `MutationObserver` to its scroll
+container watching `childList`. Mutations are **debounced to 100 ms** (S5); on
+fire, `reapplyGridRounding` rounds only rows lacking `.dr-ext-rounded`. The
+observer is torn down on reset / toggle-off and when the grid is removed.
 
-The observer is torn down when the toggle is switched off (same path that calls
-`resetTable`).
-
-## 3. Sprint List & Dependency Graph
+## 5. Sprint List & Dependency Graph
 
 ### Sprint List
 
-1. **grid-detection** — Discovery + toggle placement for ARIA grids; no
-   rounding. _Depends on:_ none.
-2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` interface;
-   refactor `roundTable`, `resetTable`, `extractPreviewSamples`, `isDataTable`
-   to use adapters. Existing tests must stay green. _Depends on:_ none (can
-   overlap with sprint 1 on a separate branch; merges to main independently).
-3. **grid-rounding** — Implement `GridAdapter` body; enable rounding for
-   currently-visible grid rows. _Depends on:_ grid-adapter merged to main.
-4. **grid-virtualization** — MutationObserver on scroll containers to re-apply
+1. **grid-detection** — Proactive cheap pass (native + ARIA) and lazy
+   right-click structural walk-up; toggle placement; no rounding.
+   _Depends on:_ none.
+2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` interface; refactor
+   the four engine functions to use adapters. Existing tests stay green.
+   _Depends on:_ none.
+3. **grid-rounding** — Implement `GridAdapter` body; round currently-visible
+   grid rows. _Depends on:_ grid-adapter merged to main.
+4. **grid-virtualization** — 100 ms-debounced MutationObserver to re-apply
    rounding on row recycle. _Depends on:_ grid-rounding merged to main.
 
 ### Dependency Graph
@@ -178,298 +218,255 @@ The observer is torn down when the toggle is switched off (same path that calls
 ```mermaid
 flowchart TD
     base[main]
-    s1["grid-detection<br/>Discovery + toggle, no rounding"]
+    s1["grid-detection<br/>Proactive cheap + lazy walk-up, no rounding"]
     s2["grid-adapter<br/>TableAdapter abstraction, tests green"]
     s3["grid-rounding<br/>GridAdapter body + visible-row rounding"]
-    s4["grid-virtualization<br/>Re-apply on scroll / row recycle"]
+    s4["grid-virtualization<br/>Re-apply on recycle, 100ms debounce"]
     base --> s1
     base --> s2
     s2 --> s3
     s3 --> s4
 ```
 
-Sprints 1 and 2 are independent of each other (different files, no shared
-interface) and can be developed in parallel. Sprint 1 can also merge to main
-before sprint 2 — the toggle will appear on grids but do nothing until sprint 3.
+Sprints 1 and 2 are independent (different concerns, no shared interface) and
+can be developed in parallel. Sprint 1 can merge before sprint 2 — the dot
+appears on grids but does nothing until sprint 3.
 
-## 4. Sprint Definitions
+## 6. Sprint Definitions
 
 ### grid-detection
 
-- **Goal:** Make the extension discover and badge **unlabelled** data grids
-  (div-based tables with no `<table>` tag and no ARIA roles) with the existing
-  toggle button, using a structural/heuristic detector. ARIA roles and library
-  class prefixes are used as optional accelerators when present. No rounding
-  happens yet; this sprint validates that heuristic discovery and toggle
-  positioning work on real pages (Databricks, AG Grid, and at least one
-  unlabelled grid).
+- **Goal:** Discover data grids and badge them with the existing toggle dot,
+  using a proactive cheap pass for native/ARIA grids and a lazy right-click
+  structural walk-up for unlabelled div-grids. No rounding yet; this validates
+  discovery and dot placement on real pages (Databricks, AG Grid, and a
+  role-less div-grid).
 - **Scope — `chrome-extension/content.js`:**
-  - Add a module-level `findDataGrids(root = document)` (based on research doc
-    §4) that returns candidate grid root elements. It scores each `div`/`section`
-    container on: repetitive uniform-height children (rows), uniform-width
-    grandchildren (cells), `display: grid`/`flex` layout, and **at least one
-    cell containing a finite number** (the primary false-positive guard). A
-    container passing the structural test qualifies with no ARIA required.
-  - Confidence boosters (raise score, never required): `role="grid"/"row"/"gridcell"`
-    attributes, library prefixes (`dg--`, `ag-`, `awsui-`), virtualization
-    markers (`transform: translateY`, `position: absolute`, large `scrollHeight`
-    vs small `offsetHeight`), and a pinned + scrollable sibling pair. Define a
-    score threshold; document it inline so it can be tuned against real pages.
-  - `injectTableToggles` (L434): after the `querySelectorAll('table')` pass, run
-    `findDataGrids()`; for each result call `createToggleForTable` with a guard
-    that skips elements already carrying `dr-ext-grid` (idempotency). Also skip
-    any element that *is* or *contains* a native `<table>` already handled.
-  - MutationObserver (L469–494): re-run `findDataGrids(node)` for added nodes;
-    mirror removal handling for grids.
-  - Right-click handler (L49, L71): replace `closest('table')` with a helper
-    `findTargetTable(el)` that returns the nearest `<table>` OR the nearest
-    ancestor carrying `dr-ext-grid` (set during discovery). This avoids relying
-    on a role/class selector that unlabelled grids won't have.
-  - `createToggleForTable`: add an early branch — if the element is not a
-    `<table>`, skip `isDataTable()` (it reads `.rows`) and instead confirm via a
-    lightweight structural check (`findDataGrids` already validated it; re-use
-    the same numeric-content probe). If it passes, attach the toggle.
-  - Mark discovered grids with `el.classList.add('dr-ext-grid')`.
-  - `positionToggle`: already uses `getBoundingClientRect()`, which works for
-    any element — no change needed.
+  - Add module-level `looksLikeGrid(el)` implementing the D1 cheap-first ladder:
+    child count → repetitive structure → consistent cell count → layout →
+    numeric content → (only then) column-width alignment. Returns a boolean.
+    **Do not test row height.** ARIA role / library class on `el` short-circuits
+    to accept and skips the geometry probe.
+  - **Proactive pass:** in `injectTableToggles` (L434), keep
+    `querySelectorAll('table')`; add a second cheap pass
+    `querySelectorAll('[role="grid"], [role="table"]')`. For each, call
+    `createToggleForTable`, skipping anything already carrying `dr-ext-grid` or
+    that is / contains an already-handled `<table>`. No structural scan here.
+  - MutationObserver (L469–494): mirror only the two cheap selector passes for
+    added nodes; mirror removal handling. **No structural scanning in the
+    observer** (that would re-introduce the cost lazy discovery avoids).
+  - **Lazy pass:** add `findTargetTable(el)` used by the right-click handler
+    (L49, L71): return the nearest `<table>`; else the nearest ancestor carrying
+    `dr-ext-grid`; else walk up calling `looksLikeGrid` (depth cap ~15, stop at
+    `<body>`), and on first match add `dr-ext-grid`, badge it, and return it.
+  - `createToggleForTable`: when the element is not a `<table>`, skip
+    `isDataTable()` (reads `.rows`) and gate on `looksLikeGrid` instead.
+  - Mark discovered grids `el.classList.add('dr-ext-grid')`.
+  - `positionToggle` already uses `getBoundingClientRect()` — no change.
 - **Scope — `chrome-extension/tests.js`:**
-  - Unit tests for `findDataGrids()` against synthetic DOM fixtures:
-    - **Pass — unlabelled grid:** plain `<div>` rows, no roles, uniform height,
-      numeric cells. (This is the headline case.)
-    - **Pass — ARIA grid:** same structure plus `role="grid"`.
+  - Unit tests for `looksLikeGrid()`:
+    - **Pass — unlabelled grid:** plain `<div>` rows/cells, no roles, **mixed
+      text+number with varying row heights**, aligned columns, numeric cells.
+      (Headline — proves the column-structure spine, S2.)
+    - **Pass — ARIA grid:** same plus `role="grid"` (short-circuit path).
     - **Pass — pinned+scrollable:** Databricks-shaped split.
-    - **Reject — layout grid:** CSS `display: grid` cards with no numeric rows
-      (fails the numeric-content guard).
-    - **Reject — nav menu:** repetitive uniform children but no numbers.
-- **Out of scope:** Any actual rounding of grid contents. The toggle's click
-  handler will fire but `roundTable` will no-op (`.rows` is undefined on a
-  div) — that is acceptable for this sprint.
+    - **Reject — layout grid:** CSS cards, no numeric rows (numeric guard).
+    - **Reject — nav menu:** repetitive rows, no numbers.
+  - Test `findTargetTable` walk-up: returns the tightest grid ancestor and stops
+    (does not overshoot to a page-level container).
+- **Out of scope:** Any rounding. The toggle click fires but `roundTable`
+  no-ops on a div (`.rows` undefined) — acceptable this sprint.
 - **Acceptance criteria:**
-  - On a page with an **unlabelled** div-grid (no `<table>`, no `role`), the
-    extension detects it via `findDataGrids()` and injects a correctly
-    positioned toggle button.
-  - The same works for ARIA grids and the Databricks pinned+scrollable shape.
-  - Right-clicking a cell inside a detected grid sets `lastRightClickedTable`
-    to the grid root (via the `dr-ext-grid` ancestor walk).
-  - No toggle appears on a plain CSS layout grid with no numeric data rows.
+  - A native `<table>` and an ARIA `[role="grid"]` both get a correctly placed
+    dot on page load (proactive).
+  - An **unlabelled** div-grid with **variable row heights** gets a dot after a
+    right-click on one of its cells (lazy), and the dot is placed on the tightest
+    grid root.
+  - No structural scanning runs on page load or in the MutationObserver
+    (verified by test/inspection — the heavy path is right-click-only).
+  - No dot on a CSS layout grid with no numeric rows.
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** none
-- **Complexity:** M _(raised from S — the heuristic scorer and its
-  false-positive tuning are the real work, not a selector query.)_
+- **Complexity:** M
 - **Dev notes:**
-  - The numeric-content guard is the single most important false-positive
-    filter — without it the structural heuristic lights up on nav bars, card
-    grids, and toolbars. Keep it mandatory.
-  - Do not rename `lastRightClickedTable` — its type widens to "table or grid
-    root" but renaming would touch too many call sites. Document the widened
-    contract in a comment.
+  - Numeric-content guard is mandatory — it's what keeps the heuristic off nav
+    bars and card grids.
+  - Do not rename `lastRightClickedTable`; its type widens to "table or grid
+    root". Document the widened contract in a comment.
   - Do not bump `manifest.json` version.
 
 ---
 
 ### grid-adapter
 
-- **Goal:** Refactor the rounding engine to operate on a `TableAdapter`
-  interface rather than raw `<table>` DOM. `NativeTableAdapter` must be
-  behavior-identical to today — all existing tests stay green. `GridAdapter`
-  defines the interface contract but its body is a stub (sprint 3 fills it in).
+- **Goal:** Refactor the rounding engine onto a `TableAdapter` interface.
+  `NativeTableAdapter` is behavior-identical to today (all existing tests stay
+  green). `GridAdapter` defines the contract with a stubbed body (sprint 3 fills
+  it in).
 - **Scope — `chrome-extension/content.js`:**
-  - Define `NativeTableAdapter` class at module level (near `isDataTable`):
-    - `constructor(el)` — stores `this.el = el`.
-    - `getElement()` — returns `this.el`.
-    - `isVirtualized()` — returns `false`.
-    - `getRows()` — returns `Array.from(el.rows).map(row => ({ getCells: () =>
-      Array.from(row.cells).map(cell => ({ getText: () => cell.innerText ||
-      cell.textContent, setText: (s) => { /* existing write logic */ },
-      el: cell, tagName: cell.tagName })) }))`.
-  - Define `GridAdapter` class stub:
-    - `constructor(el)` — stores `this.el = el`.
-    - `getElement()` — returns `this.el`.
-    - `isVirtualized()` — returns `true`.
-    - `getRows()` — returns `[]` (stub; sprint 3 implements).
-  - Add `makeAdapter(el)` factory: returns `new NativeTableAdapter(el)` if
-    `el.tagName === 'TABLE'`, else `new GridAdapter(el)`.
-  - Rewrite `isDataTable(table)`: accept an adapter (or element — wrap in
-    `makeAdapter` if an element is passed). Replace `.rows` / `.cells` access
-    with `adapter.getRows()` / `row.getCells()`.
-  - Rewrite `roundTable(table, options)`: call `makeAdapter(table)` at the top;
-    replace all `table.rows` / `row.cells` / `cell.tagName` access with adapter
-    calls. Return early if `adapter.getRows().length === 0` (handles the stub).
-  - Rewrite `resetTable(table)`: replace `table.rows` access with
-    `makeAdapter(table).getRows()`.
-  - Rewrite `extractPreviewSamples(table)`: same.
-  - The `tableOptions` WeakMap key remains the raw element (not the adapter) —
-    adapters are ephemeral per-call, elements are stable.
-- **Scope — `chrome-extension/tests.js`:**
-  - All existing tests must pass unchanged. Add two adapter unit tests:
-    `NativeTableAdapter` round-trips `getText`/`setText` correctly;
-    `GridAdapter` stub `getRows()` returns `[]` without throwing.
-- **Out of scope:** `GridAdapter.getRows()` implementation (sprint 3). Any
-  changes to `sidebar.js`, `defaults.js`, or the toggle UI.
+  - `NativeTableAdapter` (near `isDataTable`): `getElement()`,
+    `isVirtualized() → false`, and `getRows()` wrapping `Array.from(el.rows)` /
+    `row.cells` with `getText`/`setText`/`el`/`tagName` per cell, reproducing the
+    current logic verbatim.
+  - `GridAdapter` stub: `getElement()`, `isVirtualized() → true`,
+    `getRows() → []`.
+  - `makeAdapter(el)` factory: `NativeTableAdapter` if `el.tagName === 'TABLE'`,
+    else `GridAdapter`.
+  - Rewrite `isDataTable`, `roundTable`, `resetTable`, `extractPreviewSamples`
+    to read via `adapter.getRows()` / `row.getCells()`. `roundTable` returns
+    early if `getRows()` is empty (handles the stub).
+  - `tableOptions` WeakMap stays keyed by the raw element; adapters are
+    constructed fresh per call (grids change row count on scroll — never cache).
+- **Scope — `chrome-extension/tests.js`:** all existing tests pass unchanged;
+  add `NativeTableAdapter` round-trip test and a `GridAdapter` stub test.
+- **Out of scope:** `GridAdapter.getRows()` body; UI / sidebar / defaults.
 - **Acceptance criteria:**
-  - `node chrome-extension/tests.js` passes with zero regressions.
-  - Rounding a native `<table>` produces byte-identical results to the
-    pre-refactor build (verified by the existing test suite).
-  - `roundTable` called on a `[role="grid"]` element returns without throwing
-    (stub path).
+  - `node chrome-extension/tests.js` passes, zero regressions.
+  - Native `<table>` rounding is byte-identical to the pre-refactor build.
+  - `roundTable` on a grid element returns without throwing (stub path).
 - **Depends on:** none
 - **Complexity:** M
 - **Dev notes:**
-  - The adapter is constructed fresh on each `roundTable` / `resetTable` call —
-    no caching. Grids change their row count on scroll; a cached adapter would
-    return stale rows.
-  - Keep `NativeTableAdapter.getRows()` implementation as a thin wrapper around
-    the existing logic — do not simplify or restructure the row/cell iteration.
-    The goal is zero behavior change, not cleanup.
+  - Keep `NativeTableAdapter.getRows()` a thin wrapper — zero behavior change,
+    not a cleanup.
   - Do not bump `manifest.json` version.
 
 ---
 
 ### grid-rounding
 
-- **Goal:** Implement `GridAdapter.getRows()` so that rounding, reset, and
-  preview-sample extraction work on the currently-visible rows of a data grid.
+- **Goal:** Implement `GridAdapter.getRows()` so rounding, reset, and preview
+  extraction work on the currently-visible rows of a data grid.
 - **Scope — `chrome-extension/content.js`:**
-  - Implement `GridAdapter.getRows()` — **structural first, ARIA as shortcut:**
-    1. Find the scrollable content container. Prefer known library selectors
-       when present (`.dg--grid-scroll-container`, `.ag-center-cols-viewport`,
-       `[role="grid"]:not(.dg--pinned-grid)`); otherwise pick the descendant
-       holding the repetitive uniform-height children that `findDataGrids`
-       identified. Fall back to `this.el`.
-    2. Find the pinned pane if one exists (`.dg--pinned-grid`,
-       `.ag-pinned-left-cols-container`, or a sibling container with matching
-       row count) — may be `null` for single-pane / unlabelled grids.
-    3. Collect rows. **ARIA shortcut:** if `[role="row"]` elements exist, use
-       them. **Structural fallback (unlabelled grids):** take the repetitive
-       uniform-height direct children of the scroll container as rows.
-    4. For each scrollable row at index `i`, collect the pinned row at the same
-       index (if a pinned pane exists): match by `data-row-index` when present,
-       otherwise by DOM index.
-    5. Cells per row: prefer `[role="gridcell"]` when present; otherwise the
-       row's repetitive child elements (structural). Merge pinned cells first.
-    6. Return row objects: `{ getCells: () => [...pinnedCells, ...scrollableCells].map(cell => ({ getText: () => cell.textContent, setText: (s) => { cell.textContent = s; cell.classList.add('dr-ext-rounded'); cell.dataset.drOriginal = cell.dataset.drOriginal || cell.textContent; }, el: cell, tagName: 'TD' /* normalized */ })) }`.
-  - `setText` in `GridAdapter` must store the original value in
-    `cell.dataset.drOriginal` before overwriting (for reset), mirroring how
-    `NativeTableAdapter` stores it.
-  - `resetTable` via `GridAdapter`: clear `.dr-ext-rounded`, restore
-    `cell.textContent` from `cell.dataset.drOriginal`, delete
-    `cell.dataset.drOriginal`.
-  - `isDataTable` via `GridAdapter`: sample up to 10 cells from `getRows()`;
-    return `true` if any contains a finite parseable number.
-  - Update `createToggleForTable` grid path (from sprint 1): now that
-    `getRows()` works, replace the stub check with `isDataTable(makeAdapter(el))`.
+  - Implement `GridAdapter.getRows()` — structural first, ARIA/library as
+    shortcut:
+    1. Scroll container: prefer library selectors
+       (`.dg--grid-scroll-container`, `.ag-center-cols-viewport`,
+       `[role="grid"]:not(.dg--pinned-grid)`); else the descendant holding the
+       repetitive aligned-column children `looksLikeGrid` keyed on; else `this.el`.
+    2. Pinned pane (`.dg--pinned-grid`, `.ag-pinned-left-cols-container`, or a
+       sibling with matching row count) — may be `null`.
+    3. Rows: `[role="row"]` when present, else the repetitive children of the
+       scroll container.
+    4. Stitch pinned row at matching `data-row-index` (or DOM index) per row.
+    5. Cells: `[role="gridcell"]` when present, else repetitive row children;
+       pinned cells first.
+    6. Per cell: `getText() → cell.textContent`; `setText(s)` writes
+       `textContent`, adds `.dr-ext-rounded`, and records the original keyed by
+       **logical (rowIndex, colIndex)** in a per-grid originals Map.
+  - `resetTable` via `GridAdapter`: restore visible cells from the originals Map
+    and clear `.dr-ext-rounded`; non-visible rows already show the framework's
+    original text.
+  - `isDataTable` via `GridAdapter`: sample ≤ 10 cells; true if any is a finite
+    number.
+  - `createToggleForTable` grid path: replace the sprint-1 `looksLikeGrid` gate
+    with `isDataTable(makeAdapter(el))` now that `getRows()` works.
 - **Scope — `chrome-extension/tests.js`:**
-  - Add tests with synthetic grid DOM fixtures — both labelled and unlabelled:
-    - **Unlabelled grid** (no roles): plain `<div>` rows/cells with numbers —
-      structural extraction finds rows/cells and rounding applies. (Headline.)
-    - **ARIA grid:** `role="grid"`/`row`/`gridcell` — shortcut path used.
-    - A grid with a pinned pane: cell stitching produces correct column order.
-    - `resetTable` on a rounded grid restores original values.
-    - `extractPreviewSamples` on a grid returns the expected sample structure.
-- **Out of scope:** Re-applying rounding on scroll / row recycle (sprint 4).
-  The rounding state is lost when rows leave the viewport — that is acceptable
-  and documented as a known limitation until sprint 4.
+  - Unlabelled grid (no roles, variable row heights): structural extraction +
+    rounding applies. (Headline.)
+  - ARIA grid: shortcut path.
+  - Pinned pane: correct stitched column order.
+  - Reset restores originals.
+  - `extractPreviewSamples` returns the expected structure.
+- **Out of scope:** Re-apply on scroll / recycle (sprint 4). Rounding state is
+  lost when rows leave the viewport — documented limitation until sprint 4.
 - **Acceptance criteria:**
-  - Right-clicking a cell in a Databricks SQL result grid and choosing "Apply
-    rounding" visibly rounds the numbers in all currently-visible cells.
-  - Toggling off restores original values.
+  - Right-clicking a cell in a Databricks result and applying rounding rounds
+    all currently-visible cells; toggling off restores originals.
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** grid-adapter merged to main
 - **Complexity:** M
 - **Dev notes:**
-  - The pinned/scrollable stitching by DOM index is fragile if the two panes
-    have different row counts (e.g., header rows in one but not the other). Use
-    `data-row-index` matching when available; log a `console.debug` warning and
-    fall back to index matching otherwise.
-  - Do not attempt to scroll-trigger additional row rendering — only round what
-    is visible.
+  - Stitch by `data-row-index` when available; `console.debug` and fall back to
+    DOM index otherwise.
+  - Only round what is visible — never scroll-trigger extra rendering.
   - Do not bump `manifest.json` version.
 
 ---
 
 ### grid-virtualization
 
-- **Goal:** Keep a rounded grid rounded as the user scrolls: re-apply (or
-  un-apply) rounding to rows that are recycled into the viewport.
+- **Goal:** Keep a rounded grid rounded as the user scrolls — re-apply rounding
+  to rows recycled into the viewport.
 - **Scope — `chrome-extension/content.js`:**
-  - Add `gridObservers: WeakMap<Element, MutationObserver>` at module level
-    (parallel to `tableToggles`).
-  - In `roundTable`, after applying rounding, check `adapter.isVirtualized()`.
-    If `true`:
-    1. Find the scroll container element (same query as `GridAdapter.getRows()`,
-       step 1).
-    2. Create a `MutationObserver` that, on each `childList` mutation, calls a
-       helper `reapplyGridRounding(wrapperEl)`.
-    3. `reapplyGridRounding`: re-runs `roundTable(wrapperEl, tableOptions.get(wrapperEl))`
-       but only processes rows that do **not** already have `.dr-ext-rounded`
-       cells — avoids double-rounding already-visible rows.
-    4. `observe(scrollContainer, { childList: true, subtree: true })`.
-    5. Store in `gridObservers.set(wrapperEl, observer)`.
-  - In `resetTable`, if `adapter.isVirtualized()` and `gridObservers.has(el)`:
-    disconnect and delete the observer before clearing cells.
-  - In the MutationObserver that watches for removed tables (L493): also check
-    `gridObservers` for the removed element and disconnect.
+  - Add `gridObservers: WeakMap<Element, MutationObserver>`.
+  - In `roundTable`, when `adapter.isVirtualized()`: find the scroll container,
+    create a `MutationObserver` on `childList`, **debounced to 100 ms** (S5),
+    whose handler `reapplyGridRounding(wrapperEl)` re-rounds only rows lacking
+    `.dr-ext-rounded`, using `tableOptions.get(wrapperEl)` and the per-grid
+    originals Map. Store in `gridObservers`.
+  - In `resetTable`: if virtualized and observed, disconnect and delete the
+    observer before restoring cells.
+  - In the removed-node observer (L493): disconnect any `gridObservers` entry
+    for a removed grid.
 - **Scope — `chrome-extension/tests.js`:**
-  - Synthetic test: create a grid wrapper, round it, simulate row recycling via
-    `appendChild` of a new `role="row"` child, verify `reapplyGridRounding` is
-    called and the new row is rounded.
-  - Verify that after `resetTable`, appending a new row does NOT trigger
-    rounding (observer disconnected).
-- **Out of scope:** Handling horizontal scroll (new columns entering the
-  viewport) — column virtualization is rare and adds significant complexity;
-  defer to a follow-up sprint.
+  - Round a grid, append a new row (simulated recycle), advance past the 100 ms
+    debounce, assert the new row is rounded.
+  - After reset, appending a row does **not** trigger rounding (observer gone).
+  - Debounce: N rapid mutations cause a single `reapplyGridRounding`.
+- **Out of scope:** Horizontal/column virtualization — see Open Questions.
 - **Acceptance criteria:**
-  - In a Databricks SQL result, scrolling down after rounding causes newly-
-    visible rows to be rounded automatically.
-  - Turning off rounding stops re-application.
-  - No observable performance regression on pages with native `<table>` elements
-    (the observer is never attached to non-virtualized tables).
+  - Scrolling a rounded Databricks result rounds newly-visible rows
+    automatically, with no visible stutter (100 ms debounce).
+  - Toggling off stops re-application.
+  - No perf regression on native `<table>` pages (observer never attached to
+    non-virtualized tables).
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** grid-rounding merged to main
 - **Complexity:** M
 - **Dev notes:**
-  - `reapplyGridRounding` must be debounced (e.g., 50 ms `requestAnimationFrame`
-    or `setTimeout`) — grids can fire dozens of DOM mutations in a single scroll
-    tick and we don't want to re-run rounding synchronously for each one.
-  - The `subtree: true` option is necessary because grids often wrap rows in an
-    intermediate container. Monitor observed mutation counts in practice; if the
-    observer is too noisy, narrow to `childList: true` without `subtree` and
-    instead watch only direct children of the scroll container.
+  - Debounce coalesces a scroll burst's mutations into one 100 ms-spaced
+    re-round; keep each pass cheap by touching only un-rounded rows.
+  - `subtree: true` is likely needed (grids wrap rows in intermediate
+    containers); narrow to direct children if mutation volume is high.
   - Do not bump `manifest.json` version.
 
-## 5. Open Questions
+## 7. Open Questions & Risks
 
-- **Synchronized-scroll verification:** The research doc flags this as
-  unresolved. Before sprint 3 ships, manually verify on a live Databricks page
-  that scrolling the scrollable pane does move the pinned pane in sync (it
-  almost certainly does, but the stitching logic in `GridAdapter.getRows()`
-  depends on row index alignment being maintained at all times).
-- **AG Grid and Cloudscape selectors:** The sprint 3 `GridAdapter` selector
-  list covers Databricks and AG Grid. AWS Cloudscape (`.awsui-table-wrapper`)
-  and Azure Data Studio have not been tested. Add their selectors before sprint
-  3 ships if a test environment is available.
-- **Column virtualization:** Some grids (especially wide ones) also virtualize
-  columns — cells outside the horizontal viewport are not rendered. Sprint 4
-  does not address this. If it becomes a user report, it warrants a sprint 5.
-- **Right-click targeting depth:** `closest('[role="grid"]')` walks up from the
-  clicked cell. If the grid library wraps cells in extra divs, the walk may
-  overshoot to a parent grid. Add a depth limit or prefer the closest match.
+- **Framework clobbering (highest feasibility risk).** A grid cell is owned by
+  React/Angular; writing `cell.textContent` can be overwritten on the
+  framework's next render — not only on scroll-recycle (which sprint 4 handles)
+  but on any same-position re-render. The 100 ms re-apply observer is the
+  mitigation, but this is a "fight the framework" pattern. Validate on a live
+  Databricks page during sprint 3 before committing to the approach; if same-
+  position re-renders wipe rounding faster than we can re-apply, reconsider
+  (e.g., overlay rendering instead of in-place text replacement).
+- **Original-value persistence across recycle.** Originals must be keyed by
+  logical (rowIndex, colIndex), not stored only on the cell node (recycled away
+  on scroll). This needs a stable logical row id — `data-row-index` when the
+  grid provides it. Grids without any stable row id can round visible rows but
+  cannot reliably reset after scrolling; document as a limitation and detect the
+  no-id case.
+- **Walk-up stopping rule.** Lazy discovery returns the first ancestor passing
+  `looksLikeGrid`. Confirm this picks the grid root and not an inner pane
+  (pinned/scroll) — prefer the innermost match but verify it's the element that
+  owns both panes. Depth cap prevents overshoot to page-level containers.
+- **Synchronized-scroll assumption.** Pinned+scroll stitching assumes the two
+  panes keep row-index alignment at all times. Verify on a live Databricks page
+  before sprint 3 ships.
+- **AG Grid / Cloudscape / Azure Data Studio selectors.** Sprint 3's selector
+  list covers Databricks and AG Grid; add others if a test environment exists.
+- **Column virtualization.** Wide grids may also virtualize columns
+  (off-screen cells absent). Not handled; warrants a follow-up sprint if
+  reported.
 
-## 6. Out of Scope (Separate Sprint-Stack)
+## 8. Out of Scope (Separate Sprint-Stack)
 
-- Column virtualization (horizontal scroll recycling).
-- Google Sheets / Excel Online (these use canvas rendering in some browsers, not
-  DOM nodes — a fundamentally different approach is needed).
+- Column (horizontal) virtualization.
+- Google Sheets / Excel Online (canvas-rendered in places, not DOM — a
+  different approach entirely).
 - Python / `js/` sibling implementations — grid support is browser-only.
 
 ## Decisions Log
 
-- 2026-06-10: Initial draft. Sprints 1 and 2 are independent; 3 depends on 2;
-  4 depends on 3.
-- 2026-06-10: Reoriented detection and extraction around **structural
-  heuristics** for unlabelled grids (the research doc's actual focus). ARIA
-  roles and library class prefixes demoted from required selectors to optional
-  accelerators used when present. Dropped the pinned+scrollable co-occurrence as
-  a hard requirement (single-pane unlabelled grids must still be detected);
-  numeric-content + uniform-geometry is now the primary false-positive guard.
-  Sprint 1 complexity raised S → M.
+- 2026-06-10: Initial draft. Sprints 1 and 2 independent; 3 depends on 2; 4 on 3.
+- 2026-06-10: Reoriented detection/extraction around structural heuristics for
+  unlabelled grids; ARIA/library classes demoted to optional accelerators;
+  numeric-content the primary false-positive guard.
+- 2026-06-10: Strategy finalized after design discussion —
+  (a) **column-structure**, not row-height, is the heuristic spine (variable row
+  heights are normal); (b) **lazy right-click discovery** for unlabelled grids,
+  proactive badging only for the cheap native/ARIA signals; (c) geometry probe
+  measured last and narrowest; (d) re-apply observer **debounced to 100 ms**.
+  Added framework-clobbering, original-value-persistence, and walk-up-stopping
+  as tracked risks.

--- a/docs/sprint-plans/grid-support.md
+++ b/docs/sprint-plans/grid-support.md
@@ -224,12 +224,19 @@ toggle-off, and grid removal.
 
 ### Sprint List
 
+**Execute strictly sequentially — one branch at a time, each off the updated
+`main` after the prior sprint merges.** Although sprints 1 and 2 are *logically*
+independent, both edit `content.js` and both touch `createToggleForTable` and
+`isDataTable`, so developing them on parallel branches would create avoidable
+merge conflicts. Do them in order.
+
 1. **grid-detection** — Proactive cheap pass (native + ARIA) and lazy
    right-click structural walk-up; toggle placement; no rounding.
-   _Depends on:_ none.
+   _Depends on:_ none. _Branch from:_ `main`.
 2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` stub interface;
    refactor the four engine functions to use adapters. Existing tests stay green.
-   _Depends on:_ none.
+   _Depends on:_ grid-detection merged to main (shared edits to
+   `createToggleForTable` / `isDataTable`). _Branch from:_ updated `main`.
 3. **grid-rounding** — Implement `GridAdapter.getRows()`; round currently-
    visible grid rows. _Depends on:_ grid-adapter merged to main.
 4. **grid-virtualization** — 100 ms-debounced MutationObserver to re-apply
@@ -245,14 +252,15 @@ flowchart TD
     s3["grid-rounding<br/>GridAdapter body + visible-row rounding"]
     s4["grid-virtualization<br/>Re-apply on recycle, 100ms debounce"]
     base --> s1
-    base --> s2
+    s1 --> s2
     s2 --> s3
     s3 --> s4
 ```
 
-Sprints 1 and 2 are independent (different concerns, no shared interface) and
-can be developed in parallel. Sprint 1 can merge before sprint 2 — the dot
-appears on grids but does nothing until sprint 3.
+The chain is linear: each sprint branches from `main` only after the previous
+one has merged. Sprints 1 and 2 have no *logical* dependency, but the file-level
+overlap in `content.js` (`createToggleForTable`, `isDataTable`) makes sequential
+execution the conflict-free path for a single developer/session.
 
 ## 6. Sprint Definitions
 
@@ -318,7 +326,7 @@ appears on grids but does nothing until sprint 3.
   `NativeTableAdapter` must be behavior-identical to today (all existing tests
   stay green). `GridAdapter` defines the contract with a stubbed body (sprint 3
   fills it in).
-- **Branch:** `refactor/grid-adapter` off `main`
+- **Branch:** `refactor/grid-adapter` off `main` after grid-detection merges
 - **Scope — `chrome-extension/content.js`:**
   - `NativeTableAdapter` class (near `isDataTable`):
     - `constructor(el)` — `this.el = el`
@@ -343,7 +351,8 @@ appears on grids but does nothing until sprint 3.
   - `node chrome-extension/tests.js` passes with zero regressions.
   - Native `<table>` rounding byte-identical to pre-refactor build.
   - `roundTable` on a grid element returns without throwing.
-- **Depends on:** none
+- **Depends on:** grid-detection merged to main (avoids `content.js` conflicts
+  in `createToggleForTable` / `isDataTable`)
 - **Complexity:** M
 - **Dev notes:**
   - `NativeTableAdapter.getRows()` is a thin wrapper — zero behavior change.
@@ -482,3 +491,8 @@ appears on grids but does nothing until sprint 3.
   map needed; only currently-visible `.dr-ext-rounded` cells ever need resetting.
   (g) Framework-clobbering flagged as the highest feasibility risk; live
   validation required before sprint 4 commitment.
+- 2026-06-10: Switched to **strictly sequential execution** (1 → 2 → 3 → 4, each
+  branched from `main` after the prior merges). Sprints 1 and 2 are logically
+  independent but both edit `content.js` `createToggleForTable` / `isDataTable`,
+  so parallel branches would conflict. Linear chain is the conflict-free path for
+  a single developer/session.

--- a/docs/sprint-plans/grid-support.md
+++ b/docs/sprint-plans/grid-support.md
@@ -4,15 +4,15 @@
 **Base branch:** main
 **Slug:** grid-support
 
-## Context
+## 1. Context
 
 The dynamic-rounding Chrome extension rounds numbers in native HTML `<table>`
 elements. Modern web apps — Databricks SQL, AG Grid dashboards, Azure Data
 Studio, AWS Cloudscape — render results as **data grids** built from plain
 `<div>` containers, often virtualized (only visible rows exist in the DOM) and
 often split into pinned (frozen columns) and scrollable panes. Many such grids
-carry no `<table>` tag and no ARIA roles at all. These grids are invisible to
-the extension today.
+carry no `<table>` tag and no ARIA roles. These grids are invisible to the
+extension today.
 
 Research is in `docs/research/databricks-grid-detection.md`. Key structural
 facts:
@@ -29,69 +29,84 @@ Every layer of `content.js` is hard-wired to the `<table>` DOM API, so adding
 detection alone is not sufficient. The four sprints below address discovery,
 abstraction, rounding, and virtualization in dependency order.
 
-## 2. Strategy (agreed before planning)
+## 2. Strategy
 
-These decisions were worked out up front and shape every sprint:
+These decisions were finalized before planning and shape every sprint.
 
 ### S1 — Two extraction paths, four detection signals
 
 There are only **two** ways to *read* a table once found: the native table API
 (`.rows`/`.cells`, handles `colspan`/`th`) and div-walking (everything else).
-Native `<table>` is therefore its own path. ARIA grids and unlabelled grids
-share the div-walk path; they differ only in how they're *detected*.
+Native `<table>` is its own path. ARIA grids and unlabelled grids share the
+div-walk path; they differ only in how they are detected.
 
 Detection signals, in decreasing precision / increasing recall:
 `<table>` tag → library class (`dg--`, `ag-`) → ARIA `role` → raw structure.
-The cheap signals are also the precise ones, so they run first and the
-expensive structural heuristic runs last (and rarely).
+The cheap signals are also the precise ones, so they run first; the expensive
+structural heuristic runs last and rarely.
 
 ### S2 — Column structure, not row height, is the heuristic's spine
 
 Row-height uniformity is a **bad** signal: any table with a text column that
-wraps to a second line has variable row heights (most Wikipedia tables, most
-non-numeric Databricks results). The heuristic instead keys on:
+wraps produces variable row heights (most Wikipedia tables, most non-purely-
+numeric Databricks results). The heuristic instead keys on:
 
 - **Consistent cell count** — every candidate row has the same number of
-  children. (Cheap, no geometry.)
-- **Column-width alignment** — cells in the same position share a width;
-  columns line up vertically. (Robust to text wrapping — a column's width is
-  independent of how many lines its text occupies.)
+  children. Cheap, no geometry.
+- **Column-width alignment** — cells in the same column position share a
+  width; columns line up vertically. Robust to text wrapping.
 - **Repetitive row structure** — near-identical class names / child shape.
-- **Numeric content** — at least one cell parses as a finite number. This is
-  the single most important false-positive guard.
+- **Numeric content** — at least one cell parses as a finite number. The
+  single most important false-positive guard.
 
-Row height is demoted to an optional weak hint, never a requirement.
+Row height is not tested.
 
 ### S3 — Lazy discovery for unlabelled grids; proactive only where it's free
 
-The structural heuristic measures geometry (`offsetWidth` / `getComputedStyle`),
-which forces synchronous layout and is expensive on large, dynamic pages — which
-are exactly the pages that have these grids. So:
+The structural heuristic measures geometry (`offsetWidth`) which forces
+synchronous layout — expensive on large, dynamic pages, exactly the pages
+that have these grids. So:
 
-- **Proactive (on page load + cheap MutationObserver passes):** only the cheap
-  signals — `querySelectorAll('table')` and `[role="grid"], [role="table"]`.
-  These badge the toggle dot immediately and cost almost nothing.
-- **Lazy (on right-click only):** the structural heuristic. It does **not**
-  scan the page. It walks **up** from the clicked element, testing a handful of
-  ancestors, and badges the grid the first time the user interacts with it.
-
-Net effect: free dots where the signal is free; on-demand dots for the
-expensive unlabelled case, scoped to the one element the user clicked.
+- **Proactive (page load + MutationObserver):** only cheap signals —
+  `querySelectorAll('table')` and `[role="grid"], [role="table"]`. Badge the
+  dot immediately at negligible cost.
+- **Lazy (right-click only):** the structural heuristic. Walks **up** from
+  the clicked element, testing a bounded set of ancestors (see S6).
 
 ### S4 — Geometry measured last and narrowest
 
-Within the heuristic, cheap checks gate the expensive one: child count → class
-repetition → layout (`display`) → numeric content **first**; only the few
-candidates that survive get their column widths measured. Because lazy discovery
-already limits this to the right-clicked element's ancestors, the geometry probe
-touches a bounded handful of elements, never the page.
+Within the heuristic, cheap checks gate the expensive one: child count →
+class repetition → layout → numeric content **first**; only candidates
+surviving these get column widths measured. Lazy discovery further limits
+this to the right-clicked element's ancestors — never a page-wide scan.
 
 ### S5 — Debounce re-apply at 100 ms
 
-The sprint-4 re-apply observer batches the row-recycle mutations a virtualized
-grid fires during scroll and reacts at most once per **100 ms**. That is well
-under the ~100 ms "feels instant" threshold yet does ~6× less work than
-per-frame (16 ms) reaction.
+The sprint-4 re-apply observer batches the row-recycle mutations fired during
+scroll and reacts at most once per **100 ms** — well under the ~100 ms "feels
+instant" threshold while doing ~6× less work than per-frame reaction.
+
+### S6 — Walk-up stopping rule
+
+Lazy discovery walks up from the clicked element calling `looksLikeGrid` at
+each ancestor. It keeps going as long as the **parent also passes** —
+returning the **outermost** matching container, not the innermost. This
+naturally selects the wrapper element (e.g., `.dg--table-wrapper` containing
+both the pinned and scroll panes) over an inner pane, because the wrapper
+inherits the structural properties of its children. Stops when the parent
+fails the test, is `<body>`, or depth exceeds 15.
+
+### S7 — Original values stored on the node only
+
+When rounding a grid cell, the pre-round text is stored in
+`cell.dataset.drOriginal` on the cell node. This is sufficient: the only
+cells that ever need resetting are those currently in the DOM and marked
+`.dr-ext-rounded` — i.e., currently-visible rows. When a row scrolls out of
+view the framework recycles the node and overwrites our text; from our
+perspective the node is gone and no restoration is needed. The sprint-4
+re-apply observer re-rounds newly-visible rows from the stored *options*
+(`tableOptions` WeakMap), not from stored originals. No separate logical-
+coordinate originals map is needed.
 
 ## 3. Repo Survey
 
@@ -112,49 +127,46 @@ per-frame (16 ms) reaction.
 | `positionToggle` | 261 | `table.getBoundingClientRect()` |
 
 - Test command: `node chrome-extension/tests.js`
-- Branch naming: `feature/<label>` (never `claude/`)
-- Commit convention: Conventional Commits
+- Branch naming: `feature/<label>` / `fix/<label>` / `refactor/<label>` (never `claude/`)
+- Commit convention: Conventional Commits (`feat:`, `fix:`, `refactor:`)
 - Version bumps: handled by `.github/workflows/bump-version.yml` on merge to
-  main; sprint branches must NOT bump versions.
+  main; sprint branches must **not** bump versions.
 
 ## 4. Design
 
 ### D1 — Detection: proactive cheap pass + lazy structural walk-up (sprint 1)
 
-Two entry points, per strategy S3:
+Two entry points, per S3 + S6:
 
 **Proactive — `injectTableToggles` + MutationObserver:** keep the existing
-`querySelectorAll('table')` pass and add one cheap selector pass
+`querySelectorAll('table')` pass; add one cheap selector pass
 `querySelectorAll('[role="grid"], [role="table"]')`. Both badge the toggle dot
-on load. No structural scanning, no geometry. Native tables and ARIA grids are
-covered here.
+on load. No structural scanning, no geometry.
 
-**Lazy — `looksLikeGrid(el)` on right-click:** the right-click handler walks up
-from the clicked element; at each ancestor it calls `looksLikeGrid`, stopping at
-the **first** ancestor that passes (the tightest grid root). A depth cap (~15
-ancestors / stop at `<body>`) bounds the walk.
+**Lazy — `looksLikeGrid(el)` walk-up on right-click:** `findTargetTable(el)`
+replaces `closest('table')` in the right-click handler. It returns the nearest
+`<table>` ancestor first; else the nearest ancestor already carrying
+`dr-ext-grid`; else walks up calling `looksLikeGrid`, per S6 (outermost match,
+depth cap 15, stop at `<body>`). On a new match: add `dr-ext-grid` and badge.
 
 `looksLikeGrid(el)` applies the S2/S4 cheap-first ladder:
 
-1. **Child count** — ≥ ~5 children (candidate rows). Cheap.
+1. **Child count** — ≥ 5 children. Cheap.
 2. **Repetitive structure** — children share class / child shape. Cheap.
 3. **Consistent cell count** — candidate rows have equal child counts. Cheap.
-4. **Layout** — `getComputedStyle(el).display` is `grid` or `flex` (one read).
-5. **Numeric content** — ≥ 1 cell parses as a finite number. Cheap, mandatory.
+4. **Layout** — `getComputedStyle(el).display` is `grid` or `flex`. One read.
+5. **Numeric content** — ≥ 1 cell parses as a finite number. Mandatory.
 6. **Column-width alignment** — only for candidates surviving 1–5: measure
-   `offsetWidth` of column-0 cells across a few rows; expect uniform widths.
-   This is the only geometry probe, and it runs on a bounded set.
+   `offsetWidth` of column-0 cells across a sample of rows; expect uniform
+   widths. The only geometry probe; runs on a bounded set.
 
-Row height is **not** tested (S2). ARIA role / library class, when present on a
-walked ancestor, short-circuit to "accept" and skip the geometry probe.
-
-Discovered grids are marked `el.classList.add('dr-ext-grid')` so later sprints
-and the right-click handler locate them without re-running detection. In sprint
-1 a discovered grid gets the toggle dot and positioning only — no rounding.
+Row height is **not** tested (S2). An ARIA role or recognized library class on
+`el` (e.g., `role="grid"`, `.dg--`, `.ag-`) short-circuits to accept before
+step 6, skipping the geometry probe.
 
 ### D2 — TableAdapter abstraction (sprint 2)
 
-Introduce two classes in `content.js`:
+Two classes in `content.js`:
 
 ```
 NativeTableAdapter(tableElement)
@@ -168,35 +180,45 @@ GridAdapter(wrapperElement)
   .isVirtualized()  → true
 ```
 
-`NativeTableAdapter.getRows()` wraps `table.rows` / `row.cells` exactly as
-today — zero behavior change. `GridAdapter.getRows()` is a stub returning `[]`
-in this sprint (sprint 3 fills it in). `roundTable`, `resetTable`,
-`extractPreviewSamples`, and `isDataTable` are rewritten to call
-`adapter.getRows()`; no caller signature changes. A `makeAdapter(el)` factory
-picks the class by `el.tagName === 'TABLE'`.
+`NativeTableAdapter.getRows()` wraps `table.rows` / `row.cells` verbatim.
+`GridAdapter.getRows()` is a stub returning `[]` in sprint 2 (filled in sprint
+3). `makeAdapter(el)` factory: `NativeTableAdapter` if `el.tagName === 'TABLE'`,
+else `GridAdapter`. `roundTable`, `resetTable`, `extractPreviewSamples`, and
+`isDataTable` rewritten to use the adapter; no caller signature changes.
+`tableOptions` WeakMap stays keyed by the raw element; adapters are ephemeral
+per-call (grids change row count on scroll — never cache).
 
 ### D3 — GridAdapter read/write + visible-row rounding (sprint 3)
 
-`GridAdapter.getRows()` extracts rows/cells **structurally** (S2), with ARIA /
-library selectors as shortcuts when present:
+`GridAdapter.getRows()` — structural first, ARIA/library as shortcuts (S1):
 
-- **Rows** = repetitive children of the scrollable content container (or
-  `[role="row"]` when present).
-- **Cells** = repetitive children of each row (or `[role="gridcell"]`).
-- **Pinned pane**, when present, is stitched per row by `data-row-index` (or DOM
-  index) with pinned columns first. Single-pane grids skip this.
+- **Scroll container:** prefer known library selectors
+  (`.dg--grid-scroll-container`, `.ag-center-cols-viewport`,
+  `[role="grid"]:not(.dg--pinned-grid)`); else the descendant holding the
+  repetitive aligned-column children; else `this.el`.
+- **Pinned pane** (`.dg--pinned-grid`, `.ag-pinned-left-cols-container`, or a
+  sibling with matching row count) — may be `null` for single-pane grids.
+- **Rows:** `[role="row"]` when present, else repetitive children of scroll
+  container.
+- **Stitch:** for each row, collect the same-index row from the pinned pane
+  by `data-row-index` when available, else DOM index. Pinned cells first.
+- **Cells:** `[role="gridcell"]` when present, else repetitive row children.
+- **`setText(s)`:** writes `cell.textContent`, adds `.dr-ext-rounded`, stores
+  pre-round text in `cell.dataset.drOriginal` (S7 — node-only storage is
+  sufficient).
 
-`setText` writes `cell.textContent` and adds `.dr-ext-rounded`. **Original
-values are keyed by logical (rowIndex, colIndex)** in a per-grid Map (see Open
-Question on recycling), not stored solely on the cell node. Rounding applies
-only to currently-visible rows.
+`resetTable` via `GridAdapter`: restore only cells currently in the DOM with
+`.dr-ext-rounded` from their `dataset.drOriginal`; clear the class and attribute.
+Non-visible rows already show the framework's original text — no action needed.
 
 ### D4 — Virtualization re-apply observer (sprint 4)
 
-When a virtualized grid is rounded, attach a `MutationObserver` to its scroll
-container watching `childList`. Mutations are **debounced to 100 ms** (S5); on
-fire, `reapplyGridRounding` rounds only rows lacking `.dr-ext-rounded`. The
-observer is torn down on reset / toggle-off and when the grid is removed.
+When a virtualized grid is rounded: find the scroll container, attach a
+`MutationObserver` on `childList` **debounced to 100 ms** (S5). The debounced
+handler `reapplyGridRounding(wrapperEl)` re-rounds only rows lacking
+`.dr-ext-rounded`, using `tableOptions.get(wrapperEl)`. Observer stored in
+`gridObservers: WeakMap<Element, MutationObserver>`. Torn down on reset,
+toggle-off, and grid removal.
 
 ## 5. Sprint List & Dependency Graph
 
@@ -205,11 +227,11 @@ observer is torn down on reset / toggle-off and when the grid is removed.
 1. **grid-detection** — Proactive cheap pass (native + ARIA) and lazy
    right-click structural walk-up; toggle placement; no rounding.
    _Depends on:_ none.
-2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` interface; refactor
-   the four engine functions to use adapters. Existing tests stay green.
+2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` stub interface;
+   refactor the four engine functions to use adapters. Existing tests stay green.
    _Depends on:_ none.
-3. **grid-rounding** — Implement `GridAdapter` body; round currently-visible
-   grid rows. _Depends on:_ grid-adapter merged to main.
+3. **grid-rounding** — Implement `GridAdapter.getRows()`; round currently-
+   visible grid rows. _Depends on:_ grid-adapter merged to main.
 4. **grid-virtualization** — 100 ms-debounced MutationObserver to re-apply
    rounding on row recycle. _Depends on:_ grid-rounding merged to main.
 
@@ -236,63 +258,56 @@ appears on grids but does nothing until sprint 3.
 
 ### grid-detection
 
-- **Goal:** Discover data grids and badge them with the existing toggle dot,
-  using a proactive cheap pass for native/ARIA grids and a lazy right-click
-  structural walk-up for unlabelled div-grids. No rounding yet; this validates
-  discovery and dot placement on real pages (Databricks, AG Grid, and a
-  role-less div-grid).
+- **Goal:** Discover data grids and badge them with the existing toggle dot.
+  Proactive cheap pass for native/ARIA grids on page load; lazy right-click
+  structural walk-up for unlabelled div-grids. No rounding this sprint.
+- **Branch:** `feature/grid-detection` off `main`
 - **Scope — `chrome-extension/content.js`:**
-  - Add module-level `looksLikeGrid(el)` implementing the D1 cheap-first ladder:
-    child count → repetitive structure → consistent cell count → layout →
-    numeric content → (only then) column-width alignment. Returns a boolean.
-    **Do not test row height.** ARIA role / library class on `el` short-circuits
-    to accept and skips the geometry probe.
-  - **Proactive pass:** in `injectTableToggles` (L434), keep
-    `querySelectorAll('table')`; add a second cheap pass
-    `querySelectorAll('[role="grid"], [role="table"]')`. For each, call
-    `createToggleForTable`, skipping anything already carrying `dr-ext-grid` or
-    that is / contains an already-handled `<table>`. No structural scan here.
+  - Add module-level `looksLikeGrid(el)`: cheap-first ladder per D1.
+    Short-circuit accept on `role="grid"` / known library class. No row-height
+    test. Returns boolean.
+  - Add module-level `findTargetTable(el)`: returns nearest `<table>` ancestor;
+    else nearest ancestor carrying `dr-ext-grid`; else walks up per S6
+    (outermost `looksLikeGrid` match, depth cap 15, stop at `<body>`); on new
+    match adds `dr-ext-grid`, calls `createToggleForTable`, returns the element.
+    Returns `null` if nothing found.
+  - `injectTableToggles` (L434): keep `querySelectorAll('table')` pass; add
+    `querySelectorAll('[role="grid"], [role="table"]')` pass. Skip elements
+    already carrying `dr-ext-grid` or containing an already-handled `<table>`.
+    **No `looksLikeGrid` scan here** — proactive pass is cheap selectors only.
   - MutationObserver (L469–494): mirror only the two cheap selector passes for
-    added nodes; mirror removal handling. **No structural scanning in the
-    observer** (that would re-introduce the cost lazy discovery avoids).
-  - **Lazy pass:** add `findTargetTable(el)` used by the right-click handler
-    (L49, L71): return the nearest `<table>`; else the nearest ancestor carrying
-    `dr-ext-grid`; else walk up calling `looksLikeGrid` (depth cap ~15, stop at
-    `<body>`), and on first match add `dr-ext-grid`, badge it, and return it.
-  - `createToggleForTable`: when the element is not a `<table>`, skip
-    `isDataTable()` (reads `.rows`) and gate on `looksLikeGrid` instead.
-  - Mark discovered grids `el.classList.add('dr-ext-grid')`.
-  - `positionToggle` already uses `getBoundingClientRect()` — no change.
+    added nodes; mirror removal handling for grids.
+  - Right-click handler (L49, L71): replace `closest('table')` with
+    `findTargetTable(event.target)`.
+  - `createToggleForTable`: when element is not `<table>`, gate on
+    `looksLikeGrid(el)` instead of `isDataTable()` (which reads `.rows`).
+  - Mark discovered grids: `el.classList.add('dr-ext-grid')`.
+  - `positionToggle`: no change — `getBoundingClientRect()` works on any element.
 - **Scope — `chrome-extension/tests.js`:**
-  - Unit tests for `looksLikeGrid()`:
-    - **Pass — unlabelled grid:** plain `<div>` rows/cells, no roles, **mixed
-      text+number with varying row heights**, aligned columns, numeric cells.
-      (Headline — proves the column-structure spine, S2.)
-    - **Pass — ARIA grid:** same plus `role="grid"` (short-circuit path).
-    - **Pass — pinned+scrollable:** Databricks-shaped split.
-    - **Reject — layout grid:** CSS cards, no numeric rows (numeric guard).
+  - `looksLikeGrid()` unit tests:
+    - **Pass — unlabelled, variable row heights:** `<div>` rows with mixed
+      text+numbers, column widths aligned but row heights vary. (Headline — S2.)
+    - **Pass — ARIA short-circuit:** same structure plus `role="grid"`.
+    - **Pass — Databricks shape:** pinned + scrollable sibling panes.
+    - **Reject — layout grid:** CSS card grid, no numeric cells.
     - **Reject — nav menu:** repetitive rows, no numbers.
-  - Test `findTargetTable` walk-up: returns the tightest grid ancestor and stops
-    (does not overshoot to a page-level container).
-- **Out of scope:** Any rounding. The toggle click fires but `roundTable`
+  - `findTargetTable()` walk-up: returns the outermost matching ancestor (S6),
+    not an inner pane; does not overshoot to `<body>`.
+- **Out of scope:** Rounding grid contents. Toggle click fires but `roundTable`
   no-ops on a div (`.rows` undefined) — acceptable this sprint.
 - **Acceptance criteria:**
-  - A native `<table>` and an ARIA `[role="grid"]` both get a correctly placed
-    dot on page load (proactive).
-  - An **unlabelled** div-grid with **variable row heights** gets a dot after a
-    right-click on one of its cells (lazy), and the dot is placed on the tightest
-    grid root.
-  - No structural scanning runs on page load or in the MutationObserver
-    (verified by test/inspection — the heavy path is right-click-only).
+  - Native `<table>` and `[role="grid"]` get a dot on page load (proactive).
+  - An unlabelled div-grid with variable row heights gets a dot after right-
+    click; dot is on the outermost grid root (S6), not an inner pane.
+  - No structural scan runs on page load or in the MutationObserver.
   - No dot on a CSS layout grid with no numeric rows.
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** none
 - **Complexity:** M
 - **Dev notes:**
-  - Numeric-content guard is mandatory — it's what keeps the heuristic off nav
-    bars and card grids.
+  - Numeric-content guard is mandatory (guards against nav bars / card grids).
   - Do not rename `lastRightClickedTable`; its type widens to "table or grid
-    root". Document the widened contract in a comment.
+    root". Add a comment documenting the widened contract.
   - Do not bump `manifest.json` version.
 
 ---
@@ -300,35 +315,38 @@ appears on grids but does nothing until sprint 3.
 ### grid-adapter
 
 - **Goal:** Refactor the rounding engine onto a `TableAdapter` interface.
-  `NativeTableAdapter` is behavior-identical to today (all existing tests stay
-  green). `GridAdapter` defines the contract with a stubbed body (sprint 3 fills
-  it in).
+  `NativeTableAdapter` must be behavior-identical to today (all existing tests
+  stay green). `GridAdapter` defines the contract with a stubbed body (sprint 3
+  fills it in).
+- **Branch:** `refactor/grid-adapter` off `main`
 - **Scope — `chrome-extension/content.js`:**
-  - `NativeTableAdapter` (near `isDataTable`): `getElement()`,
-    `isVirtualized() → false`, and `getRows()` wrapping `Array.from(el.rows)` /
-    `row.cells` with `getText`/`setText`/`el`/`tagName` per cell, reproducing the
-    current logic verbatim.
-  - `GridAdapter` stub: `getElement()`, `isVirtualized() → true`,
-    `getRows() → []`.
-  - `makeAdapter(el)` factory: `NativeTableAdapter` if `el.tagName === 'TABLE'`,
-    else `GridAdapter`.
+  - `NativeTableAdapter` class (near `isDataTable`):
+    - `constructor(el)` — `this.el = el`
+    - `getElement()` — returns `this.el`
+    - `isVirtualized()` — returns `false`
+    - `getRows()` — wraps `Array.from(el.rows)` → each row exposes
+      `getCells()` → each cell exposes `getText()`, `setText(s)`, `el`,
+      `tagName` — reproducing current logic verbatim.
+  - `GridAdapter` stub class:
+    - `getElement()` → `this.el`; `isVirtualized()` → `true`; `getRows()` → `[]`
+  - `makeAdapter(el)` factory: `new NativeTableAdapter(el)` if
+    `el.tagName === 'TABLE'`, else `new GridAdapter(el)`.
   - Rewrite `isDataTable`, `roundTable`, `resetTable`, `extractPreviewSamples`
-    to read via `adapter.getRows()` / `row.getCells()`. `roundTable` returns
-    early if `getRows()` is empty (handles the stub).
-  - `tableOptions` WeakMap stays keyed by the raw element; adapters are
-    constructed fresh per call (grids change row count on scroll — never cache).
-- **Scope — `chrome-extension/tests.js`:** all existing tests pass unchanged;
-  add `NativeTableAdapter` round-trip test and a `GridAdapter` stub test.
-- **Out of scope:** `GridAdapter.getRows()` body; UI / sidebar / defaults.
+    to use `makeAdapter(el).getRows()` / `row.getCells()`. `roundTable` returns
+    early when `getRows()` is empty (handles stub path cleanly).
+  - `tableOptions` WeakMap stays keyed by raw element; adapters constructed
+    fresh per call.
+- **Scope — `chrome-extension/tests.js`:** all existing tests unchanged; add
+  `NativeTableAdapter` round-trip test and `GridAdapter` stub no-throw test.
+- **Out of scope:** `GridAdapter.getRows()` body; sidebar; defaults.
 - **Acceptance criteria:**
-  - `node chrome-extension/tests.js` passes, zero regressions.
-  - Native `<table>` rounding is byte-identical to the pre-refactor build.
-  - `roundTable` on a grid element returns without throwing (stub path).
+  - `node chrome-extension/tests.js` passes with zero regressions.
+  - Native `<table>` rounding byte-identical to pre-refactor build.
+  - `roundTable` on a grid element returns without throwing.
 - **Depends on:** none
 - **Complexity:** M
 - **Dev notes:**
-  - Keep `NativeTableAdapter.getRows()` a thin wrapper — zero behavior change,
-    not a cleanup.
+  - `NativeTableAdapter.getRows()` is a thin wrapper — zero behavior change.
   - Do not bump `manifest.json` version.
 
 ---
@@ -337,49 +355,49 @@ appears on grids but does nothing until sprint 3.
 
 - **Goal:** Implement `GridAdapter.getRows()` so rounding, reset, and preview
   extraction work on the currently-visible rows of a data grid.
+- **Branch:** `feature/grid-rounding` off `main` after grid-adapter merges
 - **Scope — `chrome-extension/content.js`:**
-  - Implement `GridAdapter.getRows()` — structural first, ARIA/library as
-    shortcut:
-    1. Scroll container: prefer library selectors
-       (`.dg--grid-scroll-container`, `.ag-center-cols-viewport`,
-       `[role="grid"]:not(.dg--pinned-grid)`); else the descendant holding the
-       repetitive aligned-column children `looksLikeGrid` keyed on; else `this.el`.
-    2. Pinned pane (`.dg--pinned-grid`, `.ag-pinned-left-cols-container`, or a
-       sibling with matching row count) — may be `null`.
-    3. Rows: `[role="row"]` when present, else the repetitive children of the
-       scroll container.
-    4. Stitch pinned row at matching `data-row-index` (or DOM index) per row.
+  - Implement `GridAdapter.getRows()` per D3:
+    1. Scroll container: library selectors first, then structural, then `this.el`.
+    2. Pinned pane: library selectors or same-row-count sibling; may be `null`.
+    3. Rows: `[role="row"]` when present, else repetitive children.
+    4. Stitch: same-index row from pinned pane by `data-row-index` or DOM index.
+       Log `console.debug` warning and fall back to DOM index when `data-row-index`
+       is absent.
     5. Cells: `[role="gridcell"]` when present, else repetitive row children;
        pinned cells first.
-    6. Per cell: `getText() → cell.textContent`; `setText(s)` writes
-       `textContent`, adds `.dr-ext-rounded`, and records the original keyed by
-       **logical (rowIndex, colIndex)** in a per-grid originals Map.
-  - `resetTable` via `GridAdapter`: restore visible cells from the originals Map
-    and clear `.dr-ext-rounded`; non-visible rows already show the framework's
-    original text.
-  - `isDataTable` via `GridAdapter`: sample ≤ 10 cells; true if any is a finite
-    number.
+    6. `setText(s)`: write `textContent`, add `.dr-ext-rounded`, store original
+       in `cell.dataset.drOriginal` (S7 — node-only; sufficient because only
+       currently-visible rounded cells ever need resetting).
+  - `resetTable` via `GridAdapter`: iterate cells currently in the DOM with
+    `.dr-ext-rounded`; restore from `dataset.drOriginal`; clear class + attr.
+    Non-visible rows show the framework's original text — no action needed.
+  - `isDataTable` via `GridAdapter`: sample ≤ 10 cells; true if any is finite.
   - `createToggleForTable` grid path: replace the sprint-1 `looksLikeGrid` gate
     with `isDataTable(makeAdapter(el))` now that `getRows()` works.
 - **Scope — `chrome-extension/tests.js`:**
-  - Unlabelled grid (no roles, variable row heights): structural extraction +
-    rounding applies. (Headline.)
-  - ARIA grid: shortcut path.
+  - **Unlabelled, variable row heights** (no roles): structural extraction +
+    rounding applies. Headline.
+  - ARIA grid: `[role="row"]`/`[role="gridcell"]` shortcut path.
   - Pinned pane: correct stitched column order.
-  - Reset restores originals.
-  - `extractPreviewSamples` returns the expected structure.
-- **Out of scope:** Re-apply on scroll / recycle (sprint 4). Rounding state is
-  lost when rows leave the viewport — documented limitation until sprint 4.
+  - `resetTable`: restores originals on currently-visible rows; simulated
+    recycled row (removed + re-added by framework) shows framework text (no
+    `.dr-ext-rounded`, no restore needed).
+  - `extractPreviewSamples`: returns expected structure.
+- **Known limitation (until sprint 4):** rounding state is lost when rows scroll
+  out of view — they re-enter the DOM fresh. Document in release notes.
 - **Acceptance criteria:**
-  - Right-clicking a cell in a Databricks result and applying rounding rounds
-    all currently-visible cells; toggling off restores originals.
+  - Right-click + apply rounding on a Databricks result rounds all visible cells;
+    toggle off restores them.
+  - **Framework clobbering validation:** manually verify on a live Databricks
+    page that rounding survives same-position re-renders; if the framework
+    overwrites our text faster than we can re-apply, escalate before sprint 4
+    (may require overlay rendering instead of in-place text replacement).
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** grid-adapter merged to main
 - **Complexity:** M
 - **Dev notes:**
-  - Stitch by `data-row-index` when available; `console.debug` and fall back to
-    DOM index otherwise.
-  - Only round what is visible — never scroll-trigger extra rendering.
+  - Do not attempt to scroll-trigger additional row rendering.
   - Do not bump `manifest.json` version.
 
 ---
@@ -388,85 +406,79 @@ appears on grids but does nothing until sprint 3.
 
 - **Goal:** Keep a rounded grid rounded as the user scrolls — re-apply rounding
   to rows recycled into the viewport.
+- **Branch:** `feature/grid-virtualization` off `main` after grid-rounding merges
 - **Scope — `chrome-extension/content.js`:**
-  - Add `gridObservers: WeakMap<Element, MutationObserver>`.
-  - In `roundTable`, when `adapter.isVirtualized()`: find the scroll container,
-    create a `MutationObserver` on `childList`, **debounced to 100 ms** (S5),
-    whose handler `reapplyGridRounding(wrapperEl)` re-rounds only rows lacking
-    `.dr-ext-rounded`, using `tableOptions.get(wrapperEl)` and the per-grid
-    originals Map. Store in `gridObservers`.
-  - In `resetTable`: if virtualized and observed, disconnect and delete the
-    observer before restoring cells.
-  - In the removed-node observer (L493): disconnect any `gridObservers` entry
-    for a removed grid.
+  - Add `gridObservers: WeakMap<Element, MutationObserver>` at module level.
+  - In `roundTable`, when `adapter.isVirtualized()`:
+    1. Find scroll container (same logic as `GridAdapter.getRows()` step 1).
+    2. Create `MutationObserver` with handler debounced to **100 ms**:
+       `setTimeout`-based debounce (one pending timer per grid); on fire calls
+       `reapplyGridRounding(wrapperEl)`.
+    3. `reapplyGridRounding`: calls `roundTable(wrapperEl,
+       tableOptions.get(wrapperEl))` scoped to rows lacking `.dr-ext-rounded`.
+    4. `observe(scrollContainer, { childList: true, subtree: true })`.
+    5. `gridObservers.set(wrapperEl, observer)`.
+  - In `resetTable`, if virtualized and observed: clear the debounce timer,
+    disconnect and delete the observer before restoring cells.
+  - In the removed-node MutationObserver (L493): disconnect any `gridObservers`
+    entry for a removed element.
 - **Scope — `chrome-extension/tests.js`:**
-  - Round a grid, append a new row (simulated recycle), advance past the 100 ms
-    debounce, assert the new row is rounded.
-  - After reset, appending a row does **not** trigger rounding (observer gone).
-  - Debounce: N rapid mutations cause a single `reapplyGridRounding`.
-- **Out of scope:** Horizontal/column virtualization — see Open Questions.
+  - Round a grid; append a new row (simulated recycle); advance past 100 ms
+    debounce; assert new row is rounded.
+  - N rapid row-additions fire only one `reapplyGridRounding` (debounce).
+  - After `resetTable`: appending a row does **not** trigger rounding.
+- **Out of scope:** Column (horizontal) virtualization — cells entering the
+  horizontal viewport. Warrants a follow-up sprint if reported.
 - **Acceptance criteria:**
   - Scrolling a rounded Databricks result rounds newly-visible rows
-    automatically, with no visible stutter (100 ms debounce).
+    automatically with no visible stutter.
   - Toggling off stops re-application.
-  - No perf regression on native `<table>` pages (observer never attached to
-    non-virtualized tables).
+  - No perf regression on native `<table>` pages.
   - `node chrome-extension/tests.js` passes.
 - **Depends on:** grid-rounding merged to main
 - **Complexity:** M
 - **Dev notes:**
-  - Debounce coalesces a scroll burst's mutations into one 100 ms-spaced
-    re-round; keep each pass cheap by touching only un-rounded rows.
-  - `subtree: true` is likely needed (grids wrap rows in intermediate
-    containers); narrow to direct children if mutation volume is high.
+  - Use `setTimeout` for the 100 ms debounce, not `requestAnimationFrame`
+    (rAF fires at ~16 ms; we want 100 ms).
+  - Clear the pending timer in `resetTable` to avoid a stale re-apply after
+    toggle-off.
+  - Narrow from `subtree: true` to direct-child-only if mutation volume on a
+    real page proves too high.
   - Do not bump `manifest.json` version.
 
-## 7. Open Questions & Risks
+## 7. Open Questions
 
-- **Framework clobbering (highest feasibility risk).** A grid cell is owned by
-  React/Angular; writing `cell.textContent` can be overwritten on the
-  framework's next render — not only on scroll-recycle (which sprint 4 handles)
-  but on any same-position re-render. The 100 ms re-apply observer is the
-  mitigation, but this is a "fight the framework" pattern. Validate on a live
-  Databricks page during sprint 3 before committing to the approach; if same-
-  position re-renders wipe rounding faster than we can re-apply, reconsider
-  (e.g., overlay rendering instead of in-place text replacement).
-- **Original-value persistence across recycle.** Originals must be keyed by
-  logical (rowIndex, colIndex), not stored only on the cell node (recycled away
-  on scroll). This needs a stable logical row id — `data-row-index` when the
-  grid provides it. Grids without any stable row id can round visible rows but
-  cannot reliably reset after scrolling; document as a limitation and detect the
-  no-id case.
-- **Walk-up stopping rule.** Lazy discovery returns the first ancestor passing
-  `looksLikeGrid`. Confirm this picks the grid root and not an inner pane
-  (pinned/scroll) — prefer the innermost match but verify it's the element that
-  owns both panes. Depth cap prevents overshoot to page-level containers.
-- **Synchronized-scroll assumption.** Pinned+scroll stitching assumes the two
-  panes keep row-index alignment at all times. Verify on a live Databricks page
-  before sprint 3 ships.
 - **AG Grid / Cloudscape / Azure Data Studio selectors.** Sprint 3's selector
-  list covers Databricks and AG Grid; add others if a test environment exists.
-- **Column virtualization.** Wide grids may also virtualize columns
-  (off-screen cells absent). Not handled; warrants a follow-up sprint if
-  reported.
+  list covers Databricks and AG Grid. Add others (`.awsui-table-wrapper`, Azure
+  Data Studio Monaco grid) if a test environment is available before sprint 3
+  ships.
+- **Column virtualization.** Wide grids may virtualize columns (off-screen cells
+  absent). Not handled; warrants a follow-up sprint if reported by users.
 
-## 8. Out of Scope (Separate Sprint-Stack)
+## 8. Out of Scope
 
 - Column (horizontal) virtualization.
-- Google Sheets / Excel Online (canvas-rendered in places, not DOM — a
-  different approach entirely).
+- Google Sheets / Excel Online (partially canvas-rendered — a different approach).
 - Python / `js/` sibling implementations — grid support is browser-only.
 
-## Decisions Log
+## 9. Decisions Log
 
 - 2026-06-10: Initial draft. Sprints 1 and 2 independent; 3 depends on 2; 4 on 3.
 - 2026-06-10: Reoriented detection/extraction around structural heuristics for
   unlabelled grids; ARIA/library classes demoted to optional accelerators;
   numeric-content the primary false-positive guard.
-- 2026-06-10: Strategy finalized after design discussion —
-  (a) **column-structure**, not row-height, is the heuristic spine (variable row
-  heights are normal); (b) **lazy right-click discovery** for unlabelled grids,
-  proactive badging only for the cheap native/ARIA signals; (c) geometry probe
-  measured last and narrowest; (d) re-apply observer **debounced to 100 ms**.
-  Added framework-clobbering, original-value-persistence, and walk-up-stopping
-  as tracked risks.
+- 2026-06-10: Strategy finalized —
+  (a) **Column structure** (consistent cell count + column-width alignment),
+  not row height, is the heuristic's spine. Variable row heights are the common
+  case (text wrapping); row-height tests removed.
+  (b) **Lazy right-click discovery** for unlabelled grids; proactive badging
+  only for cheap native/ARIA signals.
+  (c) Geometry probe (column-width `offsetWidth`) measured **last and narrowest**
+  — only after cheap checks pass, only on right-clicked ancestors.
+  (d) Re-apply observer **debounced to 100 ms**.
+  (e) **Walk-up returns outermost match** (S6) — keeps going while parent also
+  passes `looksLikeGrid`, ensuring the wrapper is selected over an inner pane.
+  (f) **Original values stored on the node only** (S7) — no logical-coordinate
+  map needed; only currently-visible `.dr-ext-rounded` cells ever need resetting.
+  (g) Framework-clobbering flagged as the highest feasibility risk; live
+  validation required before sprint 4 commitment.

--- a/docs/sprint-plans/grid-support.md
+++ b/docs/sprint-plans/grid-support.md
@@ -225,44 +225,105 @@ toggle-off, and grid removal.
 ### Sprint List
 
 **Execute strictly sequentially — one branch at a time, each off the updated
-`main` after the prior sprint merges.** Although sprints 1 and 2 are *logically*
-independent, both edit `content.js` and both touch `createToggleForTable` and
-`isDataTable`, so developing them on parallel branches would create avoidable
-merge conflicts. Do them in order.
+`main` after the prior sprint merges.** Two reasons combine: (a) sprints 1 and 2
+both edit `content.js` `createToggleForTable` / `isDataTable`, so parallel
+branches would conflict; (b) the riskiest unknowns resolve only by *observing*
+early outcomes, so later sprints must stay open to amendment (see Sprint 0).
 
+**Sprints 2–4 are provisional pending Sprint 0.** The adapter interface
+(sprint 2) and the in-place write model (sprints 3–4) both assume things we
+have not yet verified on a live grid — chiefly whether overwriting
+`cell.textContent` survives the host framework's re-render (the
+"framework-clobbering" risk). Sprint 0 resolves that *before* committing code to
+the architecture those sprints build on.
+
+0. **feasibility-spike** — Throwaway DevTools/console investigation on live
+   grids (Databricks, AG Grid): confirm real DOM structure and whether in-place
+   text replacement survives framework re-render. **No production code.**
+   _Depends on:_ none. _Outcome:_ sprints 2–4 confirmed, or the plan amended.
 1. **grid-detection** — Proactive cheap pass (native + ARIA) and lazy
    right-click structural walk-up; toggle placement; no rounding.
    _Depends on:_ none. _Branch from:_ `main`.
-2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` stub interface;
-   refactor the four engine functions to use adapters. Existing tests stay green.
-   _Depends on:_ grid-detection merged to main (shared edits to
-   `createToggleForTable` / `isDataTable`). _Branch from:_ updated `main`.
-3. **grid-rounding** — Implement `GridAdapter.getRows()`; round currently-
-   visible grid rows. _Depends on:_ grid-adapter merged to main.
-4. **grid-virtualization** — 100 ms-debounced MutationObserver to re-apply
-   rounding on row recycle. _Depends on:_ grid-rounding merged to main.
+2. **grid-adapter** _(provisional)_ — `NativeTableAdapter` / `GridAdapter` stub
+   interface; refactor the four engine functions to use adapters. Existing tests
+   stay green. _Depends on:_ feasibility-spike (write model confirmed) +
+   grid-detection merged. _Branch from:_ updated `main`.
+3. **grid-rounding** _(provisional)_ — Implement `GridAdapter.getRows()`; round
+   currently-visible grid rows. _Depends on:_ grid-adapter merged to main.
+4. **grid-virtualization** _(provisional)_ — 100 ms-debounced MutationObserver
+   to re-apply rounding on row recycle. _Depends on:_ grid-rounding merged.
 
 ### Dependency Graph
 
 ```mermaid
 flowchart TD
     base[main]
+    s0["feasibility-spike<br/>Validate DOM + write model (no code)"]
     s1["grid-detection<br/>Proactive cheap + lazy walk-up, no rounding"]
-    s2["grid-adapter<br/>TableAdapter abstraction, tests green"]
-    s3["grid-rounding<br/>GridAdapter body + visible-row rounding"]
-    s4["grid-virtualization<br/>Re-apply on recycle, 100ms debounce"]
+    s2["grid-adapter (provisional)<br/>TableAdapter abstraction"]
+    s3["grid-rounding (provisional)<br/>GridAdapter body + visible-row rounding"]
+    s4["grid-virtualization (provisional)<br/>Re-apply on recycle, 100ms debounce"]
+    base --> s0
     base --> s1
+    s0 --> s2
     s1 --> s2
     s2 --> s3
     s3 --> s4
 ```
 
-The chain is linear: each sprint branches from `main` only after the previous
-one has merged. Sprints 1 and 2 have no *logical* dependency, but the file-level
-overlap in `content.js` (`createToggleForTable`, `isDataTable`) makes sequential
-execution the conflict-free path for a single developer/session.
+Sprint 0 and sprint 1 are both rooted at `main` and gather information; neither
+writes production code that the other depends on (sprint 1 ships detection;
+sprint 0 is throwaway). They can run in either order, but **sprint 0's findings
+gate sprint 2** — do not start the adapter refactor until the write model is
+confirmed. The rest of the chain is linear: each sprint branches from `main`
+only after the previous one has merged.
 
 ## 6. Sprint Definitions
+
+### feasibility-spike
+
+- **Goal:** Resolve the two unknowns that could force a re-architecture, *before*
+  any committed code assumes them away. This is a **spike**: a throwaway
+  investigation whose deliverable is knowledge, not a merge.
+- **Branch:** none — no production code. Findings recorded in
+  `docs/sprint-logs/grid-support-feasibility-spike.md` (or appended to the
+  research doc).
+- **Investigate (DevTools / console on live pages — Databricks SQL result, an
+  AG Grid demo, and one role-less div-grid):**
+  1. **Real DOM structure** — confirm the row/cell nesting, the pinned vs scroll
+     container split, presence of `data-row-index` (or equivalent stable row id),
+     and whether `role`/library classes are actually present. Validates the D1
+     `looksLikeGrid` signals and the D3 `GridAdapter.getRows()` selector list.
+  2. **Framework clobbering** — manually overwrite a grid cell's `textContent`
+     in the console; then scroll the cell out and back, trigger a re-sort or
+     re-render, and observe whether our text survives or is reverted. This is the
+     highest feasibility risk: if the host framework reclaims the cell faster
+     than a 100 ms re-apply can keep up, the in-place write model (sprints 3–4)
+     is not viable and must change (e.g., overlay rendering over the cell rather
+     than mutating its text).
+- **Out of scope:** Any production code, tests, or `content.js` changes.
+- **Acceptance criteria:**
+  - Findings for both questions written up.
+  - An explicit verdict: **sprints 2–4 confirmed as planned**, OR a list of
+    specific amendments needed (which selectors, which write model). See
+    "If the spike invalidates the plan" below.
+  - This sprint does **not** merge code — its done-state is the recorded verdict.
+- **Depends on:** none
+- **Complexity:** S
+- **Dev notes:**
+  - Keep it genuinely throwaway — console snippets, screenshots, notes. Resist
+    building anything reusable here; that's what the real sprints are for.
+  - The stable-row-id finding feeds the S7 reset model: if no grid exposes a
+    stable row id, note it as a confirmed limitation.
+
+**If the spike invalidates the plan:** this plan is read-only once merged. Do
+**not** edit sprints 2–4 in place after the fact. Instead, the spike's verdict
+becomes the input to a fresh `sprint-plan` revision that supersedes the
+provisional sprints — a new plan artifact, leaving the git history of the
+decision intact. If the spike *confirms* the plan, record that in the Decisions
+Log and proceed to sprint 2 unchanged.
+
+---
 
 ### grid-detection
 
@@ -351,8 +412,10 @@ execution the conflict-free path for a single developer/session.
   - `node chrome-extension/tests.js` passes with zero regressions.
   - Native `<table>` rounding byte-identical to pre-refactor build.
   - `roundTable` on a grid element returns without throwing.
-- **Depends on:** grid-detection merged to main (avoids `content.js` conflicts
-  in `createToggleForTable` / `isDataTable`)
+- **Depends on:** feasibility-spike (write model confirmed) + grid-detection
+  merged to main (avoids `content.js` conflicts in `createToggleForTable` /
+  `isDataTable`). **Provisional** — do not start until the spike confirms the
+  in-place write model, or until the plan is revised per the spike's verdict.
 - **Complexity:** M
 - **Dev notes:**
   - `NativeTableAdapter.getRows()` is a thin wrapper — zero behavior change.
@@ -496,3 +559,11 @@ execution the conflict-free path for a single developer/session.
   independent but both edit `content.js` `createToggleForTable` / `isDataTable`,
   so parallel branches would conflict. Linear chain is the conflict-free path for
   a single developer/session.
+- 2026-06-10: Added **Sprint 0 (feasibility-spike)** and marked sprints 2–4
+  **provisional**. The riskiest unknowns (real grid DOM; whether in-place
+  `textContent` survives framework re-render) resolve only by observing a live
+  grid, and they sit upstream of the architecture sprints 2–4 commit to. The
+  spike pulls that learning forward with a throwaway investigation (no code);
+  its acceptance is a verdict — "plan confirmed" or "plan needs amending" — not a
+  merge. If it invalidates the plan, the verdict feeds a fresh sprint-plan
+  revision rather than an in-place edit (the merged plan stays read-only).

--- a/docs/sprint-plans/grid-support.md
+++ b/docs/sprint-plans/grid-support.md
@@ -1,0 +1,397 @@
+# Sprint Plan: Virtualized Data Grid Support
+
+**Created:** 2026-06-10
+**Base branch:** main
+**Slug:** grid-support
+
+## Context
+
+The dynamic-rounding Chrome extension rounds numbers in native HTML `<table>`
+elements. Modern web apps — Databricks SQL, AG Grid dashboards, Azure Data
+Studio, AWS Cloudscape — render query results as virtualized data grids built
+from `<div role="grid">` containers split into **pinned** (frozen columns) and
+**scrollable** panes. These grids are completely invisible to the extension
+today.
+
+Research is in `docs/research/databricks-grid-detection.md`. The key structural
+facts:
+
+- **Databricks SQL:** `.dg--table-wrapper` wraps `.dg--pinned-grid` +
+  `.dg--grid-scroll-container` (both `role="grid"`).
+- **AG Grid:** `.ag-pinned-left-cols-container` + `.ag-center-cols-viewport`.
+- Grids use `role="grid"` / `role="row"` / `role="gridcell"` ARIA attributes.
+- **Virtualization:** only visible rows are in the DOM; nodes are recycled as
+  the user scrolls — so there is no single "full table" in the DOM at any time.
+
+Every layer of `content.js` is hard-wired to the `<table>` DOM API, so adding
+detection alone is not sufficient. The four sprints below address: discovery,
+abstraction, rounding, and virtualization — in dependency order.
+
+## 1. Repo Survey
+
+- Chrome extension (MV3) at `chrome-extension/`: `content.js` (~1800 lines,
+  all table logic), `sidebar.js` / `sidebar.html` (options UI), `defaults.js`
+  (shared `DR_DEFAULTS`), `tests.js` (~6 k lines, Node test runner).
+- Key functions and their DOM coupling:
+
+| Function | Line | Coupling |
+|---|---|---|
+| `injectTableToggles` | 434 | `querySelectorAll('table')` |
+| MutationObserver | 469–494 | `querySelectorAll('table')` |
+| right-click handler | 49, 71 | `closest('table')` |
+| `isDataTable` | 288 | `.rows`, `.cells` |
+| `roundTable` | 740 | `table.rows`, `row.cells`, `cell.tagName !== 'TD'` |
+| `resetTable` | 636 | `table.rows` |
+| `extractPreviewSamples` | 681 | `table.rows`, `row.cells` |
+| `positionToggle` | 261 | `table.getBoundingClientRect()` |
+
+- Test command: `node chrome-extension/tests.js`
+- Branch naming: `feature/<label>` (never `claude/`)
+- Commit convention: Conventional Commits
+- Version bumps: handled by `.github/workflows/bump-version.yml` on merge to
+  main; sprint branches must NOT bump versions.
+
+## 2. Design
+
+### D1 — Grid discovery (sprint 1 only)
+
+Extend `injectTableToggles`, the MutationObserver, and the right-click handler
+to find ARIA grids alongside native tables.
+
+**Primary selector:** `[role="grid"], [role="table"]`
+
+**Heuristic fallback** (for grids that omit ARIA — see research doc §2):
+- Container has ≥ 5 direct children with uniform `offsetHeight > 0`.
+- Container or children use `display: grid` or `display: flex`.
+
+**False-positive filter (co-occurrence rule):** only promote a heuristic-
+matched container if it has both a "pinned" sibling and a "scrollable" sibling
+under the same parent. ARIA-matched grids bypass this filter.
+
+In sprint 1, a discovered grid gets a toggle button and toggle positioning; no
+rounding is attempted yet. A sentinel class `dr-ext-grid` is added to the root
+element so later sprints can locate it without re-running discovery.
+
+### D2 — TableAdapter abstraction (sprint 2)
+
+Introduce two classes in `content.js`:
+
+```
+NativeTableAdapter(tableElement)
+  .getRows()        → [{ getCells() → [{ getText(), setText(s), el }] }]
+  .getElement()     → the <table> element
+  .isVirtualized()  → false
+
+GridAdapter(wrapperElement)
+  .getRows()        → visible rows, stitched from pinned + scrollable
+  .getElement()     → the wrapper element
+  .isVirtualized()  → true
+```
+
+`getRows()` for `GridAdapter`: collect `[role="row"]` children from the
+scrollable pane; for each, also collect the same-index row from the pinned pane
+(if present); merge cells in DOM order (pinned columns first). This stitching is
+the interface contract — callers never know they are reading two DOM trees.
+
+`NativeTableAdapter.getRows()` wraps `table.rows` / `row.cells` exactly as
+today. All existing behavior is preserved verbatim.
+
+`roundTable`, `resetTable`, `extractPreviewSamples`, and `isDataTable` are
+rewritten to call `adapter.getRows()` instead of `table.rows`. No caller is
+changed; the adapter is constructed at the call site based on element type.
+
+### D3 — GridAdapter read/write + visible-row rounding (sprint 3)
+
+Implement `GridAdapter` fully (sprint 2 defines the interface; sprint 3 fills
+in the body). Key concerns:
+
+- `getText()` reads `cell.textContent` (grids use no `<td>`; cells are
+  `[role="gridcell"]` divs).
+- `setText(s)` writes `cell.textContent` and applies `.dr-ext-rounded` just as
+  `roundTable` does today — but only to visible (currently-rendered) cells.
+- `resetTable` via the adapter clears `.dr-ext-rounded` only from nodes
+  currently in the DOM; sprint 4 handles persistence across scroll.
+
+### D4 — Virtualization re-apply observer (sprint 4)
+
+When a grid is rounded, attach a `MutationObserver` to each scroll container
+that watches for `childList` changes (row recycling). On each mutation, re-run
+the rounding pass for newly-added rows, using the stored `tableOptions`
+WeakMap entry for the grid's wrapper element. Unrounded grids get no observer.
+
+The observer is torn down when the toggle is switched off (same path that calls
+`resetTable`).
+
+## 3. Sprint List & Dependency Graph
+
+### Sprint List
+
+1. **grid-detection** — Discovery + toggle placement for ARIA grids; no
+   rounding. _Depends on:_ none.
+2. **grid-adapter** — `NativeTableAdapter` / `GridAdapter` interface;
+   refactor `roundTable`, `resetTable`, `extractPreviewSamples`, `isDataTable`
+   to use adapters. Existing tests must stay green. _Depends on:_ none (can
+   overlap with sprint 1 on a separate branch; merges to main independently).
+3. **grid-rounding** — Implement `GridAdapter` body; enable rounding for
+   currently-visible grid rows. _Depends on:_ grid-adapter merged to main.
+4. **grid-virtualization** — MutationObserver on scroll containers to re-apply
+   rounding on row recycle. _Depends on:_ grid-rounding merged to main.
+
+### Dependency Graph
+
+```mermaid
+flowchart TD
+    base[main]
+    s1["grid-detection<br/>Discovery + toggle, no rounding"]
+    s2["grid-adapter<br/>TableAdapter abstraction, tests green"]
+    s3["grid-rounding<br/>GridAdapter body + visible-row rounding"]
+    s4["grid-virtualization<br/>Re-apply on scroll / row recycle"]
+    base --> s1
+    base --> s2
+    s2 --> s3
+    s3 --> s4
+```
+
+Sprints 1 and 2 are independent of each other (different files, no shared
+interface) and can be developed in parallel. Sprint 1 can also merge to main
+before sprint 2 — the toggle will appear on grids but do nothing until sprint 3.
+
+## 4. Sprint Definitions
+
+### grid-detection
+
+- **Goal:** Make the extension discover and badge ARIA data grids with the
+  existing toggle button. No rounding happens yet; this sprint validates that
+  discovery and toggle positioning work on real pages (Databricks, AG Grid).
+- **Scope — `chrome-extension/content.js`:**
+  - `injectTableToggles` (L434): after the `querySelectorAll('table')` pass,
+    add a second pass: `querySelectorAll('[role="grid"], [role="table"]')`,
+    deduplicating any native `<table>` that also carries the role. For each
+    result, call `createToggleForTable` with a guard that skips elements already
+    carrying `dr-ext-grid` (idempotency).
+  - Heuristic fallback: extract `findNonStandardTables()` (from research doc §4)
+    as a module-level function; call it after the ARIA pass; apply the
+    co-occurrence filter (skip if no pinned+scrollable sibling pair detected).
+  - MutationObserver (L469–494): mirror both passes in the added-node and
+    removed-node branches.
+  - Right-click handler (L49, L71): change `closest('table')` to
+    `closest('table, [role="grid"], [role="table"], .dg--table-wrapper')`.
+  - `createToggleForTable`: add an early guard — if the element is not a
+    `<table>`, skip `isDataTable()` (it will fail on `.rows`) and instead use a
+    lighter check: does the element contain at least one `[role="gridcell"]` or
+    a direct child with `display: flex/grid`? If yes, attach the toggle.
+  - Mark discovered grids with `el.classList.add('dr-ext-grid')`.
+  - `positionToggle`: already uses `getBoundingClientRect()`, which works for
+    any element — no change needed.
+- **Scope — `chrome-extension/tests.js`:**
+  - Add unit tests for `findNonStandardTables()` against synthetic DOM fixtures:
+    a passing case (ARIA grid), a passing heuristic case (pinned+scrollable),
+    a rejected heuristic case (no co-occurrence), and a layout-grid false
+    positive (single-pane CSS grid, no sibling pair).
+- **Out of scope:** Any actual rounding of grid contents. The toggle's click
+  handler will fire but `roundTable` will no-op (`.rows` is undefined on a
+  div) — that is acceptable for this sprint.
+- **Acceptance criteria:**
+  - On a page with `<div role="grid">`, the extension injects a toggle button
+    correctly positioned at the grid's top-right corner.
+  - Right-clicking a cell inside a `[role="grid"]` sets `lastRightClickedTable`
+    to the grid wrapper.
+  - No toggle appears on a plain CSS layout grid lacking the co-occurrence of
+    pinned + scrollable containers.
+  - `node chrome-extension/tests.js` passes.
+- **Depends on:** none
+- **Complexity:** S
+- **Dev notes:**
+  - Do not rename `lastRightClickedTable` — the variable's type widens to
+    "table or grid wrapper" but the name change is cosmetic and would touch too
+    many call sites. Document the widened contract in a brief comment.
+  - Do not bump `manifest.json` version.
+
+---
+
+### grid-adapter
+
+- **Goal:** Refactor the rounding engine to operate on a `TableAdapter`
+  interface rather than raw `<table>` DOM. `NativeTableAdapter` must be
+  behavior-identical to today — all existing tests stay green. `GridAdapter`
+  defines the interface contract but its body is a stub (sprint 3 fills it in).
+- **Scope — `chrome-extension/content.js`:**
+  - Define `NativeTableAdapter` class at module level (near `isDataTable`):
+    - `constructor(el)` — stores `this.el = el`.
+    - `getElement()` — returns `this.el`.
+    - `isVirtualized()` — returns `false`.
+    - `getRows()` — returns `Array.from(el.rows).map(row => ({ getCells: () =>
+      Array.from(row.cells).map(cell => ({ getText: () => cell.innerText ||
+      cell.textContent, setText: (s) => { /* existing write logic */ },
+      el: cell, tagName: cell.tagName })) }))`.
+  - Define `GridAdapter` class stub:
+    - `constructor(el)` — stores `this.el = el`.
+    - `getElement()` — returns `this.el`.
+    - `isVirtualized()` — returns `true`.
+    - `getRows()` — returns `[]` (stub; sprint 3 implements).
+  - Add `makeAdapter(el)` factory: returns `new NativeTableAdapter(el)` if
+    `el.tagName === 'TABLE'`, else `new GridAdapter(el)`.
+  - Rewrite `isDataTable(table)`: accept an adapter (or element — wrap in
+    `makeAdapter` if an element is passed). Replace `.rows` / `.cells` access
+    with `adapter.getRows()` / `row.getCells()`.
+  - Rewrite `roundTable(table, options)`: call `makeAdapter(table)` at the top;
+    replace all `table.rows` / `row.cells` / `cell.tagName` access with adapter
+    calls. Return early if `adapter.getRows().length === 0` (handles the stub).
+  - Rewrite `resetTable(table)`: replace `table.rows` access with
+    `makeAdapter(table).getRows()`.
+  - Rewrite `extractPreviewSamples(table)`: same.
+  - The `tableOptions` WeakMap key remains the raw element (not the adapter) —
+    adapters are ephemeral per-call, elements are stable.
+- **Scope — `chrome-extension/tests.js`:**
+  - All existing tests must pass unchanged. Add two adapter unit tests:
+    `NativeTableAdapter` round-trips `getText`/`setText` correctly;
+    `GridAdapter` stub `getRows()` returns `[]` without throwing.
+- **Out of scope:** `GridAdapter.getRows()` implementation (sprint 3). Any
+  changes to `sidebar.js`, `defaults.js`, or the toggle UI.
+- **Acceptance criteria:**
+  - `node chrome-extension/tests.js` passes with zero regressions.
+  - Rounding a native `<table>` produces byte-identical results to the
+    pre-refactor build (verified by the existing test suite).
+  - `roundTable` called on a `[role="grid"]` element returns without throwing
+    (stub path).
+- **Depends on:** none
+- **Complexity:** M
+- **Dev notes:**
+  - The adapter is constructed fresh on each `roundTable` / `resetTable` call —
+    no caching. Grids change their row count on scroll; a cached adapter would
+    return stale rows.
+  - Keep `NativeTableAdapter.getRows()` implementation as a thin wrapper around
+    the existing logic — do not simplify or restructure the row/cell iteration.
+    The goal is zero behavior change, not cleanup.
+  - Do not bump `manifest.json` version.
+
+---
+
+### grid-rounding
+
+- **Goal:** Implement `GridAdapter.getRows()` so that rounding, reset, and
+  preview-sample extraction work on the currently-visible rows of a data grid.
+- **Scope — `chrome-extension/content.js`:**
+  - Implement `GridAdapter.getRows()`:
+    1. Find the scrollable pane: `this.el.querySelector('[role="grid"]:not(.dg--pinned-grid), .dg--grid-scroll-container, .ag-center-cols-viewport')` — fall back to `this.el` if no match.
+    2. Find the pinned pane: `this.el.querySelector('.dg--pinned-grid, .ag-pinned-left-cols-container')` — may be `null`.
+    3. Collect scrollable rows: `Array.from(scrollPane.querySelectorAll(':scope > [role="row"], :scope > * > [role="row"]'))` (one level of indirection for some grid libraries).
+    4. For each scrollable row at index `i`, collect pinned row at the same index (if pinned pane exists): match by `data-row-index` attribute if present, otherwise by DOM index.
+    5. Return row objects: `{ getCells: () => [...pinnedCells, ...scrollableCells].map(cell => ({ getText: () => cell.textContent, setText: (s) => { cell.textContent = s; cell.classList.add('dr-ext-rounded'); cell.dataset.drOriginal = cell.dataset.drOriginal || cell.textContent; }, el: cell, tagName: 'TD' /* normalized */ })) }`.
+  - `setText` in `GridAdapter` must store the original value in
+    `cell.dataset.drOriginal` before overwriting (for reset), mirroring how
+    `NativeTableAdapter` stores it.
+  - `resetTable` via `GridAdapter`: clear `.dr-ext-rounded`, restore
+    `cell.textContent` from `cell.dataset.drOriginal`, delete
+    `cell.dataset.drOriginal`.
+  - `isDataTable` via `GridAdapter`: sample up to 10 cells from `getRows()`;
+    return `true` if any contains a finite parseable number.
+  - Update `createToggleForTable` grid path (from sprint 1): now that
+    `getRows()` works, replace the stub check with `isDataTable(makeAdapter(el))`.
+- **Scope — `chrome-extension/tests.js`:**
+  - Add tests with synthetic ARIA grid DOM fixtures:
+    - A simple `role="grid"` with two visible `role="row"` children and
+      `role="gridcell"` cells containing numbers: rounding applies.
+    - A grid with a pinned pane: cell stitching produces correct column order.
+    - `resetTable` on a rounded grid restores original values.
+    - `extractPreviewSamples` on a grid returns the expected sample structure.
+- **Out of scope:** Re-applying rounding on scroll / row recycle (sprint 4).
+  The rounding state is lost when rows leave the viewport — that is acceptable
+  and documented as a known limitation until sprint 4.
+- **Acceptance criteria:**
+  - Right-clicking a cell in a Databricks SQL result grid and choosing "Apply
+    rounding" visibly rounds the numbers in all currently-visible cells.
+  - Toggling off restores original values.
+  - `node chrome-extension/tests.js` passes.
+- **Depends on:** grid-adapter merged to main
+- **Complexity:** M
+- **Dev notes:**
+  - The pinned/scrollable stitching by DOM index is fragile if the two panes
+    have different row counts (e.g., header rows in one but not the other). Use
+    `data-row-index` matching when available; log a `console.debug` warning and
+    fall back to index matching otherwise.
+  - Do not attempt to scroll-trigger additional row rendering — only round what
+    is visible.
+  - Do not bump `manifest.json` version.
+
+---
+
+### grid-virtualization
+
+- **Goal:** Keep a rounded grid rounded as the user scrolls: re-apply (or
+  un-apply) rounding to rows that are recycled into the viewport.
+- **Scope — `chrome-extension/content.js`:**
+  - Add `gridObservers: WeakMap<Element, MutationObserver>` at module level
+    (parallel to `tableToggles`).
+  - In `roundTable`, after applying rounding, check `adapter.isVirtualized()`.
+    If `true`:
+    1. Find the scroll container element (same query as `GridAdapter.getRows()`,
+       step 1).
+    2. Create a `MutationObserver` that, on each `childList` mutation, calls a
+       helper `reapplyGridRounding(wrapperEl)`.
+    3. `reapplyGridRounding`: re-runs `roundTable(wrapperEl, tableOptions.get(wrapperEl))`
+       but only processes rows that do **not** already have `.dr-ext-rounded`
+       cells — avoids double-rounding already-visible rows.
+    4. `observe(scrollContainer, { childList: true, subtree: true })`.
+    5. Store in `gridObservers.set(wrapperEl, observer)`.
+  - In `resetTable`, if `adapter.isVirtualized()` and `gridObservers.has(el)`:
+    disconnect and delete the observer before clearing cells.
+  - In the MutationObserver that watches for removed tables (L493): also check
+    `gridObservers` for the removed element and disconnect.
+- **Scope — `chrome-extension/tests.js`:**
+  - Synthetic test: create a grid wrapper, round it, simulate row recycling via
+    `appendChild` of a new `role="row"` child, verify `reapplyGridRounding` is
+    called and the new row is rounded.
+  - Verify that after `resetTable`, appending a new row does NOT trigger
+    rounding (observer disconnected).
+- **Out of scope:** Handling horizontal scroll (new columns entering the
+  viewport) — column virtualization is rare and adds significant complexity;
+  defer to a follow-up sprint.
+- **Acceptance criteria:**
+  - In a Databricks SQL result, scrolling down after rounding causes newly-
+    visible rows to be rounded automatically.
+  - Turning off rounding stops re-application.
+  - No observable performance regression on pages with native `<table>` elements
+    (the observer is never attached to non-virtualized tables).
+  - `node chrome-extension/tests.js` passes.
+- **Depends on:** grid-rounding merged to main
+- **Complexity:** M
+- **Dev notes:**
+  - `reapplyGridRounding` must be debounced (e.g., 50 ms `requestAnimationFrame`
+    or `setTimeout`) — grids can fire dozens of DOM mutations in a single scroll
+    tick and we don't want to re-run rounding synchronously for each one.
+  - The `subtree: true` option is necessary because grids often wrap rows in an
+    intermediate container. Monitor observed mutation counts in practice; if the
+    observer is too noisy, narrow to `childList: true` without `subtree` and
+    instead watch only direct children of the scroll container.
+  - Do not bump `manifest.json` version.
+
+## 5. Open Questions
+
+- **Synchronized-scroll verification:** The research doc flags this as
+  unresolved. Before sprint 3 ships, manually verify on a live Databricks page
+  that scrolling the scrollable pane does move the pinned pane in sync (it
+  almost certainly does, but the stitching logic in `GridAdapter.getRows()`
+  depends on row index alignment being maintained at all times).
+- **AG Grid and Cloudscape selectors:** The sprint 3 `GridAdapter` selector
+  list covers Databricks and AG Grid. AWS Cloudscape (`.awsui-table-wrapper`)
+  and Azure Data Studio have not been tested. Add their selectors before sprint
+  3 ships if a test environment is available.
+- **Column virtualization:** Some grids (especially wide ones) also virtualize
+  columns — cells outside the horizontal viewport are not rendered. Sprint 4
+  does not address this. If it becomes a user report, it warrants a sprint 5.
+- **Right-click targeting depth:** `closest('[role="grid"]')` walks up from the
+  clicked cell. If the grid library wraps cells in extra divs, the walk may
+  overshoot to a parent grid. Add a depth limit or prefer the closest match.
+
+## 6. Out of Scope (Separate Sprint-Stack)
+
+- Column virtualization (horizontal scroll recycling).
+- Google Sheets / Excel Online (these use canvas rendering in some browsers, not
+  DOM nodes — a fundamentally different approach is needed).
+- Python / `js/` sibling implementations — grid support is browser-only.
+
+## Decisions Log
+
+- 2026-06-10: Initial draft. Sprints 1 and 2 are independent; 3 depends on 2;
+  4 depends on 3.


### PR DESCRIPTION
## Summary

- **`docs/research/databricks-grid-detection.md`** — research notes on identifying virtualized data grids (Databricks SQL and others), including selectors, structural detection heuristics, cross-platform patterns, and open questions.
- **`docs/sprint-plans/grid-support.md`** — 4-sprint plan (+ feasibility spike) for extending the extension to support unlabelled div-based data grids. Sprints 2–4 marked provisional pending the spike's verdict on DOM structure and framework-clobbering risk.
- **`.agent/skills/sprint-plan/SKILL.md`** — new Phase 4b: sequence sprints to pull risky learning forward; insert a feasibility spike (no-code investigation, verdict gates downstream sprints) when you can't reorder.
- **`.agent/skills/sprint-stack/SKILL.md`** — spike-aware execution: detect spike sprints, halt at them, resolve via a user-written log on `main` (Confirmed / Amend), defer downstream sprints until resolved.

## Key decisions in the plan

- Heuristic detects **unlabelled** grids via column-structure (consistent cell count + column-width alignment + numeric content) — not row height, which breaks on wrapped text.
- **Lazy right-click discovery** for unlabelled grids; proactive badging only for cheap native/ARIA signals on page load.
- **Sprint 0 (feasibility-spike)** validates real DOM structure and whether in-place `textContent` survives framework re-render before the adapter architecture (sprints 2–4) is built.
- Re-apply observer debounced to **100 ms**.

## Test plan

- [ ] Review `docs/sprint-plans/grid-support.md` — strategy, sprint definitions, spike, provisional markers
- [ ] Review `docs/research/databricks-grid-detection.md`
- [ ] Review skill additions in `.agent/skills/sprint-plan/SKILL.md` (Phase 4b) and `.agent/skills/sprint-stack/SKILL.md` (spike handling)