### PR TITLE
Refactor the rounding engine onto a TableAdapter interface

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -31,6 +31,59 @@ const GRID_ARIA_SELECTOR = '[role="grid"], [role="table"]';
 // rounding.js (loaded by manifest content_scripts ahead of this file) so the
 // sidebar can call the same arithmetic for its preview band.
 
+// --- TableAdapter abstraction ---
+// Two adapter classes provide a uniform row/cell interface over both native
+// <table> elements and div-based virtual grids. The four engine functions
+// (isDataTable, roundTable, resetTable, extractPreviewSamples) consume only
+// the adapter API; they never touch .rows/.cells directly.
+
+class NativeTableAdapter {
+  constructor(el) {
+    this.el = el;
+  }
+  getElement() { return this.el; }
+  isVirtualized() { return false; }
+  getRows() {
+    return Array.from(this.el.rows).map(row => ({
+      getCells() {
+        return Array.from(row.cells).map(cell => ({
+          getText() { return cell.innerText || cell.textContent || ''; },
+          setText(s) {
+            cell.dataset.originalHtml = cell.innerHTML;
+            cell.textContent = s;
+          },
+          el: cell,
+          tagName: cell.tagName,
+        }));
+      },
+    }));
+  }
+}
+
+class GridAdapter {
+  constructor(el) {
+    this.el = el;
+  }
+  getElement() { return this.el; }
+  isVirtualized() { return true; }
+  /** Stub — returns empty until grid-rounding sprint implements this. */
+  getRows() { return []; }
+}
+
+/**
+ * Factory: returns a NativeTableAdapter for <table> elements, GridAdapter otherwise.
+ * Adapters are ephemeral (never cached) — grids change row count on scroll.
+ *
+ * Duck-typing fallback: plain objects with a `rows` property (e.g. test stubs)
+ * are treated as native tables since they expose the same row/cell interface.
+ */
+function makeAdapter(el) {
+  if (el.tagName === 'TABLE' || (el.tagName === undefined && el.rows)) {
+    return new NativeTableAdapter(el);
+  }
+  return new GridAdapter(el);
+}
+
 // Toggle geometry constants
 const TOGGLE_DOT_PX = 10;
 const TOGGLE_PILL_WIDTH_PX = 28;
@@ -455,19 +508,20 @@ function findTargetTable(el) {
 }
 
 function isDataTable(table) {
-  if (table.rows.length < 2) return false;
+  const rows = makeAdapter(table).getRows();
+  if (rows.length < 2) return false;
   let hasMultipleColumns = false;
-  for (let i = 0; i < table.rows.length; i++) {
-    if (table.rows[i].cells.length >= 2) {
+  for (let i = 0; i < rows.length; i++) {
+    if (rows[i].getCells().length >= 2) {
       hasMultipleColumns = true;
       break;
     }
   }
   if (!hasMultipleColumns) return false;
-  for (let i = 0; i < table.rows.length; i++) {
-    const row = table.rows[i];
-    for (let j = 0; j < row.cells.length; j++) {
-      const text = row.cells[j].textContent.trim().replace(CLEAN_REGEX, '');
+  for (let i = 0; i < rows.length; i++) {
+    const cells = rows[i].getCells();
+    for (let j = 0; j < cells.length; j++) {
+      const text = cells[j].getText().trim().replace(CLEAN_REGEX, '');
       if (text !== '' && isFinite(parseFloat(text))) return true;
     }
   }
@@ -864,12 +918,12 @@ function resetTable(table) {
 // times are intentionally skipped here — they're deferred to a future sprint.
 function collectNumericCells(table) {
   const out = [];
-  const rows = table.rows ? Array.from(table.rows) : [];
+  const rows = makeAdapter(table).getRows();
   for (const row of rows) {
-    const cells = row.cells ? Array.from(row.cells) : [];
-    for (const cell of cells) {
-      if (cell.tagName !== 'TD') continue;
-      const text = cell.innerText || cell.textContent || '';
+    const cells = row.getCells();
+    for (const cellObj of cells) {
+      if (cellObj.tagName !== 'TD') continue;
+      const text = cellObj.getText();
       const trimmed = typeof text === 'string' ? text.trim() : '';
       if (!trimmed) continue;
       if (isDateLike(trimmed) || isTimeLike(trimmed)) continue;
@@ -958,23 +1012,27 @@ function roundTable(table, options) {
   }
   chrome.runtime.sendMessage({ action: 'RANGE_OK' });
   const ranges = rangeParse.ranges;
-  const rows = Array.from(table.rows);
+  const adapterRows = makeAdapter(table).getRows();
+  // Clean stub path: if the adapter returns no rows (e.g. GridAdapter stub),
+  // return early without throwing.
+  if (adapterRows.length === 0) return;
   const data = [];
   const cellsMap = [];
   const cellInfo = [];
 
-  for (let r = 0; r < rows.length; r++) {
-    const cells = Array.from(rows[r].cells);
+  for (let r = 0; r < adapterRows.length; r++) {
+    const adapterCells = adapterRows[r].getCells();
     const rowData = [];
     const rowCells = [];
     const rowInfo = [];
     let dataCol = 0;
-    for (let c = 0; c < cells.length; c++) {
-      const cell = cells[c];
+    for (let c = 0; c < adapterCells.length; c++) {
+      const cellObj = adapterCells[c];
+      const cell = cellObj.el;
       // Skip <th> row-header cells entirely — they are not data columns.
-      if (cell.tagName !== 'TD') continue;
+      if (cellObj.tagName !== 'TD') continue;
       const col = dataCol++;
-      const text = cell.innerText || cell.textContent;
+      const text = cellObj.getText();
       rowData.push(text);
       rowCells.push(cell);
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -103,6 +103,10 @@ Object.defineProperty(globalThis, 'lastRightClickedTable', {
 // Expose grid-detection helpers for the grid-detection test suite.
 globalThis.looksLikeGrid = looksLikeGrid;
 globalThis.findTargetTable = findTargetTable;
+// Expose TableAdapter abstraction for the grid-adapter test suite.
+globalThis.makeAdapter = makeAdapter;
+globalThis.NativeTableAdapter = NativeTableAdapter;
+globalThis.GridAdapter = GridAdapter;
 `);
 
 let passed = 0;
@@ -6548,6 +6552,189 @@ function withFindTargetEnv(elements, fn) {
     eq('findTargetTable: marks outermost grid with dr-ext-grid class',
       outer.classList.contains('dr-ext-grid'), true);
   });
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint grid-adapter: TableAdapter abstraction
+// AC2 — NativeTableAdapter round-trip test
+// AC3 — GridAdapter stub no-throw test
+// AC4 — source scan: no role="gridcell" or data-row-index literals in content.js
+// ---------------------------------------------------------------------------
+
+// Helper: build a minimal native-table stub that NativeTableAdapter can wrap.
+// el.rows is an array of row objects with .cells arrays of cell objects.
+// Each cell has .innerText, .textContent, .tagName, .classList, .dataset,
+// .innerHTML, .querySelector (for compatibility with roundTable internals).
+function makeNativeTableEl(rowsSpec) {
+  // rowsSpec: array of arrays of { tag, text }
+  const el = {
+    tagName: 'TABLE',
+    rows: rowsSpec.map(rowSpec => ({
+      cells: rowSpec.map(s => ({
+        tagName: (s.tag || 'td').toUpperCase(),
+        innerText: s.text,
+        textContent: s.text,
+        innerHTML: s.text,
+        classList: {
+          _c: [],
+          add(c) { if (!this._c.includes(c)) this._c.push(c); },
+          remove(c) { this._c = this._c.filter(x => x !== c); },
+          contains(c) { return this._c.includes(c); },
+        },
+        dataset: {},
+        title: '',
+        querySelector: () => null,
+        querySelectorAll: () => [],
+      }))
+    })),
+    dataset: {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+  return el;
+}
+
+// TA1: NativeTableAdapter round-trip
+// Build a native table element, wrap it with makeAdapter(), walk the adapter
+// API (getRows → getCells → getText) and assert values match what was put in.
+// Also assert isVirtualized() === false and getElement() returns the element.
+(function nativeTableAdapter_roundTrip() {
+  const tableEl = makeNativeTableEl([
+    [{ tag: 'td', text: '1,234' }, { tag: 'td', text: '5,678' }],
+    [{ tag: 'td', text: '9,012' }, { tag: 'td', text: '3,456' }],
+  ]);
+
+  const adapter = makeAdapter(tableEl);
+
+  eq('NativeTableAdapter: makeAdapter returns NativeTableAdapter for TABLE element',
+    adapter instanceof NativeTableAdapter, true);
+
+  eq('NativeTableAdapter: getElement() returns the original element',
+    adapter.getElement(), tableEl);
+
+  eq('NativeTableAdapter: isVirtualized() === false',
+    adapter.isVirtualized(), false);
+
+  const rows = adapter.getRows();
+  eq('NativeTableAdapter: getRows() returns 2 rows',
+    rows.length, 2);
+
+  const cells0 = rows[0].getCells();
+  eq('NativeTableAdapter: row 0 has 2 cells',
+    cells0.length, 2);
+
+  eq('NativeTableAdapter: row 0 cell 0 getText() returns "1,234"',
+    cells0[0].getText(), '1,234');
+
+  eq('NativeTableAdapter: row 0 cell 1 getText() returns "5,678"',
+    cells0[1].getText(), '5,678');
+
+  const cells1 = rows[1].getCells();
+  eq('NativeTableAdapter: row 1 cell 0 getText() returns "9,012"',
+    cells1[0].getText(), '9,012');
+
+  eq('NativeTableAdapter: row 1 cell 1 getText() returns "3,456"',
+    cells1[1].getText(), '3,456');
+
+  // Each cell object must expose .el pointing back to the DOM cell element
+  eq('NativeTableAdapter: cell .el is the underlying DOM cell',
+    cells0[0].el, tableEl.rows[0].cells[0]);
+})();
+
+// TA2: NativeTableAdapter — cell count matches table structure
+// A 3-row × 3-column table round-trips with correct row and cell counts.
+(function nativeTableAdapter_3x3() {
+  const tableEl = makeNativeTableEl([
+    [{ tag: 'td', text: 'a' }, { tag: 'td', text: 'b' }, { tag: 'td', text: 'c' }],
+    [{ tag: 'td', text: '1' }, { tag: 'td', text: '2' }, { tag: 'td', text: '3' }],
+    [{ tag: 'td', text: 'x' }, { tag: 'td', text: 'y' }, { tag: 'td', text: 'z' }],
+  ]);
+
+  const adapter = makeAdapter(tableEl);
+  const rows = adapter.getRows();
+
+  eq('NativeTableAdapter: 3×3 table — getRows() returns 3 rows',
+    rows.length, 3);
+
+  eq('NativeTableAdapter: 3×3 table — row 1 has 3 cells',
+    rows[1].getCells().length, 3);
+
+  eq('NativeTableAdapter: 3×3 table — row 2 cell 2 text is "z"',
+    rows[2].getCells()[2].getText(), 'z');
+})();
+
+// TA3: GridAdapter stub — makeAdapter on a non-TABLE element returns GridAdapter
+// isVirtualized() === true, getRows() === [], getElement() returns the element.
+(function gridAdapter_stub_properties() {
+  const divEl = {
+    tagName: 'DIV',
+    dataset: {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    classList: {
+      _c: [],
+      add(c) { if (!this._c.includes(c)) this._c.push(c); },
+      contains(c) { return this._c.includes(c); },
+    },
+  };
+
+  const adapter = makeAdapter(divEl);
+
+  eq('GridAdapter: makeAdapter on DIV returns GridAdapter',
+    adapter instanceof GridAdapter, true);
+
+  eq('GridAdapter: getElement() returns the div element',
+    adapter.getElement(), divEl);
+
+  eq('GridAdapter: isVirtualized() === true',
+    adapter.isVirtualized(), true);
+
+  eq('GridAdapter: getRows() returns empty array (stub)',
+    adapter.getRows().length, 0);
+})();
+
+// TA4: roundTable on a grid element (non-TABLE) — must not throw, must be a no-op
+// The stub path: GridAdapter.getRows() → [] causes roundTable to return early.
+// No .dr-ext-rounded cells should appear; no exception thrown.
+(function gridAdapter_stub_noThrow() {
+  const divEl = {
+    tagName: 'DIV',
+    dataset: {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    classList: {
+      _c: [],
+      add(c) { if (!this._c.includes(c)) this._c.push(c); },
+      contains(c) { return this._c.includes(c); },
+    },
+  };
+
+  let threw = false;
+  try {
+    roundTable(divEl, Object.assign({}, DR_DEFAULTS));
+  } catch (e) {
+    threw = true;
+  }
+
+  eq('GridAdapter stub: roundTable on grid element does not throw',
+    threw, false);
+
+  // The element should have no .dr-ext-rounded cells since it was a no-op
+  eq('GridAdapter stub: roundTable on grid element is a no-op (querySelector returns null)',
+    divEl.querySelector('.dr-ext-rounded'), null);
+})();
+
+// TA5: source-scan — no role="gridcell" or data-row-index literals in content.js
+// Per AC4 of the grid-adapter sprint, these stale Sprint 1 selectors must have
+// been replaced by role="cell" / data-row / data-index.
+(function sourceNoLegacySelectors() {
+  const contentSrc = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+
+  eq('grid-adapter AC4: no role="gridcell" literal remains in content.js',
+    contentSrc.includes('role="gridcell"'), false);
+
+  eq('grid-adapter AC4: no data-row-index literal remains in content.js',
+    contentSrc.includes('data-row-index'), false);
 })();
 
 // --- Report ---

--- a/docs/sprint-logs/grid-support-v2-grid-adapter.md
+++ b/docs/sprint-logs/grid-support-v2-grid-adapter.md
@@ -1,0 +1,22 @@
+# Sprint Log: grid-adapter
+
+**Plan:** docs/sprint-plans/grid-support-v2.md
+**Sprint goal:** Refactor the rounding engine onto a `TableAdapter` interface.
+**Date:** 2026-06-11
+**Result:** Completed
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Added `NativeTableAdapter`, `GridAdapter` (stub `getRows() → []`), and a `makeAdapter(el)` factory to `content.js`. Refactored `isDataTable`, `roundTable`, `resetTable`, and `extractPreviewSamples` (via `collectNumericCells`) to consume the adapter read API (`makeAdapter(el).getRows()` / `row.getCells()` / `getText()`) instead of touching `.rows`/`.cells` directly. `roundTable` early-returns when `getRows()` is empty (clean `GridAdapter` stub path). Native write/restore path unchanged (writes via `cellObj.el`, stores `dataset.originalHtml`, restores in `resetTable`). Confirmed no `role="gridcell"` / `data-row-index` literals remain. `manifest.json` untouched.
+- **Tests:** pass — `node chrome-extension/tests.js` → Passed: 825, Failed: 0 (804 pre-existing + 21 new). Test-writer added a `NativeTableAdapter` round-trip test, a 3×3 cell-count test, a `GridAdapter` stub-properties test, a `roundTable`-on-grid no-throw test, and a source-scan for stale selectors.
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:**
+  - Native rounding is behavior-identical: the refactor changes only the *read* layer; the write/restore path and storage key are unchanged.
+  - `NativeTableAdapter.setText` is currently dead code (native path writes via `cellObj.el` per spec); harmless — it uses the same `dataset.originalHtml` key.
+  - Minor, practically-unreachable edge case: a 0-row native table now hits the empty-rows early return, skipping the trailing `syncSwitchForTable`. `roundTable` is always `isDataTable`-gated (≥2 rows), so unreached in practice.
+  - The selector "correction" was a no-op in practice — the legacy `role="gridcell"` / `data-row-index` literals never existed on `main` (grid-detection used the correct `role="grid"`/`role="table"`). Matches the plan's "no behavioral risk" characterization.
+  - Non-blocking test gap: AC2 ("behavior-identical native rounding") is verified at the adapter read layer; a dedicated `roundTable`→`resetTable` round-trip through the adapter could pin it more directly. Worth adding opportunistically in grid-rounding.
+
+## PR
+(opened to main — see PR link)


### PR DESCRIPTION
Plan: docs/sprint-plans/grid-support-v2.md

Refactors the rounding engine onto a `TableAdapter` interface. `NativeTableAdapter` is behavior-identical to today (all existing tests stay green); `GridAdapter` defines the contract with a stubbed `getRows() → []`. `makeAdapter(el)` factory routes `<table>` → native, else grid. The four engine functions (`isDataTable`, `roundTable`, `resetTable`, `extractPreviewSamples`) now consume the adapter read API; `roundTable` no-ops on an empty (stub) grid.

## Acceptance criteria
- [x] `node chrome-extension/tests.js` passes with zero regressions (825 passed / 0 failed)
- [x] Native `<table>` rounding behavior-identical to pre-refactor (read layer only; write/restore path unchanged)
- [x] `roundTable` on a grid element returns without throwing (clean stub path)
- [x] No `role="gridcell"` or `data-row-index` literal remains in `content.js`

## Reviewer notes
- `NativeTableAdapter.setText` is currently unused (native path writes via `cellObj.el` per spec); harmless, same `dataset.originalHtml` key.
- Minor, practically-unreachable edge case: a 0-row native table now hits the empty-rows early return, skipping the trailing `syncSwitchForTable`; `roundTable` is always `isDataTable`-gated (≥2 rows).
- The legacy `role="gridcell"`/`data-row-index` selectors never existed on `main`, so the selector correction was a no-op in practice (matches the plan's "no behavioral risk" note).
- Non-blocking test gap: AC2 verified at the adapter read layer; a dedicated `roundTable`→`resetTable` round-trip through the adapter could pin it more directly — to add opportunistically in grid-rounding.
