### PR TITLE
Round visible data-grid rows via text-node nodeValue patching

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1238,11 +1238,15 @@ function roundTable(table, options) {
   }
   chrome.runtime.sendMessage({ action: 'RANGE_OK' });
   const ranges = rangeParse.ranges;
-  const adapterRows = makeAdapter(table).getRows();
+  const adapter = makeAdapter(table);
+  const adapterRows = adapter.getRows();
   // Clean stub path: if the adapter returns no rows (e.g. GridAdapter stub),
   // return early without throwing.
   if (adapterRows.length === 0) return;
+  const isVirtualized = adapter.isVirtualized();
   const data = [];
+  // For native tables, cellsMap stores raw element. For grid tables, cellsMap
+  // stores the full cellObj so the write pass can call cellObj.setText().
   const cellsMap = [];
   const cellInfo = [];
 
@@ -1260,7 +1264,9 @@ function roundTable(table, options) {
       const col = dataCol++;
       const text = cellObj.getText();
       rowData.push(text);
-      rowCells.push(cell);
+      // Carry the full cellObj for grid adapters so the write pass can call
+      // cellObj.setText(); for native adapters carry the raw element (unchanged).
+      rowCells.push(isVirtualized ? cellObj : cell);
 
       const trimmed = typeof text === 'string' ? text.trim() : '';
       // Whole-cell quote short-circuit: if the entire cell content is a single
@@ -1419,7 +1425,6 @@ function roundTable(table, options) {
       if (info.mode === 'skip') continue;
 
       const originalValue = data[r][c];
-      const cell = cellsMap[r][c];
       let formattedValue;
 
       if (info.mode === 'date') {
@@ -1437,10 +1442,19 @@ function roundTable(table, options) {
         // simplifies (e.g. "35.0" → "35").
         if (formattedValue === originalValue.trim()) continue;
       } else {
+        // mode === 'extracted': multi-match HTML-preserving patches.
+        // Known limitation: mode:'extracted' cells (mixed text with embedded numbers,
+        // e.g. <sup>-containing cells) require applyExtractedPatches which writes innerHTML.
+        // This is incompatible with the nodeValue-only write model required for virtualized
+        // grids (innerHTML writes crash React's reconciler). Skip extracted cells on grids
+        // for this sprint — only pure-numeric and date/time cells are rounded on grids.
+        if (isVirtualized) continue;
+
         // Round each match and patch its text node directly. This avoids the
         // whole-cell character-distribution approach, which mis-allocates
         // characters when newText length differs from original (corrupting
         // adjacent <sup> content, punctuation, and <a> text nodes).
+        const cell = cellsMap[r][c];
         const patches = [];
         for (const m of info.matches) {
           const rounded = roundCellSetAware(m.num, m.num, max_mag, offsetTop, offsetOther, numTop);
@@ -1456,13 +1470,24 @@ function roundTable(table, options) {
         continue;
       }
 
-      // Cache pristine HTML before mutation so toggle/reset can restore it
-      // without needing to keep the rounded value around.
-      cell.dataset.originalHtml = cell.innerHTML;
-      replaceTextPreservingHTML(cell, originalValue, formattedValue);
-      cell.title = `Original: ${originalValue}`;
-      cell.classList.add('dr-ext-rounded');
-      cell.dataset.originalValue = originalValue;
+      if (isVirtualized) {
+        // Grid path: write via nodeValue patching only — never innerHTML/textContent.
+        // cellsMap holds the full cellObj (GridAdapter._makeCellObj) for grid tables.
+        // cellObj.setText stores drOriginal, patches in place, adds dr-ext-rounded.
+        // Do NOT set dataset.originalHtml (would cause resetTable to fall into the
+        // native innerHTML restore branch — the crash mode on toggle-off).
+        const cellObj = cellsMap[r][c];
+        cellObj.setText(formattedValue);
+      } else {
+        // Native-table path: cache pristine HTML before mutation so toggle/reset can
+        // restore it without needing to keep the rounded value around.
+        const cell = cellsMap[r][c];
+        cell.dataset.originalHtml = cell.innerHTML;
+        replaceTextPreservingHTML(cell, originalValue, formattedValue);
+        cell.title = `Original: ${originalValue}`;
+        cell.classList.add('dr-ext-rounded');
+        cell.dataset.originalValue = originalValue;
+      }
     }
   }
   syncSwitchForTable(table);

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -60,14 +60,221 @@ class NativeTableAdapter {
   }
 }
 
+/**
+ * Depth-first search returning the deepest non-empty Text node
+ * (nodeType === 3, non-whitespace nodeValue) under cellEl.
+ * Returns null if no such node exists.
+ * @param {Element} cellEl
+ * @returns {Text|null}
+ */
+function findCellTextNode(cellEl) {
+  if (!cellEl) return null;
+  // Walk depth-first; track the deepest non-empty text node found.
+  let best = null;
+  function visit(node) {
+    if (node.nodeType === 3) {
+      // Text node
+      if (node.nodeValue && node.nodeValue.trim() !== '') {
+        best = node;
+      }
+      return;
+    }
+    if (node.childNodes) {
+      for (let i = 0; i < node.childNodes.length; i++) {
+        visit(node.childNodes[i]);
+      }
+    }
+  }
+  visit(cellEl);
+  return best;
+}
+
+/** CSS class applied to rounded grid cells (same class used by native-table path). */
+const GRID_ROUNDED_CLASS = 'dr-ext-rounded';
+
 class GridAdapter {
   constructor(el) {
     this.el = el;
   }
   getElement() { return this.el; }
   isVirtualized() { return true; }
-  /** Stub — returns empty until grid-rounding sprint implements this. */
-  getRows() { return []; }
+
+  /**
+   * Return the scroll container for this grid.
+   * Priority: known library selectors → else this.el.
+   */
+  _getScrollContainer() {
+    const el = this.el;
+    // Known library selectors (single-pane Databricks, AG Grid, etc.)
+    const knownSelectors = [
+      '.dg--grid-scroll-container',
+      '.dg--grid-container',
+      '.ag-center-cols-viewport',
+      '[role="grid"]',
+    ];
+    for (const sel of knownSelectors) {
+      const found = el.querySelector && el.querySelector(sel);
+      if (found) return found;
+    }
+    // Check if the element itself matches a known selector
+    if (el.matches) {
+      for (const sel of knownSelectors) {
+        try {
+          if (el.matches(sel)) return el;
+        } catch (e) { /* ignore */ }
+      }
+    }
+    return el;
+  }
+
+  /**
+   * Find the pinned pane sibling, if any.
+   * Returns null for single-pane grids (Databricks).
+   */
+  _getPinnedPane(scrollContainer) {
+    const pinnedSelectors = [
+      '.dg--pinned-grid',
+      '.ag-pinned-left-cols-container',
+    ];
+    const el = this.el;
+    for (const sel of pinnedSelectors) {
+      const found = el.querySelector && el.querySelector(sel);
+      if (found && found !== scrollContainer) return found;
+    }
+    return null;
+  }
+
+  /**
+   * Extract rows from a container element.
+   * Prefers [role="row"] / .dg--virtual-row; else repetitive children.
+   * @param {Element} container
+   * @returns {Element[]}
+   */
+  _getRowEls(container) {
+    if (!container) return [];
+    // Try ARIA/library rows first
+    let rows = container.querySelectorAll && container.querySelectorAll('[role="row"]');
+    if (rows && rows.length > 0) return Array.from(rows);
+    rows = container.querySelectorAll && container.querySelectorAll('.dg--virtual-row');
+    if (rows && rows.length > 0) return Array.from(rows);
+    // Fallback: repetitive children (direct children only)
+    if (container.children) return Array.from(container.children);
+    return [];
+  }
+
+  /**
+   * Extract cell elements from a row element.
+   * Prefers [role="cell"] / .dg--cell; else repetitive children.
+   * (The legacy role "gridcell" is NOT used — per spike amendment 2, only role="cell" is correct.)
+   * @param {Element} rowEl
+   * @returns {Element[]}
+   */
+  _getCellEls(rowEl) {
+    if (!rowEl) return [];
+    let cells = rowEl.querySelectorAll && rowEl.querySelectorAll('[role="cell"]');
+    if (cells && cells.length > 0) return Array.from(cells);
+    cells = rowEl.querySelectorAll && rowEl.querySelectorAll('.dg--cell');
+    if (cells && cells.length > 0) return Array.from(cells);
+    // Fallback: direct children
+    if (rowEl.children) return Array.from(rowEl.children);
+    return [];
+  }
+
+  /**
+   * Get the row key from a row element for pinned-pane stitching.
+   * Prefers data-row, then data-index.
+   * @param {Element} rowEl
+   * @param {number} domIndex
+   * @returns {string}
+   */
+  _getRowKey(rowEl, domIndex) {
+    if (rowEl.dataset) {
+      if (rowEl.dataset.row !== undefined) return rowEl.dataset.row;
+      if (rowEl.dataset.index !== undefined) return rowEl.dataset.index;
+    }
+    return String(domIndex);
+  }
+
+  /**
+   * Build a cell object compatible with the NativeTableAdapter cell shape.
+   * setText uses nodeValue patching — never textContent/innerHTML/appendChild/removeChild.
+   * @param {Element} cellEl
+   * @returns {{getText(): string, setText(s: string): void, el: Element, tagName: string}}
+   */
+  _makeCellObj(cellEl) {
+    return {
+      el: cellEl,
+      tagName: 'TD', // grid cells are treated as data cells (no <th> concept)
+      getText() {
+        // Prefer the stored original (if already rounded), else live text
+        if (cellEl.dataset && cellEl.dataset.drOriginal !== undefined) {
+          return cellEl.dataset.drOriginal;
+        }
+        const tn = findCellTextNode(cellEl);
+        return tn ? tn.nodeValue : (cellEl.textContent || '');
+      },
+      setText(s) {
+        const tn = findCellTextNode(cellEl);
+        if (tn === null) return; // no-op: cell has no text node to patch
+        // Store the original value on the cell element once.
+        if (cellEl.dataset && cellEl.dataset.drOriginal === undefined) {
+          cellEl.dataset.drOriginal = tn.nodeValue;
+        }
+        // Patch in place — NEVER replace the node (preserves React fiber identity).
+        tn.nodeValue = s;
+        if (cellEl.classList) cellEl.classList.add(GRID_ROUNDED_CLASS);
+      },
+    };
+  }
+
+  /**
+   * Return stitched rows from the grid: pinned cells first, then scroll cells.
+   * Each row exposes getCells() → array of cell objects.
+   */
+  getRows() {
+    const scrollContainer = this._getScrollContainer();
+    const pinnedPane = this._getPinnedPane(scrollContainer);
+
+    const scrollRows = this._getRowEls(scrollContainer);
+    if (scrollRows.length === 0) return [];
+
+    // Build a map from row-key → pinned row element for efficient stitching.
+    let pinnedRows = [];
+    const pinnedByKey = new Map();
+    if (pinnedPane) {
+      pinnedRows = this._getRowEls(pinnedPane);
+      pinnedRows.forEach((pr, idx) => {
+        const key = this._getRowKey(pr, idx);
+        pinnedByKey.set(key, pr);
+      });
+    }
+
+    const adapter = this;
+    return scrollRows.map((rowEl, idx) => {
+      const scrollKey = adapter._getRowKey(rowEl, idx);
+      // Find the matching pinned row (by data-row / data-index / DOM index).
+      let pinnedRowEl = pinnedByKey.get(scrollKey) || (pinnedRows[idx] || null);
+
+      return {
+        getCells() {
+          const cells = [];
+          // Pinned cells first (if any pinned pane exists).
+          if (pinnedRowEl) {
+            const pinnedCellEls = adapter._getCellEls(pinnedRowEl);
+            for (const cellEl of pinnedCellEls) {
+              cells.push(adapter._makeCellObj(cellEl));
+            }
+          }
+          // Scroll cells.
+          const scrollCellEls = adapter._getCellEls(rowEl);
+          for (const cellEl of scrollCellEls) {
+            cells.push(adapter._makeCellObj(cellEl));
+          }
+          return cells;
+        },
+      };
+    });
+  }
 }
 
 /**
@@ -507,8 +714,12 @@ function findTargetTable(el) {
   return null;
 }
 
+/** Maximum number of cells sampled across grid rows when probing isDataTable for virtual grids. */
+const GRID_IS_DATA_TABLE_CELL_SAMPLE = 10;
+
 function isDataTable(table) {
-  const rows = makeAdapter(table).getRows();
+  const adapter = makeAdapter(table);
+  const rows = adapter.getRows();
   if (rows.length < 2) return false;
   let hasMultipleColumns = false;
   for (let i = 0; i < rows.length; i++) {
@@ -518,9 +729,15 @@ function isDataTable(table) {
     }
   }
   if (!hasMultipleColumns) return false;
+  // For virtual grids, limit the cell scan to a small sample to avoid probing
+  // potentially hundreds of rows. For native tables the loop is cheap.
+  const maxCells = adapter.isVirtualized() ? GRID_IS_DATA_TABLE_CELL_SAMPLE : Infinity;
+  let cellCount = 0;
   for (let i = 0; i < rows.length; i++) {
     const cells = rows[i].getCells();
     for (let j = 0; j < cells.length; j++) {
+      if (cellCount >= maxCells) return false;
+      cellCount++;
       const text = cells[j].getText().trim().replace(CLEAN_REGEX, '');
       if (text !== '' && isFinite(parseFloat(text))) return true;
     }
@@ -532,14 +749,10 @@ function isDataTable(table) {
 let _globalTapCollapseAdded = false;
 
 function createToggleForTable(table) {
-  // For native <table> elements use the existing isDataTable() gate which reads
-  // .rows/.cells. For div-based grid roots use the structural looksLikeGrid()
-  // heuristic, since .rows is not available on non-table elements.
-  if (table.tagName === 'TABLE') {
-    if (!isDataTable(table)) return;
-  } else {
-    if (!looksLikeGrid(table)) return;
-  }
+  // For native <table> elements use isDataTable() (via NativeTableAdapter).
+  // For div-based grid roots use isDataTable() via GridAdapter now that getRows() is implemented.
+  // looksLikeGrid() is no longer used here — it remains available for findTargetTable walk-up.
+  if (!isDataTable(table)) return;
   ensureToggleStyleInjected();
 
   const button = document.createElement('button');
@@ -898,13 +1111,26 @@ function flashRangePulse(table, ranges) {
 function resetTable(table) {
   const roundedCells = table.querySelectorAll('.dr-ext-rounded');
   for (const cell of roundedCells) {
-    if (cell.dataset.originalHtml !== undefined) {
-      cell.innerHTML = cell.dataset.originalHtml;
+    // Grid cells are reset via nodeValue patching (drOriginal is set by GridAdapter.setText).
+    // Native-table cells are reset via innerHTML (originalHtml is set by NativeTableAdapter.setText).
+    if (cell.dataset.drOriginal !== undefined) {
+      // Grid path: restore the original text node value in place (preserves node identity).
+      const tn = findCellTextNode(cell);
+      if (tn !== null) {
+        tn.nodeValue = cell.dataset.drOriginal;
+      }
+      cell.classList.remove(GRID_ROUNDED_CLASS);
+      delete cell.dataset.drOriginal;
+    } else {
+      // Native-table path: restore full HTML (supports mixed/extracted cells).
+      if (cell.dataset.originalHtml !== undefined) {
+        cell.innerHTML = cell.dataset.originalHtml;
+      }
+      cell.classList.remove('dr-ext-rounded');
+      delete cell.dataset.originalValue;
+      delete cell.dataset.originalHtml;
+      cell.removeAttribute('title');
     }
-    cell.classList.remove('dr-ext-rounded');
-    delete cell.dataset.originalValue;
-    delete cell.dataset.originalHtml;
-    cell.removeAttribute('title');
   }
   delete table.dataset.drShowingOriginal;
   syncSwitchForTable(table);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -6737,6 +6737,606 @@ function makeNativeTableEl(rowsSpec) {
     contentSrc.includes('data-row-index'), false);
 })();
 
+// =============================================================================
+// Sprint grid-rounding tests
+// Spec: docs/sprint-plans/grid-support-v2.md §2 D3 + §4 "grid-rounding"
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// DOM-stub helpers for grid cells that contain real Text nodes (nodeType 3).
+//
+// findCellTextNode does a depth-first walk that checks node.nodeType,
+// node.nodeValue, and iterates node.childNodes. We build minimal objects that
+// satisfy exactly those interfaces — no jsdom required.
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a plain-object Text node (nodeType 3) with a live nodeValue.
+ * Designed so findCellTextNode will recognise and return it.
+ */
+function makeTextNode(value) {
+  return {
+    nodeType: 3,
+    nodeValue: value,
+    childNodes: null,   // text nodes have no children; visit() guards on childNodes
+  };
+}
+
+/**
+ * Create a plain-object Element node (nodeType 1) that can contain childNodes.
+ * @param {string} [className='']
+ * @param {Array}  [childNodes=[]]
+ */
+function makeElementNode(className, childNodes) {
+  const cls = className || '';
+  const kids = childNodes || [];
+  return {
+    nodeType: 1,
+    className: cls,
+    childNodes: kids,
+    children: kids.filter(n => n.nodeType === 1),
+    dataset: {},
+    classList: (() => {
+      const c = [];
+      return {
+        _c: c,
+        add(x)      { if (!c.includes(x)) c.push(x); },
+        remove(x)   { const i = c.indexOf(x); if (i >= 0) c.splice(i, 1); },
+        contains(x) { return c.includes(x); },
+      };
+    })(),
+  };
+}
+
+/**
+ * Create a div-grid cell element that wraps a single Text node.
+ * The text node is accessible via cell.childNodes[0].
+ * @param {string} text  — the cell's text content
+ */
+function makeGridCellWithTextNode(text) {
+  const tn = makeTextNode(text);
+  const cell = makeElementNode('', [tn]);
+  return cell;
+}
+
+/**
+ * Create a div-grid cell that wraps a nested span > text node (deeper nesting).
+ * Tests that findCellTextNode descends past intermediate elements.
+ */
+function makeGridCellDeepTextNode(text) {
+  const tn = makeTextNode(text);
+  const span = makeElementNode('inner', [tn]);
+  const cell = makeElementNode('', [span]);
+  return cell;
+}
+
+/**
+ * Build a complete div-based grid suitable for GridAdapter consumption.
+ *
+ * Returns { wrapperEl, rowEls, cellEls } so tests can inspect individual rows/cells.
+ *
+ * @param {Array<Array<string>>} rowData  — 2D array of cell text values
+ * @param {{className?: string, useDataRow?: boolean, useDgClasses?: boolean}} [opts]
+ */
+function makeGridWrapper(rowData, opts) {
+  const options = opts || {};
+  const useDataRow = options.useDataRow !== false;   // default true
+  const useDgClasses = !!options.useDgClasses;
+
+  const rowEls = [];
+  const allCellEls = [];
+
+  rowData.forEach(function(cellTexts, rowIndex) {
+    const cellEls = cellTexts.map(function(text) {
+      const cell = makeGridCellWithTextNode(text);
+      if (useDgClasses) {
+        cell.classList.add('dg--cell');
+        // querySelectorAll('.dg--cell') on a row element must return child cells
+        // — we attach it on the row below after building it.
+      }
+      allCellEls.push(cell);
+      return cell;
+    });
+
+    const row = makeElementNode(useDgClasses ? 'dg--virtual-row' : 'row', cellEls);
+    if (useDataRow) {
+      row.dataset = { row: String(rowIndex) };
+    } else {
+      row.dataset = {};
+    }
+    row.children = cellEls;
+
+    // querySelectorAll stubs on the row element (used by GridAdapter._getCellEls)
+    row.querySelectorAll = function(sel) {
+      if (useDgClasses && sel === '.dg--cell') return cellEls;
+      if (sel === '[role="cell"]') return [];
+      return [];
+    };
+
+    rowEls.push(row);
+  });
+
+  // The wrapper element acts as both the grid root and the scroll container
+  // (single-pane: no known library selectors → _getScrollContainer returns this.el)
+  const wrapper = makeElementNode(options.className || 'grid-wrapper', rowEls);
+  wrapper.tagName = 'DIV';
+  wrapper.children = rowEls;
+
+  // querySelectorAll stubs on the wrapper (used by GridAdapter._getScrollContainer
+  // and _getRowEls / _getPinnedPane)
+  wrapper.querySelector = function(sel) { return null; };   // no sub-containers
+  wrapper.querySelectorAll = function(sel) {
+    if (useDgClasses && sel === '.dg--virtual-row') return rowEls;
+    if (sel === '[role="row"]') return [];
+    // For _getPinnedPane selectors — return nothing (single-pane grid)
+    return [];
+  };
+  wrapper.matches = function() { return false; };
+  wrapper.dataset = {};
+
+  return { wrapperEl: wrapper, rowEls: rowEls, cellEls: allCellEls };
+}
+
+// ---------------------------------------------------------------------------
+// GR1: Unlabelled variable-row-height grid — structural extraction + nodeValue rounding
+// The headline test: no ARIA roles, no dg-- classes. GridAdapter must fall back
+// to direct children as rows and direct row-children as cells.
+// ---------------------------------------------------------------------------
+
+(function gr1_unlabelledGrid_extractionAndRounding() {
+  // Build a 3×2 grid with numeric values at different magnitudes
+  const grid = makeGridWrapper([
+    ['8584629', '286'],
+    ['1234567', '99'],
+    ['7654321', '55'],
+  ]);
+
+  const adapter = makeAdapter(grid.wrapperEl);
+
+  eq('GR1: makeAdapter returns GridAdapter for div wrapper',
+    adapter instanceof GridAdapter, true);
+
+  eq('GR1: isVirtualized() === true',
+    adapter.isVirtualized(), true);
+
+  const rows = adapter.getRows();
+  eq('GR1: getRows() returns 3 rows',
+    rows.length, 3);
+
+  const cells0 = rows[0].getCells();
+  eq('GR1: row 0 has 2 cells',
+    cells0.length, 2);
+
+  eq('GR1: row 0 cell 0 getText() returns "8584629"',
+    cells0[0].getText(), '8584629');
+
+  eq('GR1: row 0 cell 1 getText() returns "286"',
+    cells0[1].getText(), '286');
+
+  // Now round via setText and confirm nodeValue changed
+  cells0[0].setText('8500000');
+  const tn0 = grid.cellEls[0].childNodes[0];
+  eq('GR1: after setText, text node nodeValue is rounded value',
+    tn0.nodeValue, '8500000');
+
+  // The dr-ext-rounded class must be on the cell element
+  eq('GR1: after setText, cell carries dr-ext-rounded class',
+    grid.cellEls[0].classList.contains('dr-ext-rounded'), true);
+})();
+
+// ---------------------------------------------------------------------------
+// GR2: .dg--virtual-row / .dg--cell shaped grid — path extracts via library selectors
+// ---------------------------------------------------------------------------
+
+(function gr2_dgGrid_extraction() {
+  const grid = makeGridWrapper([
+    ['1000000', '500'],
+    ['2000000', '750'],
+  ], { useDgClasses: true });
+
+  const adapter = makeAdapter(grid.wrapperEl);
+
+  const rows = adapter.getRows();
+  eq('GR2: dg-- grid getRows() returns 2 rows',
+    rows.length, 2);
+
+  const cells = rows[0].getCells();
+  eq('GR2: dg-- grid row 0 has 2 cells',
+    cells.length, 2);
+
+  eq('GR2: dg-- grid row 0 cell 0 text is "1000000"',
+    cells[0].getText(), '1000000');
+
+  // Confirm data-row attribute path: row 0 has dataset.row = "0"
+  eq('GR2: dg-- grid row 0 has data-row="0"',
+    grid.rowEls[0].dataset.row, '0');
+
+  eq('GR2: dg-- grid row 1 has data-row="1"',
+    grid.rowEls[1].dataset.row, '1');
+})();
+
+// ---------------------------------------------------------------------------
+// GR3: nodeValue write asserts NODE IDENTITY — the regression guard for the
+// reconciler crash. The spec mandates: patch in place, never replace the node.
+// ---------------------------------------------------------------------------
+
+(function gr3_nodeIdentityPreservation() {
+  const grid = makeGridWrapper([
+    ['9876543', '123'],
+  ]);
+
+  const adapter = makeAdapter(grid.wrapperEl);
+  const rows = adapter.getRows();
+  const cellObj = rows[0].getCells()[0];
+
+  // Capture the Text node object reference BEFORE setText.
+  const textNodeBefore = grid.cellEls[0].childNodes[0];
+  const childCountBefore = grid.cellEls[0].childNodes.length;
+
+  // Round via setText
+  cellObj.setText('9900000');
+
+  // The Text node reference returned by findCellTextNode must be the SAME object.
+  const textNodeAfter = grid.cellEls[0].childNodes[0];
+
+  eq('GR3: text node object identity preserved after setText (same reference)',
+    textNodeAfter === textNodeBefore, true);
+
+  eq('GR3: text node nodeValue was patched to rounded value',
+    textNodeAfter.nodeValue, '9900000');
+
+  // The cell's child node list length must be unchanged (no insertion/removal)
+  eq('GR3: cell childNodes.length unchanged after setText (no appendChild/removeChild)',
+    grid.cellEls[0].childNodes.length, childCountBefore);
+
+  // Double-safety: the cell element itself is unchanged (not recreated)
+  eq('GR3: cell element reference unchanged after setText',
+    grid.cellEls[0], grid.cellEls[0]);
+})();
+
+// ---------------------------------------------------------------------------
+// GR3b: setText does NOT use textContent/innerHTML — source-level guard
+// The spec forbids: cell.textContent=, cell.innerHTML=, removeChild, appendChild
+// on a cell during a grid write. We verify the node reference is identical (GR3)
+// which implies none of those paths ran. Additionally scan source for the
+// critical prohibition.
+// ---------------------------------------------------------------------------
+
+(function gr3b_noTextContentWriteInGridPath() {
+  // The _makeCellObj method must ONLY use tn.nodeValue = s.
+  // Source scan: the setText implementation inside _makeCellObj must not contain
+  // 'textContent =' (with a write) or 'innerHTML =' outside the native-table path.
+  const src = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+
+  // Extract _makeCellObj body (from _makeCellObj to the closing brace of its returned object)
+  const makeCellObjIdx = src.indexOf('_makeCellObj(');
+  const bodyAfter = makeCellObjIdx >= 0 ? src.slice(makeCellObjIdx, makeCellObjIdx + 1000) : '';
+
+  // Within that body, there must be no 'textContent =' assignment
+  // (the tn.nodeValue = s line is the ONLY allowed write in grid setText)
+  eq('GR3b: _makeCellObj setText does not contain textContent= assignment',
+    /textContent\s*=/.test(bodyAfter), false);
+
+  // Must contain the nodeValue write pattern
+  eq('GR3b: _makeCellObj setText uses nodeValue = s (the required write model)',
+    /tn\.nodeValue\s*=/.test(bodyAfter), true);
+})();
+
+// ---------------------------------------------------------------------------
+// GR4: resetTable restores originals on visible rows; recycled rows (no
+// .dr-ext-rounded) are left untouched
+// ---------------------------------------------------------------------------
+
+(function gr4_resetTable_restoresOriginals() {
+  const grid = makeGridWrapper([
+    ['8584629', '286'],
+    ['1234567', '99'],
+  ]);
+
+  const adapter = makeAdapter(grid.wrapperEl);
+  const rows = adapter.getRows();
+
+  // Round all cells
+  rows.forEach(function(row) {
+    row.getCells().forEach(function(c) {
+      c.setText('ROUNDED');
+    });
+  });
+
+  // All cells should carry dr-ext-rounded and drOriginal
+  eq('GR4 (setup): cell 0 is rounded',
+    grid.cellEls[0].classList.contains('dr-ext-rounded'), true);
+  eq('GR4 (setup): cell 0 drOriginal is stored original value',
+    grid.cellEls[0].dataset.drOriginal, '8584629');
+
+  // Simulate a recycled row: cell has NO .dr-ext-rounded (framework removed+readded it)
+  // We model this by creating a fresh cell that was never rounded by us.
+  const recycledCell = makeGridCellWithTextNode('FRAMEWORK_TEXT');
+  // recycledCell has no dr-ext-rounded class and no drOriginal — simulates a
+  // framework-recycled row that shows fresh content.
+
+  // Build a querySelectorAll stub on the wrapper that returns only the already-rounded cells
+  // (the recycled cell is not in the DOM under the wrapper for purposes of this test)
+  const roundedCells = grid.cellEls.filter(function(c) {
+    return c.classList.contains('dr-ext-rounded');
+  });
+
+  // Attach querySelectorAll('.dr-ext-rounded') to the wrapper
+  grid.wrapperEl.querySelectorAll = function(sel) {
+    if (sel === '.dr-ext-rounded') return roundedCells;
+    return [];
+  };
+
+  // Also need querySelector for isTableRounded's call after reset
+  grid.wrapperEl.querySelector = function(sel) {
+    if (sel === '.dr-ext-rounded') return null; // after reset, none
+    return null;
+  };
+
+  // resetTable expects a table.querySelectorAll that returns .dr-ext-rounded cells
+  resetTable(grid.wrapperEl);
+
+  // All previously-rounded cells should now have their original text restored
+  eq('GR4: cell 0 nodeValue restored to original',
+    grid.cellEls[0].childNodes[0].nodeValue, '8584629');
+
+  eq('GR4: cell 0 no longer carries dr-ext-rounded',
+    grid.cellEls[0].classList.contains('dr-ext-rounded'), false);
+
+  eq('GR4: cell 0 drOriginal cleared after reset',
+    grid.cellEls[0].dataset.drOriginal, undefined);
+
+  // The recycled cell was never touched by us and must not be modified
+  eq('GR4: recycled cell text node untouched (framework text preserved)',
+    recycledCell.childNodes[0].nodeValue, 'FRAMEWORK_TEXT');
+
+  eq('GR4: recycled cell has no dr-ext-rounded class',
+    recycledCell.classList.contains('dr-ext-rounded'), false);
+})();
+
+// ---------------------------------------------------------------------------
+// GR5: extractPreviewSamples on a grid — expected structure returned
+// ---------------------------------------------------------------------------
+
+(function gr5_extractPreviewSamples_gridStructure() {
+  // Build a grid with numeric cells of two distinct magnitudes so both
+  // top and bottom bands are populated in the returned structure.
+  const grid = makeGridWrapper([
+    ['8584629', '286'],
+    ['9123456', '514'],
+    ['7654321', '432'],
+  ]);
+
+  const result = extractPreviewSamples(grid.wrapperEl);
+
+  // Must return the correct shape: { samples: { top: [...], bottom: [...] }, maxMag: <number> }
+  eq('GR5: extractPreviewSamples returns an object with samples key',
+    typeof result.samples, 'object');
+
+  eq('GR5: extractPreviewSamples samples has top array',
+    Array.isArray(result.samples.top), true);
+
+  eq('GR5: extractPreviewSamples samples has bottom array',
+    Array.isArray(result.samples.bottom), true);
+
+  eq('GR5: extractPreviewSamples returns maxMag as a number',
+    typeof result.maxMag, 'number');
+
+  // The large-magnitude cells (8M, 9M, 7M) are magnitude 6; they go in top.
+  eq('GR5: top band contains at least one entry',
+    result.samples.top.length >= 1, true);
+
+  // Each entry must have original and num fields
+  if (result.samples.top.length > 0) {
+    eq('GR5: top[0] has original field',
+      typeof result.samples.top[0].original, 'string');
+    eq('GR5: top[0] has num field',
+      typeof result.samples.top[0].num, 'number');
+  }
+
+  // maxMag for cells in the 8M range is 6
+  eq('GR5: maxMag is 6 for cells around 8,000,000',
+    result.maxMag, 6);
+})();
+
+// ---------------------------------------------------------------------------
+// GR6: Adversarial extras
+// ---------------------------------------------------------------------------
+
+// GR6a: findCellTextNode returns the deepest non-empty text node
+(function gr6a_findCellTextNode_deepestNode() {
+  // Cell with nested structure: div > span > text("42")
+  const innerText = makeTextNode('42');
+  const span = makeElementNode('inner', [innerText]);
+  const cell = makeElementNode('cell', [span]);
+
+  // findCellTextNode must walk depth-first and return the deepest node
+  const result = findCellTextNode(cell);
+
+  eq('GR6a: findCellTextNode returns the deepest non-empty text node',
+    result === innerText, true);
+
+  eq('GR6a: findCellTextNode result nodeValue is "42"',
+    result && result.nodeValue, '42');
+})();
+
+// GR6b: findCellTextNode returns null when no text node exists
+(function gr6b_findCellTextNode_nullWhenEmpty() {
+  // Cell with only element children, no text
+  const span = makeElementNode('inner', []);
+  const cell = makeElementNode('cell', [span]);
+
+  eq('GR6b: findCellTextNode returns null for cell with no text nodes',
+    findCellTextNode(cell), null);
+})();
+
+// GR6c: findCellTextNode returns null for a whitespace-only text node
+(function gr6c_findCellTextNode_whitespaceIsNull() {
+  const wsNode = makeTextNode('   ');
+  const cell = makeElementNode('cell', [wsNode]);
+
+  eq('GR6c: findCellTextNode returns null for whitespace-only text node',
+    findCellTextNode(cell), null);
+})();
+
+// GR6d: setText is a no-op when the cell has no text node
+(function gr6d_setText_noopWhenNoTextNode() {
+  // Build a cell with no text node
+  const emptyCell = makeElementNode('empty-cell', []);
+  emptyCell.querySelector = function() { return null; };
+
+  const adapter = makeAdapter(
+    (function() {
+      const wrapEl = makeElementNode('wrapper', []);
+      wrapEl.tagName = 'DIV';
+      wrapEl.dataset = {};
+      wrapEl.querySelector = function() { return null; };
+      wrapEl.querySelectorAll = function() { return []; };
+      wrapEl.matches = function() { return false; };
+      return wrapEl;
+    })()
+  );
+
+  // Directly call _makeCellObj to get a cell object for our empty cell
+  const cellObj = adapter._makeCellObj(emptyCell);
+
+  let threw = false;
+  try {
+    cellObj.setText('should-be-noop');
+  } catch (e) {
+    threw = true;
+  }
+
+  eq('GR6d: setText on cell with no text node does not throw',
+    threw, false);
+
+  eq('GR6d: setText on cell with no text node leaves classList unchanged',
+    emptyCell.classList.contains('dr-ext-rounded'), false);
+})();
+
+// GR6e: dataset.drOriginal is stored ONCE and NOT overwritten on a second setText call
+(function gr6e_drOriginal_storedOnce() {
+  const grid = makeGridWrapper([['12345']]);
+  const adapter = makeAdapter(grid.wrapperEl);
+  const cellObj = adapter.getRows()[0].getCells()[0];
+
+  // First setText: original should be stored
+  cellObj.setText('12000');
+  const storedOriginal = grid.cellEls[0].dataset.drOriginal;
+  eq('GR6e: drOriginal stored on first setText',
+    storedOriginal, '12345');
+
+  // Second setText (e.g. rounding again): drOriginal must NOT change
+  cellObj.setText('10000');
+  eq('GR6e: drOriginal NOT overwritten on second setText',
+    grid.cellEls[0].dataset.drOriginal, '12345');
+
+  // But the nodeValue IS updated
+  eq('GR6e: nodeValue updated to second setText value',
+    grid.cellEls[0].childNodes[0].nodeValue, '10000');
+})();
+
+// GR6f: isDataTable returns true for a grid with numeric cells
+(function gr6f_isDataTable_numericGrid() {
+  const grid = makeGridWrapper([
+    ['Name', '1234567'],
+    ['Foo',  '9876543'],
+    ['Bar',  '5555555'],
+  ]);
+
+  // isDataTable calls makeAdapter(el).getRows(), so the wrapper must be a div
+  eq('GR6f: isDataTable returns true for grid with numeric cells',
+    isDataTable(grid.wrapperEl), true);
+})();
+
+// GR6g: isDataTable returns false for an all-text grid (no finite numbers)
+(function gr6g_isDataTable_allTextGrid() {
+  const grid = makeGridWrapper([
+    ['Name',  'City'],
+    ['Alice', 'Paris'],
+    ['Bob',   'Berlin'],
+    ['Carol', 'Tokyo'],
+  ]);
+
+  eq('GR6g: isDataTable returns false for all-text grid (no numeric cells)',
+    isDataTable(grid.wrapperEl), false);
+})();
+
+// GR6h: findCellTextNode returns the LAST non-empty text node in depth-first order
+// (implementation uses "best = node" overwriting, so last DFS visit wins — this is
+// the "deepest" semantic: the last text node encountered in DFS order).
+(function gr6h_findCellTextNode_lastDfsTextNode() {
+  // Cell with two sibling text nodes; the second (deeper in DFS order) should win.
+  const firstText  = makeTextNode('first');
+  const secondText = makeTextNode('42');
+  const cell = makeElementNode('cell', [firstText, secondText]);
+
+  const result = findCellTextNode(cell);
+
+  // The implementation overwrites `best` on every non-empty text node, so the
+  // last one encountered (secondText) is returned.
+  eq('GR6h: findCellTextNode returns last non-empty text node in DFS order',
+    result === secondText, true);
+})();
+
+// GR6i: GridAdapter.setText sequence — getText after setText returns the rounded value
+// (confirms the adapter's read/write round-trip works symmetrically)
+(function gr6i_setText_getTextRoundTrip() {
+  const grid = makeGridWrapper([['9876543']]);
+  const adapter = makeAdapter(grid.wrapperEl);
+  const cellObj = adapter.getRows()[0].getCells()[0];
+
+  eq('GR6i (setup): getText before setText returns original',
+    cellObj.getText(), '9876543');
+
+  cellObj.setText('9900000');
+
+  // The nodeValue was patched; getText should now return the rounded value
+  // (implementation reads drOriginal if set, so getText returns the original — check)
+  // Actually, getText returns drOriginal if dataset.drOriginal is set.
+  // After setText, drOriginal = '9876543' and nodeValue = '9900000'.
+  // getText() returns dataset.drOriginal ('9876543') — this is the spec design:
+  // getText after setText returns the ORIGINAL so re-rounding uses the right base.
+  eq('GR6i: getText after setText returns stored original (for re-round safety)',
+    cellObj.getText(), '9876543');
+
+  // The nodeValue on the text node is the rounded value
+  eq('GR6i: text node nodeValue after setText is the rounded value',
+    grid.cellEls[0].childNodes[0].nodeValue, '9900000');
+})();
+
+// GR6j: SPEC GAP GUARD — roundTable must call adapter's setText (or equivalent
+// nodeValue-only path) for grid cells. The spec (D3) says the write is:
+//   tn.nodeValue = s   (via GridAdapter.setText → findCellTextNode → nodeValue =)
+// NOT cell.innerHTML = … which destroys React fiber identity.
+//
+// Source-level assertion: content.js must NOT contain a bare `cell.innerHTML =`
+// assignment *outside* the native-table reset/extracted path. We check that the
+// replaceTextPreservingHTML fallback branch (line ~2195) and the extracted-patch
+// branch are the only innerHTML writes; a grid-routed pure-cell path must not
+// write innerHTML.
+//
+// This test encodes the hard rule from the sprint brief:
+//   "The grid write must be nodeValue-only."
+// It passes today because replaceTextPreservingHTML's single-text-node path is
+// nodeValue-safe. It will flag a regression if someone adds an innerHTML= write
+// in the adapter's setText or in a new grid-specific roundTable branch.
+(function gr6j_gridSetText_sourceGuard_noInnerHTMLInAdapterSetText() {
+  const src = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
+
+  // Extract _makeCellObj body (the GridAdapter's cell factory, ~1000 chars)
+  const idx = src.indexOf('_makeCellObj(');
+  const body = idx >= 0 ? src.slice(idx, idx + 1200) : '';
+
+  // The grid adapter's setText (inside _makeCellObj) must NOT assign innerHTML
+  eq('GR6j: GridAdapter _makeCellObj setText has no innerHTML= assignment',
+    /innerHTML\s*=/.test(body), false);
+
+  // It MUST have the nodeValue assignment (the only permitted write)
+  eq('GR6j: GridAdapter _makeCellObj setText uses tn.nodeValue = s',
+    /tn\.nodeValue\s*=/.test(body), true);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -7337,6 +7337,225 @@ function makeGridWrapper(rowData, opts) {
     /tn\.nodeValue\s*=/.test(body), true);
 })();
 
+// =============================================================================
+// E2E grid rounding tests — drive roundTable/resetTable on real div-grid stubs.
+// Spec: docs/sprint-plans/grid-support-v2.md §2 D3 + §4 "grid-rounding".
+// Regression guard for commit 3404e86: roundTable must write via nodeValue
+// (GridAdapter.setText → drOriginal), NOT via replaceTextPreservingHTML /
+// innerHTML (which crashes React's reconciler).
+// =============================================================================
+
+/**
+ * Build a self-contained div-grid wrapper whose querySelectorAll('.dr-ext-rounded')
+ * dynamically reflects which cells currently carry that class.
+ *
+ * Uses makeGridWrapper (existing helper, ~L6821) for the DOM stub, then
+ * overwrites the querySelectorAll stub on the wrapper so resetTable can find
+ * rounded cells after roundTable has run.
+ *
+ * @param {Array<Array<string>>} rowData  — 2D array of cell text values
+ * @returns {{ wrapperEl, rowEls, cellEls }}
+ */
+function makeE2EGridWrapper(rowData) {
+  const grid = makeGridWrapper(rowData);
+
+  // Collect all cells for dynamic querySelectorAll lookup.
+  const allCells = grid.cellEls.slice();
+
+  // Override wrapper querySelectorAll:
+  // - '.dr-ext-rounded': walk allCells and return those carrying the class.
+  // - other selectors: delegate to the original stub (returns []).
+  grid.wrapperEl.querySelectorAll = function(sel) {
+    if (sel === '.dr-ext-rounded') {
+      return allCells.filter(function(c) {
+        return c.classList.contains('dr-ext-rounded');
+      });
+    }
+    // _getRowEls fallback path in GridAdapter uses children, not querySelectorAll,
+    // so returning [] for other selectors is safe.
+    return [];
+  };
+
+  // Override wrapper querySelector so isTableRounded / syncSwitchForTable don't throw.
+  grid.wrapperEl.querySelector = function(sel) {
+    if (sel === '.dr-ext-rounded') {
+      return allCells.find(function(c) { return c.classList.contains('dr-ext-rounded'); }) || null;
+    }
+    return null;
+  };
+
+  // dataset is already set by makeGridWrapper; ensure drShowingOriginal can be deleted.
+  if (!grid.wrapperEl.dataset) grid.wrapperEl.dataset = {};
+
+  return grid;
+}
+
+// ---------------------------------------------------------------------------
+// E2E-GR1: roundTable on a numeric div-grid — nodeValue written, node identity
+// preserved, drOriginal set, originalHtml NOT set, dr-ext-rounded applied.
+// ---------------------------------------------------------------------------
+(function e2e_gr1_roundTable_numericGrid_nodeValuePath() {
+  // 3-row grid. Use simplifyFirstRow:true so all rows (including row 0) are processed.
+  const grid = makeE2EGridWrapper([
+    ['8584629', '286'],
+    ['1234567', '99'],
+    ['7654321', '55'],
+  ]);
+
+  // cellEls[0] is row-0, col-0.  With simplifyFirstRow:true it will be rounded.
+  const cell0 = grid.cellEls[0];
+  const textNodeBefore = cell0.childNodes[0];
+  const childCountBefore = cell0.childNodes.length;
+  const originalValue = textNodeBefore.nodeValue;  // '8584629'
+
+  // Drive the real engine entry point with simplifyFirstRow+Column:true so row/col 0
+  // are not excluded by the default "skip header" heuristic.
+  const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true, simplifyFirstColumn: true });
+  roundTable(grid.wrapperEl, opts);
+
+  // The cell must now carry the rounded class.
+  eq('E2E-GR1: cell[0] has dr-ext-rounded after roundTable',
+    cell0.classList.contains('dr-ext-rounded'), true);
+
+  // The text was actually changed (8584629 → some abbreviated form; check it differs).
+  eq('E2E-GR1: cell[0] text node value changed from original',
+    cell0.childNodes[0].nodeValue !== originalValue, true);
+
+  // Node identity: the SAME Text node object must hold the new value.
+  eq('E2E-GR1: Text node object identity preserved (same reference)',
+    cell0.childNodes[0] === textNodeBefore, true);
+
+  // childNodes.length must be unchanged (no appendChild / removeChild).
+  eq('E2E-GR1: cell[0] childNodes.length unchanged after roundTable',
+    cell0.childNodes.length, childCountBefore);
+
+  // drOriginal must be set on the cell element (nodeValue path).
+  eq('E2E-GR1: cell[0] dataset.drOriginal is set to original text',
+    cell0.dataset.drOriginal, originalValue);
+
+  // originalHtml must NOT be set (that is the native-table / extracted path).
+  eq('E2E-GR1: cell[0] dataset.originalHtml is NOT set on a grid cell',
+    cell0.dataset.originalHtml, undefined);
+})();
+
+// ---------------------------------------------------------------------------
+// E2E-GR2: resetTable after roundTable — Text node restored in place, class
+// removed, drOriginal cleared, childNodes.length still unchanged.
+// ---------------------------------------------------------------------------
+(function e2e_gr2_resetTable_restoresNodeValue() {
+  const grid = makeE2EGridWrapper([
+    ['8584629', '286'],
+    ['1234567', '99'],
+  ]);
+
+  const cell0 = grid.cellEls[0];
+  const textNodeBefore = cell0.childNodes[0];
+  const childCountBefore = cell0.childNodes.length;
+  const originalValue = textNodeBefore.nodeValue;  // '8584629'
+
+  // Round first — use simplifyFirstRow+Column:true so row/col 0 are not excluded.
+  const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true, simplifyFirstColumn: true });
+  roundTable(grid.wrapperEl, opts);
+
+  // Confirm the cell is rounded before we reset (pre-condition).
+  eq('E2E-GR2 (pre): cell[0] is rounded before resetTable',
+    cell0.classList.contains('dr-ext-rounded'), true);
+
+  // Now reset.
+  resetTable(grid.wrapperEl);
+
+  // nodeValue must be back to the original on the SAME Text node.
+  eq('E2E-GR2: Text node nodeValue restored to original value',
+    textNodeBefore.nodeValue, originalValue);
+
+  // The SAME node object must still be in childNodes[0].
+  eq('E2E-GR2: Text node identity preserved through reset (same reference)',
+    cell0.childNodes[0] === textNodeBefore, true);
+
+  // dr-ext-rounded class must be removed.
+  eq('E2E-GR2: dr-ext-rounded removed after resetTable',
+    cell0.classList.contains('dr-ext-rounded'), false);
+
+  // drOriginal must be cleared.
+  eq('E2E-GR2: dataset.drOriginal cleared after resetTable',
+    cell0.dataset.drOriginal, undefined);
+
+  // childNodes.length still unchanged (no innerHTML write at any point).
+  eq('E2E-GR2: childNodes.length unchanged throughout (no innerHTML write)',
+    cell0.childNodes.length, childCountBefore);
+})();
+
+// ---------------------------------------------------------------------------
+// E2E-GR3 (Negative guard): after roundTable on a grid, NO cell has
+// dataset.originalHtml set. Locks in that grids never take the native write path.
+// ---------------------------------------------------------------------------
+(function e2e_gr3_noOriginalHtmlOnGridCells() {
+  const grid = makeE2EGridWrapper([
+    ['8584629', '286'],
+    ['1234567', '99'],
+    ['7654321', '55'],
+  ]);
+
+  // simplifyFirstRow:true ensures all rows are processed (maximal coverage).
+  roundTable(grid.wrapperEl, Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true }));
+
+  const anyHasOriginalHtml = grid.cellEls.some(function(c) {
+    return c.dataset.originalHtml !== undefined;
+  });
+
+  eq('E2E-GR3: no grid cell has dataset.originalHtml after roundTable (native path locked out)',
+    anyHasOriginalHtml, false);
+})();
+
+// ---------------------------------------------------------------------------
+// E2E-GR4: mode:'extracted' skip on grids — mixed-text cell is left unrounded;
+// pure-numeric cell IS rounded. Known limitation: grids skip extracted cells
+// (innerHTML incompatible with nodeValue-only write model).
+// ---------------------------------------------------------------------------
+(function e2e_gr4_extractedModeSkippedOnGrid() {
+  // Two rows so simplifyFirstRow:false (default) doesn't exclude everything.
+  // Row 0: skipped (simplifyFirstRow:false).
+  // Row 1: mixed-text cell → extracted mode → skipped on grid;
+  //        pure-numeric cell → pure mode → rounded.
+  const grid = makeE2EGridWrapper([
+    ['placeholder', '0'],             // row 0: excluded by simplifyFirstRow:false
+    ['abc 1234567 def', '9876543'],   // row 1: exercised
+  ]);
+
+  // cellEls[2] = row1/col0 (mixed), cellEls[3] = row1/col1 (numeric)
+  const mixedCell   = grid.cellEls[2];
+  const numericCell = grid.cellEls[3];
+
+  const mixedTextBefore   = mixedCell.childNodes[0].nodeValue;
+  const numericTextBefore = numericCell.childNodes[0].nodeValue;
+
+  // Use opts with simplifyMixedCells:true so mixed cells are classified as extracted,
+  // and simplifyFirstRow:false (default) so row 0 is excluded (standard behaviour).
+  const opts = Object.assign({}, DR_DEFAULTS, { simplifyMixedCells: true });
+  roundTable(grid.wrapperEl, opts);
+
+  // Mixed cell must be UNROUNDED (extracted path skipped on virtualized grid).
+  eq('E2E-GR4: mixed-text cell NOT rounded on grid (extracted mode skipped)',
+    mixedCell.classList.contains('dr-ext-rounded'), false);
+
+  eq('E2E-GR4: mixed-text cell text node unchanged',
+    mixedCell.childNodes[0].nodeValue, mixedTextBefore);
+
+  // Pure-numeric cell must be rounded.
+  eq('E2E-GR4: pure-numeric cell IS rounded on grid',
+    numericCell.classList.contains('dr-ext-rounded'), true);
+
+  eq('E2E-GR4: pure-numeric cell text changed from original',
+    numericCell.childNodes[0].nodeValue !== numericTextBefore, true);
+
+  // drOriginal set on numeric, not on mixed.
+  eq('E2E-GR4: drOriginal set on pure-numeric cell',
+    numericCell.dataset.drOriginal, numericTextBefore);
+
+  eq('E2E-GR4: drOriginal NOT set on mixed-text cell',
+    mixedCell.dataset.drOriginal, undefined);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/docs/sprint-logs/grid-support-v2-grid-rounding.md
+++ b/docs/sprint-logs/grid-support-v2-grid-rounding.md
@@ -1,0 +1,28 @@
+# Sprint Log: grid-rounding
+
+**Plan:** docs/sprint-plans/grid-support-v2.md
+**Sprint goal:** Implement `GridAdapter.getRows()` with corrected selectors and round visible grid rows via text-node `nodeValue` patching.
+**Date:** 2026-06-12
+**Result:** Completed (after 1 retry)
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Implemented `GridAdapter.getRows()` (scroll container → nullable pinned pane → rows → stitch by `data-row`/`data-index` → cells via `role="cell"`/`.dg--cell`), `findCellTextNode`, and the `nodeValue` `setText` (stores `dataset.drOriginal`, adds `dr-ext-rounded`). Added `resetTable` grid branch and `isDataTable` grid sampling.
+- **Tests:** pass (876) — but all grid assertions called the adapter `setText` directly.
+- **Reviewer verdict:** BLOCK
+- **Reviewer notes:** `roundTable`/`resetTable` never routed grid cells through the `nodeValue` adapter — they used the native `replaceTextPreservingHTML` (reachable `innerHTML` fallback = React reconciler crash) and stored `dataset.originalHtml`, while reset read `drOriginal`. The `nodeValue` `setText` was dead code from the round path; green tests masked the gap.
+
+### Attempt 2
+- **Developer:** `roundTable` now computes the adapter once and branches on `adapter.isVirtualized()`. Grid cells write only via `cellObj.setText(formatted)` (pure `nodeValue`, sets `drOriginal`, never `originalHtml`/`innerHTML`/`replaceTextPreservingHTML`/`applyExtractedPatches`). `mode:'extracted'` (mixed-text) cells are skipped on grids (`if (isVirtualized) continue`) as a documented known limitation. Native `<table>` path relocated into the `else` branch, byte-identical.
+- **Tests:** pass (895) — test-writer added 4 E2E tests (E2E-GR1..GR4) driving `roundTable`/`resetTable` directly on a div-grid, asserting Text-node identity (`===`), `childNodes.length` unchanged, `drOriginal` set, `originalHtml` unset, and the extracted-skip alongside a pure-numeric round.
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:**
+  - Grid round/reset fully on the `nodeValue` path; storage keys reconcile (`drOriginal` only).
+  - `getText` reads `drOriginal`, so re-rounding is idempotent.
+  - `findCellTextNode` patches only the deepest text node — fine for this sprint's pure-numeric/date scope; relevant if future grid work touches multi-text-node cells.
+  - `mode:'extracted'` skip on grids is an intentional, documented limitation (mixed-text/`<sup>` cells not rounded on virtualized grids) — mention in the user-facing changelog.
+  - No MutationObserver added (correctly deferred to grid-virtualization); `manifest.json` untouched.
+
+## PR
+(opened with base refactor/grid-adapter — see PR link)


### PR DESCRIPTION
Plan: docs/sprint-plans/grid-support-v2.md

Implements `GridAdapter.getRows()` (scroll container → nullable pinned pane → rows → stitch by `data-row`/`data-index` → cells via `role="cell"`/`.dg--cell`) and rounds visible grid rows via **text-node `nodeValue` patching**. `roundTable` branches on `adapter.isVirtualized()`: grid cells are written only through `cellObj.setText` (pure `nodeValue`, stores `dataset.drOriginal`, never `innerHTML`/`originalHtml`), preserving the React fiber's text-node identity. `resetTable` restores grids via the `drOriginal` nodeValue branch. Native `<table>` path unchanged.

Builds on the merged grid-adapter (#117).

## Acceptance criteria
- [x] `node chrome-extension/tests.js` passes (895 / 0)
- [x] Grid rounding writes via `nodeValue` only — node identity preserved (E2E tests assert same `Text` node `===` and `childNodes.length` unchanged); reset restores originals
- [x] `GridAdapter.getRows()` extracts from unlabelled repetitive-children grids and `.dg--`-shaped grids
- [x] No `innerHTML`/`textContent`/`appendChild`/`removeChild` reachable on a grid cell

## Deferred follow-up (tracked in #120)
Mixed-text / `mode:'extracted'` cells (e.g. `<sup>` exponents, numbers embedded in surrounding text) are **not yet** rounded on virtualized grids — they're skipped for now because the existing extracted write path can fall back to `innerHTML` (the crash mode). Pure-numeric and date/time grid cells round correctly. Implementing extracted rounding via in-place `nodeValue` patching is deferred to **#120**, not a permanent limitation.

## Reviewer notes
- Storage keys reconcile: grid round/reset use `drOriginal` only; `getText` reads it too, so re-rounding is idempotent.
- `findCellTextNode` patches only the deepest text node — fine for this sprint's scope.
- No MutationObserver added — deferred to grid-virtualization.
- One BLOCK → fixed on retry: the initial pass routed grid cells through the native `replaceTextPreservingHTML` path (reachable `innerHTML` crash mode); now fully on the `nodeValue` adapter, with E2E tests driving `roundTable`/`resetTable` directly.
