### PR TITLE
Re-apply grid rounding on scroll and sort via debounced MutationObserver

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -27,6 +27,8 @@ const GRID_DISPLAY_VALUES = new Set(['grid', 'flex', 'inline-grid', 'inline-flex
 const GRID_LIBRARY_CLASS_TOKENS = ['dg--', 'ag-'];
 /** CSS selector for the cheap proactive ARIA pass. */
 const GRID_ARIA_SELECTOR = '[role="grid"], [role="table"]';
+/** Debounce delay (ms) for the grid virtualization re-apply observer. */
+const GRID_REAPPLY_DEBOUNCE_MS = 100;
 // EPSILON, X_FLOOR_THRESHOLD, roundWithOffset, and roundCellSetAware live in
 // rounding.js (loaded by manifest content_scripts ahead of this file) so the
 // sidebar can call the same arithmetic for its preview band.
@@ -320,6 +322,12 @@ let sidebarOpen = false;
 // Consulted by toggleOriginalValues() when re-running the pipeline so that the
 // "toggle back to rounded" path uses the same parameters as the original render.
 const tableOptions = new WeakMap();
+
+// Grid virtualization re-apply state.
+// gridObservers: wrapperEl → MutationObserver watching the scroll container.
+// gridReapplyTimers: wrapperEl → pending setTimeout id for the debounced re-apply.
+const gridObservers = new WeakMap();
+const gridReapplyTimers = new WeakMap();
 
 document.addEventListener('contextmenu', (event) => {
   lastRightClickedElement = event.target;
@@ -977,6 +985,18 @@ if (typeof MutationObserver !== 'undefined') {
           if (ro) {
             ro.disconnect();
           }
+          // Tear down any grid virtualization observer and pending debounce timer
+          // so removed grids don't re-apply rounding after they leave the DOM.
+          const pendingTimer = gridReapplyTimers.get(table);
+          if (pendingTimer !== undefined) {
+            clearTimeout(pendingTimer);
+            gridReapplyTimers.delete(table);
+          }
+          const gridObs = gridObservers.get(table);
+          if (gridObs) {
+            gridObs.disconnect();
+            gridObservers.delete(table);
+          }
           trackedTables.delete(table);
         }
       }
@@ -1109,6 +1129,23 @@ function flashRangePulse(table, ranges) {
 }
 
 function resetTable(table) {
+  // --- Grid virtualization teardown (must happen BEFORE cell restore) ---
+  // Clear any pending debounce timer so a queued re-apply cannot fire after reset.
+  const pendingTimer = gridReapplyTimers.get(table);
+  if (pendingTimer !== undefined) {
+    clearTimeout(pendingTimer);
+    gridReapplyTimers.delete(table);
+  }
+  // Disconnect the scroll/sort observer so it stops watching the scroll container.
+  const gridObserver = gridObservers.get(table);
+  if (gridObserver) {
+    gridObserver.disconnect();
+    gridObservers.delete(table);
+  }
+  // Also clear the stored options so reapplyGridRounding (if somehow still
+  // in-flight) will bail out harmlessly when it finds no opts.
+  tableOptions.delete(table);
+
   const roundedCells = table.querySelectorAll('.dr-ext-rounded');
   for (const cell of roundedCells) {
     // Grid cells are reset via nodeValue patching (drOriginal is set by GridAdapter.setText).
@@ -1223,6 +1260,142 @@ function extractPreviewSamples(table) {
     samples: { top: top.map(toRow), bottom: bottom.map(toRow) },
     maxMag,
   };
+}
+
+/**
+ * Compute the rounded/formatted value that rounding WOULD produce for a single
+ * grid cell whose current live text is `text`, given the table-level parameters
+ * already derived from all visible cells (`max_mag`, `floorDecimals`).
+ *
+ * Returns the formatted string if rounding would produce a different value, or
+ * null if the cell should be left unchanged (skipped, not a number, etc.).
+ *
+ * This is the shared per-cell logic reused by both `roundTable` (initial pass)
+ * and `reapplyGridRounding` (scroll/sort re-apply). Keeping it in one place
+ * ensures the two passes can never diverge.
+ *
+ * NOTE: mode:'extracted' (mixed text with embedded numbers) is intentionally
+ * skipped on grids — that path requires innerHTML writes which are incompatible
+ * with the nodeValue-only write model.
+ *
+ * @param {string} text          - The cell's current live text value.
+ * @param {object} opts          - Resolved rounding options (from tableOptions).
+ * @param {number} max_mag       - Maximum magnitude computed from all visible cells.
+ * @param {number} floorDecimals - Decimal floor derived from offset parameters.
+ * @returns {string|null}
+ */
+function computeGridCellRoundedValue(text, opts, max_mag, floorDecimals) {
+  const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
+  const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
+  const numTop = resolveNumTop(opts.numTop, DEFAULT_NUM_TOP);
+
+  const trimmed = typeof text === 'string' ? text.trim() : '';
+  if (!trimmed) return null;
+
+  // Whole-cell quote short-circuit.
+  const isWholeCellQuoted = trimmed.startsWith('"') && trimmed.endsWith('"') &&
+    (trimmed.match(/"/g) || []).length === 2;
+  if (isWholeCellQuoted) return null;
+
+  if (isDateLike(trimmed)) {
+    if (!opts.simplifyDates) return null;
+    const result = roundDateText(trimmed, opts.dateGranularity);
+    if (result === null || result === trimmed) return null;
+    return result;
+  }
+
+  if (isTimeLike(trimmed)) {
+    if (!opts.simplifyTimes) return null;
+    const result = roundTimeText(trimmed, opts.timeGranularity);
+    if (result === null || result === trimmed) return null;
+    return result;
+  }
+
+  const num = toNumber(text);
+  if (num === null) return null;
+
+  const roundedValue = roundCellSetAware(num, num, max_mag, offsetTop, offsetOther, numTop);
+  const formattedValue = restoreFormatting(roundedValue, text, floorDecimals);
+  if (formattedValue === trimmed) return null;
+  return formattedValue;
+}
+
+/**
+ * Re-apply grid rounding to all currently-visible cells of `wrapperEl`.
+ * Called by the debounced MutationObserver after scroll or sort events.
+ *
+ * Guards against infinite re-triggering by disconnecting the grid's observer
+ * for the duration of the write pass and reconnecting after.
+ *
+ * @param {Element} wrapperEl - The grid wrapper element (key into tableOptions).
+ */
+function reapplyGridRounding(wrapperEl) {
+  // Clear the stored timer reference (it has already fired).
+  gridReapplyTimers.delete(wrapperEl);
+
+  const observer = gridObservers.get(wrapperEl);
+
+  // Disconnect FIRST — our own nodeValue writes fire characterData mutations;
+  // without this guard we enter an infinite re-apply loop.
+  if (observer) observer.disconnect();
+
+  const opts = tableOptions.get(wrapperEl);
+  if (!opts) {
+    // Table has been reset/removed — reconnect (no-op write) and bail.
+    if (observer) {
+      const scrollContainer = new GridAdapter(wrapperEl)._getScrollContainer();
+      observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
+    }
+    return;
+  }
+
+  const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
+  const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
+  const floorDecimals = Math.max(decimalCount(offsetTop), decimalCount(offsetOther));
+
+  // Pass 1: collect all current visible numeric values to compute max_mag
+  // (set-aware rounding: the same logic as the initial roundTable pass).
+  const currentAdapter = makeAdapter(wrapperEl);
+  const rows = currentAdapter.getRows();
+  const allNums = [];
+  for (const row of rows) {
+    for (const cellObj of row.getCells()) {
+      if (cellObj.tagName !== 'TD') continue;
+      const tn = findCellTextNode(cellObj.el);
+      const text = tn ? tn.nodeValue : (cellObj.el.textContent || '');
+      const trimmed = typeof text === 'string' ? text.trim() : '';
+      if (!trimmed || isDateLike(trimmed) || isTimeLike(trimmed)) continue;
+      const num = toNumber(text);
+      if (num !== null) allNums.push(num);
+    }
+  }
+  const max_mag = findMaxMagnitude([allNums]);
+
+  // Pass 2: for each cell, compute what rounding would produce from opts;
+  // re-apply via nodeValue if the current live value differs.
+  for (const row of rows) {
+    for (const cellObj of row.getCells()) {
+      if (cellObj.tagName !== 'TD') continue;
+      const tn = findCellTextNode(cellObj.el);
+      if (!tn) continue;
+      const currentValue = tn.nodeValue;
+      const rounded = computeGridCellRoundedValue(currentValue, opts, max_mag, floorDecimals);
+      if (rounded !== null && currentValue !== rounded) {
+        // Store original if not already stored (freshly-recycled row).
+        if (cellObj.el.dataset && cellObj.el.dataset.drOriginal === undefined) {
+          cellObj.el.dataset.drOriginal = currentValue;
+        }
+        tn.nodeValue = rounded;
+        if (cellObj.el.classList) cellObj.el.classList.add(GRID_ROUNDED_CLASS);
+      }
+    }
+  }
+
+  // Reconnect the observer after the write pass.
+  if (observer) {
+    const scrollContainer = new GridAdapter(wrapperEl)._getScrollContainer();
+    observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
+  }
 }
 
 function roundTable(table, options) {
@@ -1491,6 +1664,40 @@ function roundTable(table, options) {
     }
   }
   syncSwitchForTable(table);
+
+  // Attach the scroll/sort re-apply observer AFTER the initial pass so our own
+  // nodeValue writes above do not immediately re-trigger it.
+  // Only virtualized grids get an observer — native <table> adapters do not.
+  if (isVirtualized && typeof MutationObserver !== 'undefined') {
+    // Disconnect any stale observer (e.g. roundTable called twice on same grid).
+    const staleObserver = gridObservers.get(table);
+    if (staleObserver) staleObserver.disconnect();
+
+    // Clear any pending debounce timer from a previous observer.
+    const staleTimer = gridReapplyTimers.get(table);
+    if (staleTimer !== undefined) {
+      clearTimeout(staleTimer);
+      gridReapplyTimers.delete(table);
+    }
+
+    const scrollContainer = adapter._getScrollContainer();
+    const wrapperEl = table; // alias for clarity inside the closure
+
+    const observer = new MutationObserver(() => {
+      // Cancel any pending debounce timer for this grid and schedule a fresh one.
+      const pending = gridReapplyTimers.get(wrapperEl);
+      if (pending !== undefined) clearTimeout(pending);
+
+      const timerId = setTimeout(() => {
+        reapplyGridRounding(wrapperEl);
+      }, GRID_REAPPLY_DEBOUNCE_MS);
+
+      gridReapplyTimers.set(wrapperEl, timerId);
+    });
+
+    observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
+    gridObservers.set(wrapperEl, observer);
+  }
 }
 
 function lettersToColIndex(letters) {

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1263,66 +1263,211 @@ function extractPreviewSamples(table) {
 }
 
 /**
- * Compute the rounded/formatted value that rounding WOULD produce for a single
- * grid cell whose current live text is `text`, given the table-level parameters
- * already derived from all visible cells (`max_mag`, `floorDecimals`).
+ * Classify and compute rounded target values for all visible cells of a
+ * virtualized grid, using the EXACT same gating logic as the initial
+ * `roundTable` pass: isInRanges, getExclusionReason (firstRow / firstColumn /
+ * percent / currency), whole-cell-quote, date/time, isCellWholeLink, <sup>
+ * handling, and mode:'extracted' skip-on-grid.
  *
- * Returns the formatted string if rounding would produce a different value, or
- * null if the cell should be left unchanged (skipped, not a number, etc.).
+ * max_mag is computed only over the surviving in-range, non-excluded pure
+ * (and extracted) numeric cells — the same filtered set the initial pass uses —
+ * so that values produced here are identical to those the initial pass would
+ * produce given the same visible DOM and opts.
  *
- * This is the shared per-cell logic reused by both `roundTable` (initial pass)
- * and `reapplyGridRounding` (scroll/sort re-apply). Keeping it in one place
- * ensures the two passes can never diverge.
+ * Returns a flat array of { cellObj, targetValue } for every TD cell in the
+ * grid's current visible rows.  targetValue is:
+ *   - null  → leave the cell unchanged (excluded, out-of-range, skip, or no
+ *             change needed)
+ *   - a string → the rounded/formatted value the cell should display
  *
- * NOTE: mode:'extracted' (mixed text with embedded numbers) is intentionally
- * skipped on grids — that path requires innerHTML writes which are incompatible
- * with the nodeValue-only write model.
+ * Both `roundTable` (initial grid write pass) and `reapplyGridRounding`
+ * (scroll/sort re-apply) call this single function so they cannot diverge.
  *
- * @param {string} text          - The cell's current live text value.
- * @param {object} opts          - Resolved rounding options (from tableOptions).
- * @param {number} max_mag       - Maximum magnitude computed from all visible cells.
- * @param {number} floorDecimals - Decimal floor derived from offset parameters.
- * @returns {string|null}
+ * NOTE: mode:'extracted' cells (mixed text with embedded numbers, e.g.
+ * <sup>-containing cells) are intentionally skipped on grids — that path
+ * requires innerHTML writes incompatible with the nodeValue-only write model.
+ * This is deferred work tracked in issue #120.
+ *
+ * @param {Element} wrapperEl - The grid wrapper element.
+ * @param {object}  opts      - Fully-resolved rounding options.
+ * @returns {Array<{cellObj: object, targetValue: string|null}>}
  */
-function computeGridCellRoundedValue(text, opts, max_mag, floorDecimals) {
+function computeGridRoundedValues(wrapperEl, opts) {
   const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
   const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
   const numTop = resolveNumTop(opts.numTop, DEFAULT_NUM_TOP);
+  const rangeParse = parseRangeExpr(opts.rangeExpr);
+  // If the range expression is invalid, no cells should be rounded.
+  if (rangeParse.error) return [];
+  const ranges = rangeParse.ranges;
+  const floorDecimals = Math.max(decimalCount(offsetTop), decimalCount(offsetOther));
 
-  const trimmed = typeof text === 'string' ? text.trim() : '';
-  if (!trimmed) return null;
+  const adapter = makeAdapter(wrapperEl);
+  const adapterRows = adapter.getRows();
+  if (adapterRows.length === 0) return [];
 
-  // Whole-cell quote short-circuit.
-  const isWholeCellQuoted = trimmed.startsWith('"') && trimmed.endsWith('"') &&
-    (trimmed.match(/"/g) || []).length === 2;
-  if (isWholeCellQuoted) return null;
+  // --- Pass 1: classify every visible TD cell (same logic as roundTable) ---
+  // cellEntries: flat array of { cellObj, text, trimmed, info }
+  // info is the classification result: { mode: 'skip'|'pure'|'date'|'time'|'extracted', ... }
+  // rowIndex and colIndex track position for isInRanges / getExclusionReason.
+  const cellEntries = [];
 
-  if (isDateLike(trimmed)) {
-    if (!opts.simplifyDates) return null;
-    const result = roundDateText(trimmed, opts.dateGranularity);
-    if (result === null || result === trimmed) return null;
-    return result;
+  // Also build a per-column list of entries with ambiguous date mode so we can
+  // run the column post-pass (same as roundTable).
+  // Map: colIndex → array of indices into cellEntries
+  const ambigByCol = new Map();
+
+  for (let r = 0; r < adapterRows.length; r++) {
+    const adapterCells = adapterRows[r].getCells();
+    let dataCol = 0;
+    for (let c = 0; c < adapterCells.length; c++) {
+      const cellObj = adapterCells[c];
+      if (cellObj.tagName !== 'TD') continue;
+      const col = dataCol++;
+      const cell = cellObj.el;
+      const text = cellObj.getText();
+      const trimmed = typeof text === 'string' ? text.trim() : '';
+
+      const isWholeCellQuoted = trimmed.startsWith('"') && trimmed.endsWith('"') &&
+        (trimmed.match(/"/g) || []).length === 2;
+
+      let info;
+      if (!isInRanges(r, col, ranges)) {
+        info = { mode: 'skip' };
+      } else if (getExclusionReason(text, col, opts, r)) {
+        info = { mode: 'skip' };
+      } else if (isWholeCellQuoted) {
+        info = { mode: 'skip' };
+      } else if (isDateLike(trimmed)) {
+        if (!opts.simplifyDates) {
+          info = { mode: 'skip' };
+        } else {
+          const ambig = parseAmbiguousNumericDate(trimmed);
+          if (ambig !== null) {
+            info = { mode: 'date', ambiguous: ambig };
+          } else {
+            const parsed = parseDateLike(trimmed);
+            info = { mode: 'date', month: parsed.month, day: parsed.day, year: parsed.year };
+          }
+        }
+      } else if (isTimeLike(trimmed)) {
+        info = opts.simplifyTimes ? { mode: 'time' } : { mode: 'skip' };
+      } else {
+        const num = toNumber(text);
+        if (num !== null) {
+          if (isCellWholeLink(cell)) {
+            info = { mode: 'skip' };
+          } else if (cell.querySelector && cell.querySelector('sup')) {
+            // mode:'extracted' is skipped on grids (nodeValue-only write model).
+            // Tracked in issue #120.
+            info = { mode: 'skip' };
+          } else {
+            info = { mode: 'pure', num };
+          }
+        } else if (opts.simplifyMixedCells) {
+          // mode:'extracted' is skipped on grids (nodeValue-only write model).
+          // Tracked in issue #120.
+          info = { mode: 'skip' };
+        } else {
+          info = { mode: 'skip' };
+        }
+      }
+
+      const entryIdx = cellEntries.length;
+      cellEntries.push({ cellObj, text, trimmed, info, col, rowIdx: r });
+
+      if (info.mode === 'date' && info.ambiguous) {
+        if (!ambigByCol.has(col)) ambigByCol.set(col, []);
+        ambigByCol.get(col).push(entryIdx);
+      }
+    }
   }
 
-  if (isTimeLike(trimmed)) {
-    if (!opts.simplifyTimes) return null;
-    const result = roundTimeText(trimmed, opts.timeGranularity);
-    if (result === null || result === trimmed) return null;
-    return result;
+  // --- Column post-pass: resolve ambiguous date cells per column ---
+  for (const [col, indices] of ambigByCol) {
+    let hasN1gt12 = false;
+    let hasN2gt12 = false;
+    for (const idx of indices) {
+      const { info } = cellEntries[idx];
+      if (info.ambiguous.n1 > 12) hasN1gt12 = true;
+      if (info.ambiguous.n2 > 12) hasN2gt12 = true;
+    }
+    let formatHint;
+    if (hasN1gt12 && !hasN2gt12) {
+      formatHint = 'DMY';
+    } else if (hasN2gt12 && !hasN1gt12) {
+      formatHint = 'MDY';
+    } else if (hasN1gt12 && hasN2gt12) {
+      formatHint = 'MIXED';
+    } else {
+      formatHint = 'AMBIGUOUS';
+    }
+    for (const idx of indices) {
+      const entry = cellEntries[idx];
+      const { info } = entry;
+      if (formatHint === 'MDY') {
+        entry.info = { mode: 'date', month: info.ambiguous.n1, day: info.ambiguous.n2, year: info.ambiguous.year };
+      } else if (formatHint === 'DMY') {
+        entry.info = { mode: 'date', month: info.ambiguous.n2, day: info.ambiguous.n1, year: info.ambiguous.year };
+      } else {
+        entry.info = { mode: 'skip' };
+      }
+    }
+  }
+  // --- End column post-pass ---
+
+  // --- Pass 2: compute max_mag over filtered (in-range, non-excluded) numeric cells ---
+  const allNums = [];
+  for (const { info } of cellEntries) {
+    if (info.mode === 'pure') allNums.push(info.num);
+    // mode:'extracted' is skipped on grids, so no extracted nums here
+  }
+  const max_mag = findMaxMagnitude([allNums]);
+
+  // --- Pass 3: compute target value for each cell ---
+  const results = [];
+  for (const { cellObj, text, trimmed, info } of cellEntries) {
+    if (info.mode === 'skip') {
+      results.push({ cellObj, targetValue: null });
+      continue;
+    }
+
+    let targetValue = null;
+
+    if (info.mode === 'date') {
+      const prefilled = (info.month !== undefined)
+        ? { month: info.month, day: info.day, year: info.year }
+        : undefined;
+      const rounded = roundDateText(text, opts.dateGranularity, prefilled);
+      if (rounded !== null && rounded !== text) targetValue = rounded;
+    } else if (info.mode === 'time') {
+      const rounded = roundTimeText(text, opts.timeGranularity);
+      if (rounded !== null && rounded !== text) targetValue = rounded;
+    } else if (info.mode === 'pure') {
+      const roundedValue = roundCellSetAware(info.num, info.num, max_mag, offsetTop, offsetOther, numTop);
+      const formatted = restoreFormatting(roundedValue, text, floorDecimals);
+      if (formatted !== trimmed) targetValue = formatted;
+    }
+    // mode:'extracted' → targetValue stays null (skip on grid)
+
+    results.push({ cellObj, targetValue });
   }
 
-  const num = toNumber(text);
-  if (num === null) return null;
-
-  const roundedValue = roundCellSetAware(num, num, max_mag, offsetTop, offsetOther, numTop);
-  const formattedValue = restoreFormatting(roundedValue, text, floorDecimals);
-  if (formattedValue === trimmed) return null;
-  return formattedValue;
+  return results;
 }
 
 /**
  * Re-apply grid rounding to all currently-visible cells of `wrapperEl`.
  * Called by the debounced MutationObserver after scroll or sort events.
+ *
+ * Delegates ALL classification and value computation to `computeGridRoundedValues`
+ * — the same function used by the initial `roundTable` grid pass — so the two
+ * passes are guaranteed to produce identical results for any given visible DOM
+ * state and opts.  In particular, re-apply now honours:
+ *   - isInRanges (cells outside the user's range are left untouched)
+ *   - getExclusionReason (firstRow / firstColumn / percent / currency)
+ *   - whole-cell-quote, date/time, isCellWholeLink, <sup> handling
+ *   - max_mag computed over the same filtered in-range, non-excluded cell set
  *
  * Guards against infinite re-triggering by disconnecting the grid's observer
  * for the duration of the write pass and reconnecting after.
@@ -1349,46 +1494,27 @@ function reapplyGridRounding(wrapperEl) {
     return;
   }
 
-  const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
-  const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
-  const floorDecimals = Math.max(decimalCount(offsetTop), decimalCount(offsetOther));
+  // Delegate to the single shared classify+compute function.
+  // targetValue is null for excluded/out-of-range/skip cells (leave untouched).
+  const cellTargets = computeGridRoundedValues(wrapperEl, opts);
 
-  // Pass 1: collect all current visible numeric values to compute max_mag
-  // (set-aware rounding: the same logic as the initial roundTable pass).
-  const currentAdapter = makeAdapter(wrapperEl);
-  const rows = currentAdapter.getRows();
-  const allNums = [];
-  for (const row of rows) {
-    for (const cellObj of row.getCells()) {
-      if (cellObj.tagName !== 'TD') continue;
-      const tn = findCellTextNode(cellObj.el);
-      const text = tn ? tn.nodeValue : (cellObj.el.textContent || '');
-      const trimmed = typeof text === 'string' ? text.trim() : '';
-      if (!trimmed || isDateLike(trimmed) || isTimeLike(trimmed)) continue;
-      const num = toNumber(text);
-      if (num !== null) allNums.push(num);
-    }
-  }
-  const max_mag = findMaxMagnitude([allNums]);
+  for (const { cellObj, targetValue } of cellTargets) {
+    // null means "leave unchanged" — excluded, out-of-range, or no change needed.
+    if (targetValue === null) continue;
 
-  // Pass 2: for each cell, compute what rounding would produce from opts;
-  // re-apply via nodeValue if the current live value differs.
-  for (const row of rows) {
-    for (const cellObj of row.getCells()) {
-      if (cellObj.tagName !== 'TD') continue;
-      const tn = findCellTextNode(cellObj.el);
-      if (!tn) continue;
-      const currentValue = tn.nodeValue;
-      const rounded = computeGridCellRoundedValue(currentValue, opts, max_mag, floorDecimals);
-      if (rounded !== null && currentValue !== rounded) {
-        // Store original if not already stored (freshly-recycled row).
-        if (cellObj.el.dataset && cellObj.el.dataset.drOriginal === undefined) {
-          cellObj.el.dataset.drOriginal = currentValue;
-        }
-        tn.nodeValue = rounded;
-        if (cellObj.el.classList) cellObj.el.classList.add(GRID_ROUNDED_CLASS);
-      }
+    const tn = findCellTextNode(cellObj.el);
+    if (!tn) continue;
+    const currentValue = tn.nodeValue;
+
+    // Only write if the live text node differs from the computed target.
+    if (currentValue === targetValue) continue;
+
+    // Store the original value on freshly-recycled rows (not yet rounded by us).
+    if (cellObj.el.dataset && cellObj.el.dataset.drOriginal === undefined) {
+      cellObj.el.dataset.drOriginal = currentValue;
     }
+    tn.nodeValue = targetValue;
+    if (cellObj.el.classList) cellObj.el.classList.add(GRID_ROUNDED_CLASS);
   }
 
   // Reconnect the observer after the write pass.
@@ -1417,9 +1543,58 @@ function roundTable(table, options) {
   // return early without throwing.
   if (adapterRows.length === 0) return;
   const isVirtualized = adapter.isVirtualized();
+
+  // --- Virtualized grid path ---
+  // Delegate ALL classification and value computation to computeGridRoundedValues
+  // so the initial write pass and reapplyGridRounding share one gated path and
+  // cannot produce diverging results for the same visible DOM + opts.
+  if (isVirtualized) {
+    const cellTargets = computeGridRoundedValues(table, opts);
+    for (const { cellObj, targetValue } of cellTargets) {
+      // null means "leave unchanged" — excluded, out-of-range, or no change needed.
+      if (targetValue === null) continue;
+      cellObj.setText(targetValue);
+    }
+    syncSwitchForTable(table);
+
+    // Attach the scroll/sort re-apply observer AFTER the initial pass so our own
+    // nodeValue writes above do not immediately re-trigger it.
+    if (typeof MutationObserver !== 'undefined') {
+      // Disconnect any stale observer (e.g. roundTable called twice on same grid).
+      const staleObserver = gridObservers.get(table);
+      if (staleObserver) staleObserver.disconnect();
+
+      // Clear any pending debounce timer from a previous observer.
+      const staleTimer = gridReapplyTimers.get(table);
+      if (staleTimer !== undefined) {
+        clearTimeout(staleTimer);
+        gridReapplyTimers.delete(table);
+      }
+
+      const scrollContainer = adapter._getScrollContainer();
+      const wrapperEl = table; // alias for clarity inside the closure
+
+      const observer = new MutationObserver(() => {
+        // Cancel any pending debounce timer for this grid and schedule a fresh one.
+        const pending = gridReapplyTimers.get(wrapperEl);
+        if (pending !== undefined) clearTimeout(pending);
+
+        const timerId = setTimeout(() => {
+          reapplyGridRounding(wrapperEl);
+        }, GRID_REAPPLY_DEBOUNCE_MS);
+
+        gridReapplyTimers.set(wrapperEl, timerId);
+      });
+
+      observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
+      gridObservers.set(wrapperEl, observer);
+    }
+    return;
+  }
+
+  // --- Native <table> path (byte-identical to prior implementation) ---
   const data = [];
-  // For native tables, cellsMap stores raw element. For grid tables, cellsMap
-  // stores the full cellObj so the write pass can call cellObj.setText().
+  // For native tables, cellsMap stores raw element.
   const cellsMap = [];
   const cellInfo = [];
 
@@ -1437,9 +1612,8 @@ function roundTable(table, options) {
       const col = dataCol++;
       const text = cellObj.getText();
       rowData.push(text);
-      // Carry the full cellObj for grid adapters so the write pass can call
-      // cellObj.setText(); for native adapters carry the raw element (unchanged).
-      rowCells.push(isVirtualized ? cellObj : cell);
+      // For native adapters carry the raw element (unchanged).
+      rowCells.push(cell);
 
       const trimmed = typeof text === 'string' ? text.trim() : '';
       // Whole-cell quote short-circuit: if the entire cell content is a single
@@ -1616,13 +1790,6 @@ function roundTable(table, options) {
         if (formattedValue === originalValue.trim()) continue;
       } else {
         // mode === 'extracted': multi-match HTML-preserving patches.
-        // Known limitation: mode:'extracted' cells (mixed text with embedded numbers,
-        // e.g. <sup>-containing cells) require applyExtractedPatches which writes innerHTML.
-        // This is incompatible with the nodeValue-only write model required for virtualized
-        // grids (innerHTML writes crash React's reconciler). Skip extracted cells on grids
-        // for this sprint — only pure-numeric and date/time cells are rounded on grids.
-        if (isVirtualized) continue;
-
         // Round each match and patch its text node directly. This avoids the
         // whole-cell character-distribution approach, which mis-allocates
         // characters when newText length differs from original (corrupting
@@ -1643,61 +1810,17 @@ function roundTable(table, options) {
         continue;
       }
 
-      if (isVirtualized) {
-        // Grid path: write via nodeValue patching only — never innerHTML/textContent.
-        // cellsMap holds the full cellObj (GridAdapter._makeCellObj) for grid tables.
-        // cellObj.setText stores drOriginal, patches in place, adds dr-ext-rounded.
-        // Do NOT set dataset.originalHtml (would cause resetTable to fall into the
-        // native innerHTML restore branch — the crash mode on toggle-off).
-        const cellObj = cellsMap[r][c];
-        cellObj.setText(formattedValue);
-      } else {
-        // Native-table path: cache pristine HTML before mutation so toggle/reset can
-        // restore it without needing to keep the rounded value around.
-        const cell = cellsMap[r][c];
-        cell.dataset.originalHtml = cell.innerHTML;
-        replaceTextPreservingHTML(cell, originalValue, formattedValue);
-        cell.title = `Original: ${originalValue}`;
-        cell.classList.add('dr-ext-rounded');
-        cell.dataset.originalValue = originalValue;
-      }
+      // Native-table path: cache pristine HTML before mutation so toggle/reset can
+      // restore it without needing to keep the rounded value around.
+      const cell = cellsMap[r][c];
+      cell.dataset.originalHtml = cell.innerHTML;
+      replaceTextPreservingHTML(cell, originalValue, formattedValue);
+      cell.title = `Original: ${originalValue}`;
+      cell.classList.add('dr-ext-rounded');
+      cell.dataset.originalValue = originalValue;
     }
   }
   syncSwitchForTable(table);
-
-  // Attach the scroll/sort re-apply observer AFTER the initial pass so our own
-  // nodeValue writes above do not immediately re-trigger it.
-  // Only virtualized grids get an observer — native <table> adapters do not.
-  if (isVirtualized && typeof MutationObserver !== 'undefined') {
-    // Disconnect any stale observer (e.g. roundTable called twice on same grid).
-    const staleObserver = gridObservers.get(table);
-    if (staleObserver) staleObserver.disconnect();
-
-    // Clear any pending debounce timer from a previous observer.
-    const staleTimer = gridReapplyTimers.get(table);
-    if (staleTimer !== undefined) {
-      clearTimeout(staleTimer);
-      gridReapplyTimers.delete(table);
-    }
-
-    const scrollContainer = adapter._getScrollContainer();
-    const wrapperEl = table; // alias for clarity inside the closure
-
-    const observer = new MutationObserver(() => {
-      // Cancel any pending debounce timer for this grid and schedule a fresh one.
-      const pending = gridReapplyTimers.get(wrapperEl);
-      if (pending !== undefined) clearTimeout(pending);
-
-      const timerId = setTimeout(() => {
-        reapplyGridRounding(wrapperEl);
-      }, GRID_REAPPLY_DEBOUNCE_MS);
-
-      gridReapplyTimers.set(wrapperEl, timerId);
-    });
-
-    observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
-    gridObservers.set(wrapperEl, observer);
-  }
 }
 
 function lettersToColIndex(letters) {

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -109,7 +109,7 @@ globalThis.NativeTableAdapter = NativeTableAdapter;
 globalThis.GridAdapter = GridAdapter;
 // Expose grid-virtualization internals for the grid-virtualization test suite.
 globalThis.reapplyGridRounding = reapplyGridRounding;
-globalThis.computeGridCellRoundedValue = computeGridCellRoundedValue;
+globalThis.computeGridRoundedValues = computeGridRoundedValues;
 globalThis.gridObservers = gridObservers;
 globalThis.gridReapplyTimers = gridReapplyTimers;
 globalThis.GRID_REAPPLY_DEBOUNCE_MS = GRID_REAPPLY_DEBOUNCE_MS;

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -107,6 +107,12 @@ globalThis.findTargetTable = findTargetTable;
 globalThis.makeAdapter = makeAdapter;
 globalThis.NativeTableAdapter = NativeTableAdapter;
 globalThis.GridAdapter = GridAdapter;
+// Expose grid-virtualization internals for the grid-virtualization test suite.
+globalThis.reapplyGridRounding = reapplyGridRounding;
+globalThis.computeGridCellRoundedValue = computeGridCellRoundedValue;
+globalThis.gridObservers = gridObservers;
+globalThis.gridReapplyTimers = gridReapplyTimers;
+globalThis.GRID_REAPPLY_DEBOUNCE_MS = GRID_REAPPLY_DEBOUNCE_MS;
 `);
 
 let passed = 0;
@@ -7554,6 +7560,499 @@ function makeE2EGridWrapper(rowData) {
 
   eq('E2E-GR4: drOriginal NOT set on mixed-text cell',
     mixedCell.dataset.drOriginal, undefined);
+})();
+
+// =============================================================================
+// Grid-virtualization re-apply tests
+// Spec: docs/sprint-plans/grid-support-v2.md §2 D4 + §4 "grid-virtualization"
+// Commit: a65129c added GRID_REAPPLY_DEBOUNCE_MS, gridObservers, gridReapplyTimers,
+// computeGridCellRoundedValue, reapplyGridRounding, observer attachment in roundTable,
+// and teardown in resetTable + removed-node observer.
+//
+// Timer/observer control mechanism:
+//   - Before each test, override global.MutationObserver with a capturing stub that
+//     stores the callback so tests can fire it manually (simulating DOM mutations).
+//   - Override global.setTimeout with a synchronous capture: store {fn, ms} in a
+//     local array; call fn() directly to "advance past the debounce".
+//   - Override global.clearTimeout with a no-op that marks the captured timer cancelled.
+//   - Restore all globals in a finally block.
+//
+// The capturing MutationObserver must be installed BEFORE roundTable is called so that
+// roundTable's `new MutationObserver(cb)` instantiates the capturing class, not the
+// no-op stub that was installed at eval time.
+// =============================================================================
+
+/**
+ * Build a grid with a capturing MutationObserver stub installed, then round it.
+ * Returns { grid, capturedObserver, capturedTimers, origMO, origSetTimeout, origClearTimeout }.
+ *
+ * The caller is responsible for restoring globals in a finally block.
+ *
+ * @param {Array<Array<string>>} rowData
+ * @param {object} [roundOpts]   — merged with DR_DEFAULTS for roundTable
+ */
+function setupVirtGrid(rowData, roundOpts) {
+  const pendingTimers = [];
+  let cancelledIds = new Set();
+
+  // Capturing MutationObserver: stores callback + observe options so tests can drive them.
+  let capturedObserver = null;
+  const CapturingMO = class {
+    constructor(cb) {
+      this._cb = cb;
+      this._observing = false;
+      this._options = null;
+      this._target = null;
+      this.disconnectCount = 0;
+      this.reconnectCount = 0;
+      capturedObserver = this;
+    }
+    observe(target, options) {
+      if (!this._observing) {
+        this.reconnectCount++;
+      }
+      this._observing = true;
+      this._target = target;
+      this._options = options;
+    }
+    disconnect() {
+      this._observing = false;
+      this.disconnectCount++;
+    }
+    /** Test helper: fire the callback as if a mutation occurred. */
+    trigger(mutations) {
+      if (this._cb) this._cb(mutations || [], this);
+    }
+  };
+
+  const origMO = global.MutationObserver;
+  const origSetTimeout = global.setTimeout;
+  const origClearTimeout = global.clearTimeout;
+
+  global.MutationObserver = CapturingMO;
+  global.setTimeout = function(fn, ms) {
+    const id = pendingTimers.length;
+    pendingTimers.push({ fn, ms, cancelled: false });
+    return id;
+  };
+  global.clearTimeout = function(id) {
+    if (id !== undefined && id !== null && pendingTimers[id]) {
+      pendingTimers[id].cancelled = true;
+    }
+  };
+
+  const grid = makeE2EGridWrapper(rowData);
+  const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true, simplifyFirstColumn: true }, roundOpts || {});
+  roundTable(grid.wrapperEl, opts);
+
+  return {
+    grid,
+    get capturedObserver() { return capturedObserver; },
+    pendingTimers,
+    origMO,
+    origSetTimeout,
+    origClearTimeout,
+  };
+}
+
+/** Fire all non-cancelled pending timers synchronously (simulate "advance past debounce"). */
+function flushTimers(pendingTimers) {
+  for (const t of pendingTimers) {
+    if (!t.cancelled) t.fn();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GV1: Recycle (childList) — new row appended while grid is rounded;
+// observer + debounce fires; new row's numeric cells become rounded.
+// ---------------------------------------------------------------------------
+(function gv1_recycle_newRowRounded() {
+  let ctx;
+  try {
+    // 2-row grid with big numbers so rounding changes the value.
+    ctx = setupVirtGrid([
+      ['8584629', '1234567'],
+      ['7654321', '2345678'],
+    ]);
+    const { grid, pendingTimers } = ctx;
+
+    // Pre-condition: existing cells are rounded.
+    eq('GV1 (pre): existing cell[0] is rounded after roundTable',
+      grid.cellEls[0].classList.contains('dr-ext-rounded'), true);
+
+    // Simulate row recycling: append a new unrounded row.
+    const newCell0 = makeGridCellWithTextNode('9876543');
+    const newCell1 = makeGridCellWithTextNode('3456789');
+    const newRow = makeElementNode('row', [newCell0, newCell1]);
+    newRow.dataset = { row: '2' };
+    newRow.children = [newCell0, newCell1];
+    newRow.querySelectorAll = function(sel) { return []; };
+
+    // Add to the grid's children and allCells so querySelectorAll('.dr-ext-rounded') works.
+    grid.wrapperEl.children.push(newRow);
+    grid.wrapperEl.rowEls = grid.wrapperEl.children;
+    // Patch the querySelectorAll on the wrapper to also scan new cells.
+    const allCells = grid.cellEls.concat([newCell0, newCell1]);
+    grid.wrapperEl.querySelectorAll = function(sel) {
+      if (sel === '.dr-ext-rounded') {
+        return allCells.filter(function(c) { return c.classList.contains('dr-ext-rounded'); });
+      }
+      return [];
+    };
+
+    // Trigger the observer callback (simulating a childList mutation).
+    const obs = ctx.capturedObserver;
+    eq('GV1 (pre): capturing observer was created',
+      obs !== null, true);
+
+    obs.trigger([{ type: 'childList' }]);
+
+    // The observer callback schedules a debounce timer — flush it.
+    flushTimers(pendingTimers);
+
+    // The new cells should now be rounded.
+    eq('GV1: new row cell[0] is rounded after recycle + re-apply',
+      newCell0.classList.contains('dr-ext-rounded'), true);
+
+    eq('GV1: new row cell[1] is rounded after recycle + re-apply',
+      newCell1.classList.contains('dr-ext-rounded'), true);
+
+    // The text node value must have changed from the original unrounded value.
+    eq('GV1: new row cell[0] text node value differs from original unrounded value',
+      newCell0.childNodes[0].nodeValue !== '9876543', true);
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV2: Sort revert (characterData) — the headline test.
+// Round a grid; rewrite a rounded cell's text node back to its original value
+// (simulating an in-place sort: same Text node, class .dr-ext-rounded retained).
+// Trigger observer + debounce; assert cell is re-rounded.
+// ---------------------------------------------------------------------------
+(function gv2_sortRevert_cellReRounded() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { grid, pendingTimers } = ctx;
+
+    // cell[0] is a big numeric cell — it should be rounded.
+    const cell0 = grid.cellEls[0];
+    eq('GV2 (pre): cell[0] carries dr-ext-rounded after initial roundTable',
+      cell0.classList.contains('dr-ext-rounded'), true);
+
+    const tn0 = cell0.childNodes[0];
+    const roundedValue = tn0.nodeValue;   // e.g. '8600000'
+    const originalValue = cell0.dataset.drOriginal;  // e.g. '8584629'
+
+    eq('GV2 (pre): roundedValue differs from original',
+      roundedValue !== originalValue, true);
+
+    // Simulate an in-place sort: framework rewrites text node back to original
+    // but the cell KEEPS our .dr-ext-rounded class (node identity preserved).
+    tn0.nodeValue = originalValue;
+    // Class is still present (as in real sort behaviour).
+    eq('GV2 (pre): class still present after sort-revert (simulated)',
+      cell0.classList.contains('dr-ext-rounded'), true);
+
+    // Trigger characterData mutation.
+    const obs = ctx.capturedObserver;
+    obs.trigger([{ type: 'characterData', target: tn0 }]);
+
+    // Flush the debounce timer.
+    flushTimers(pendingTimers);
+
+    // The cell must be re-rounded: its text node value must equal the rounded value again.
+    eq('GV2: cell[0] text node value re-rounded after sort-revert + re-apply',
+      cell0.childNodes[0].nodeValue, roundedValue);
+
+    eq('GV2: cell[0] still carries dr-ext-rounded after re-apply',
+      cell0.classList.contains('dr-ext-rounded'), true);
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV3: Debounce — N rapid mutations result in reapplyGridRounding running once.
+// Fire the observer callback 5 times in quick succession; assert that only
+// one non-cancelled timer fires (earlier ones are cancelled by the debounce).
+// ---------------------------------------------------------------------------
+(function gv3_debounce_nMutationsFireReapplyOnce() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { pendingTimers } = ctx;
+    const obs = ctx.capturedObserver;
+
+    // Fire observer callback 5 times rapidly.
+    for (let i = 0; i < 5; i++) {
+      obs.trigger([{ type: 'childList' }]);
+    }
+
+    // Count how many timers were NOT cancelled (should be exactly 1 — the last scheduled one).
+    const activeCnt = pendingTimers.filter(function(t) { return !t.cancelled; }).length;
+    eq('GV3: exactly 1 active (non-cancelled) debounce timer after 5 rapid mutations',
+      activeCnt, 1);
+
+    // Track re-apply call count by spying on gridReapplyTimers writes inside flush.
+    let reapplyCalls = 0;
+    const origRAGR = global.reapplyGridRounding;
+    // We can't easily intercept the closure directly; instead count timer fires.
+    // Each non-cancelled timer fires reapplyGridRounding once.
+    flushTimers(pendingTimers);
+    // If any additional timers were scheduled by the re-apply itself, they would appear here.
+    const newTimers = pendingTimers.filter(function(t, i) { return i >= 5; });
+    eq('GV3: no additional debounce timers spawned by the single re-apply (bounded)',
+      newTimers.filter(function(t) { return !t.cancelled; }).length, 0);
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV4: No self-trigger loop — a single re-apply does not schedule an unbounded
+// cascade. After flushing the debounce timer once, no further timers should be
+// pending (disconnect/reconnect guard prevents our own writes from re-triggering).
+// ---------------------------------------------------------------------------
+(function gv4_noSelfTriggerLoop() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { pendingTimers } = ctx;
+    const obs = ctx.capturedObserver;
+
+    // Trigger once and flush — this runs reapplyGridRounding.
+    obs.trigger([{ type: 'childList' }]);
+    const countBefore = pendingTimers.length;  // should be 1
+
+    flushTimers(pendingTimers);
+
+    // reapplyGridRounding disconnects observer before writes and reconnects after.
+    // Its own nodeValue writes must NOT schedule a new debounce timer.
+    const countAfter = pendingTimers.length;
+    eq('GV4: no new timer scheduled during re-apply (self-trigger loop prevented)',
+      countAfter, countBefore);
+
+    // Also assert the observer was disconnected during the write pass and reconnected.
+    eq('GV4: observer disconnected at least once during re-apply (write guard)',
+      obs.disconnectCount >= 1, true);
+
+    eq('GV4: observer reconnected after re-apply',
+      obs.reconnectCount >= 2, true);  // once in roundTable, once in reapplyGridRounding
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV5: After resetTable — a subsequent mutation does NOT trigger rounding.
+// Observer disconnected + timer cleared on reset; subsequent observer trigger
+// must not schedule a new debounce timer.
+// ---------------------------------------------------------------------------
+(function gv5_afterResetTable_noReTrigger() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { grid, pendingTimers } = ctx;
+    const obs = ctx.capturedObserver;
+
+    // Pre-condition: observer is set up.
+    eq('GV5 (pre): gridObservers has entry for wrapperEl',
+      gridObservers.has(grid.wrapperEl), true);
+
+    // Reset the table — should disconnect the observer and clear any pending timer.
+    resetTable(grid.wrapperEl);
+
+    eq('GV5: gridObservers entry removed after resetTable',
+      gridObservers.has(grid.wrapperEl), false);
+
+    eq('GV5: gridReapplyTimers entry removed after resetTable',
+      gridReapplyTimers.has(grid.wrapperEl), false);
+
+    // Observer should be disconnected.
+    eq('GV5: observer disconnected after resetTable',
+      obs.disconnectCount >= 1, true);
+
+    // Now simulate a mutation — the observer callback fires (it's the same object,
+    // but it's been disconnected so in the real DOM it would not fire; here we
+    // call it manually to prove the debounce logic does NOT schedule a new timer
+    // because gridObservers / tableOptions no longer has the wrapper).
+    const timerCountBefore = pendingTimers.length;
+    obs.trigger([{ type: 'childList' }]);
+    // The callback still fires (we're calling it directly), but reapplyGridRounding
+    // will bail harmlessly because tableOptions no longer has the wrapper.
+    // The debounce timer IS still scheduled by the closure (the closure holds wrapperEl).
+    // Flush it and confirm no rounding occurred.
+    flushTimers(pendingTimers);
+
+    // After flush, cell[0] should be unrounded (resetTable restored originals).
+    eq('GV5: cell[0] is NOT rounded after resetTable (dr-ext-rounded removed)',
+      grid.cellEls[0].classList.contains('dr-ext-rounded'), false);
+
+    // Original value must be restored.
+    eq('GV5: cell[0] text node value is restored to original after resetTable',
+      grid.cellEls[0].childNodes[0].nodeValue, '8584629');
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV6 (Adversarial): Native <table> gets NO observer — after rounding a native
+// table, gridObservers has no entry for it. Observer is grid-only (perf guard).
+// ---------------------------------------------------------------------------
+(function gv6_nativeTable_noGridObserver() {
+  // Build a minimal native table stub that isDataTable and roundTable can process.
+  const origMO = global.MutationObserver;
+  const origSetTimeout = global.setTimeout;
+  try {
+    // Count MutationObserver instantiations to ensure none happen for native tables.
+    let moConstructCount = 0;
+    global.MutationObserver = class {
+      constructor(cb) { moConstructCount++; this._cb = cb; }
+      observe() {}
+      disconnect() {}
+    };
+    global.setTimeout = () => 99;
+
+    // Use the existing makeMockTable-level helper if available, or build manually.
+    // We need a table with rows and cells that roundTable can process.
+    // The simplest approach: build with the pattern used by existing native-table tests.
+    const cell00 = { innerHTML: '8584629', textContent: '8584629', dataset: {}, classList: { _c: [], add(x){this._c.push(x);}, remove(x){this._c=this._c.filter(v=>v!==x);}, contains(x){return this._c.includes(x);} }, getAttribute: () => null };
+    const cell01 = { innerHTML: '1234567', textContent: '1234567', dataset: {}, classList: { _c: [], add(x){this._c.push(x);}, remove(x){this._c=this._c.filter(v=>v!==x);}, contains(x){return this._c.includes(x);} }, getAttribute: () => null };
+    const row0 = { cells: [cell00, cell01], tagName: 'TR', rowIndex: 0 };
+    const cell10 = { innerHTML: '7654321', textContent: '7654321', dataset: {}, classList: { _c: [], add(x){this._c.push(x);}, remove(x){this._c=this._c.filter(v=>v!==x);}, contains(x){return this._c.includes(x);} }, getAttribute: () => null };
+    const cell11 = { innerHTML: '2345678', textContent: '2345678', dataset: {}, classList: { _c: [], add(x){this._c.push(x);}, remove(x){this._c=this._c.filter(v=>v!==x);}, contains(x){return this._c.includes(x);} }, getAttribute: () => null };
+    const row1 = { cells: [cell10, cell11], tagName: 'TR', rowIndex: 1 };
+    const nativeTable = {
+      tagName: 'TABLE',
+      rows: [row0, row1],
+      classList: { _c: [], add(x){this._c.push(x);}, remove(x){this._c=this._c.filter(v=>v!==x);}, contains(x){return this._c.includes(x);} },
+      dataset: {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      getBoundingClientRect: () => ({ top: 0, left: 0, width: 100, height: 40 }),
+    };
+
+    const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true });
+    roundTable(nativeTable, opts);
+
+    eq('GV6: gridObservers has NO entry for a native <table> after roundTable',
+      gridObservers.has(nativeTable), false);
+
+    eq('GV6: no MutationObserver instantiated for native table rounding',
+      moConstructCount, 0);
+
+  } finally {
+    global.MutationObserver = origMO;
+    global.setTimeout = origSetTimeout;
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV7 (Adversarial): Removed-grid teardown — simulate the removed-node observer
+// path for an observed grid; assert its observer is disconnected + timer cleared.
+// ---------------------------------------------------------------------------
+(function gv7_removedGrid_teardown() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { grid, pendingTimers } = ctx;
+    const obs = ctx.capturedObserver;
+
+    // Schedule a pending debounce timer by triggering the observer.
+    obs.trigger([{ type: 'childList' }]);
+
+    eq('GV7 (pre): a debounce timer is pending',
+      pendingTimers.filter(function(t) { return !t.cancelled; }).length, 1);
+
+    eq('GV7 (pre): gridObservers has entry for grid',
+      gridObservers.has(grid.wrapperEl), true);
+
+    // The removed-node observer path in content.js (the _tableObserver that watches
+    // document.body) calls disconnect + delete when it detects a tracked table was
+    // removed from the DOM. We simulate that path directly by invoking the same
+    // cleanup logic that the observer callback executes:
+    //   clearTimeout(gridReapplyTimers.get(table)); gridReapplyTimers.delete(table);
+    //   gridObservers.get(table).disconnect(); gridObservers.delete(table);
+    // In the test harness the _tableObserver is a no-op stub, so we exercise the
+    // teardown path via resetTable (which runs the same teardown code and is the
+    // direct production path called by the toggle-off handler).
+    // For the removed-node path specifically: call the same sequence manually.
+    const pendingTimer = gridReapplyTimers.get(grid.wrapperEl);
+    if (pendingTimer !== undefined) {
+      global.clearTimeout(pendingTimer);
+      gridReapplyTimers.delete(grid.wrapperEl);
+    }
+    const gridObs = gridObservers.get(grid.wrapperEl);
+    if (gridObs) {
+      gridObs.disconnect();
+      gridObservers.delete(grid.wrapperEl);
+    }
+
+    // Assert cleanup.
+    eq('GV7: observer disconnected after removed-node teardown',
+      obs.disconnectCount >= 1, true);
+
+    eq('GV7: gridObservers entry deleted after removed-node teardown',
+      gridObservers.has(grid.wrapperEl), false);
+
+    eq('GV7: gridReapplyTimers entry deleted after removed-node teardown',
+      gridReapplyTimers.has(grid.wrapperEl), false);
+
+    // Previously-pending timer must now be cancelled.
+    eq('GV7: pending debounce timer was cancelled during teardown',
+      pendingTimers.filter(function(t) { return !t.cancelled; }).length, 0);
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
 })();
 
 // --- Report ---

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -8055,6 +8055,218 @@ function flushTimers(pendingTimers) {
   }
 })();
 
+// ---------------------------------------------------------------------------
+// GV8: Exclusion-gate parity — re-apply HONORS firstRow / firstColumn gates.
+//
+// Regression guard for the BLOCK: before the fix, reapplyGridRounding recomputed
+// max_mag over an unfiltered cell set and wrote excluded cells.  After the fix
+// (computeGridRoundedValues shared path), excluded cells get targetValue:null and
+// are never written.
+//
+// Grid layout (2 rows × 2 cols):
+//   row 0:  'Header'     '999999'     ← row 0 excluded by simplifyFirstRow:false
+//   row 1:  '12345678'   '87654321'   ← row 1 data; col 0 excluded by simplifyFirstColumn:false
+//
+// Round with simplifyFirstRow:false, simplifyFirstColumn:false (the real defaults).
+// After initial roundTable:
+//   - cellEls[0] (row0,col0) = excluded (firstRow)   → NOT rounded
+//   - cellEls[1] (row0,col1) = excluded (firstRow)   → NOT rounded
+//   - cellEls[2] (row1,col0) = excluded (firstColumn)→ NOT rounded
+//   - cellEls[3] (row1,col1) = in-range numeric      → IS rounded
+//
+// Then simulate a sort-revert on cellEls[3] (revert text to original).
+// Trigger observer + flush.
+// Assert:
+//   - cellEls[0] still NOT rounded (text unchanged, no dr-ext-rounded)
+//   - cellEls[2] still NOT rounded (text unchanged, no dr-ext-rounded)
+//   - cellEls[3] IS re-rounded (text equals initial rounded value)
+// ---------------------------------------------------------------------------
+(function gv8_reapply_honorsExclusionGates_firstRowFirstColumn() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid(
+      [
+        ['Header', '999999'],
+        ['12345678', '87654321'],
+      ],
+      // Override the setupVirtGrid defaults: exclusions must be ON (false = exclude).
+      { simplifyFirstRow: false, simplifyFirstColumn: false }
+    );
+    const { grid, pendingTimers } = ctx;
+
+    // cellEls layout (row-major): [row0col0, row0col1, row1col0, row1col1]
+    const cell_r0c0 = grid.cellEls[0];  // 'Header'    — excluded firstRow
+    const cell_r0c1 = grid.cellEls[1];  // '999999'    — excluded firstRow
+    const cell_r1c0 = grid.cellEls[2];  // '12345678'  — excluded firstColumn
+    const cell_r1c1 = grid.cellEls[3];  // '87654321'  — should be rounded
+
+    // --- Pre-conditions after initial roundTable ---
+    eq('GV8 (pre): row-0 col-0 is NOT rounded by initial pass (firstRow excluded)',
+      cell_r0c0.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV8 (pre): row-0 col-1 is NOT rounded by initial pass (firstRow excluded)',
+      cell_r0c1.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV8 (pre): row-1 col-0 is NOT rounded by initial pass (firstColumn excluded)',
+      cell_r1c0.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV8 (pre): row-1 col-1 IS rounded by initial pass (in-range data cell)',
+      cell_r1c1.classList.contains('dr-ext-rounded'), true);
+
+    // Capture the rounded value so we can verify re-apply restores it.
+    const tn_r1c1 = cell_r1c1.childNodes[0];
+    const roundedValue_r1c1 = tn_r1c1.nodeValue;
+    const originalValue_r1c1 = cell_r1c1.dataset.drOriginal;  // '87654321'
+
+    eq('GV8 (pre): row-1 col-1 rounded value differs from original',
+      roundedValue_r1c1 !== originalValue_r1c1, true);
+
+    // Simulate a sort-revert on the in-range cell: framework rewrites the text
+    // node back to the original value (node identity preserved, class retained).
+    tn_r1c1.nodeValue = originalValue_r1c1;
+
+    eq('GV8 (pre): row-1 col-1 class still present after sort-revert',
+      cell_r1c1.classList.contains('dr-ext-rounded'), true);
+
+    // Trigger observer and flush debounce.
+    const obs = ctx.capturedObserver;
+    obs.trigger([{ type: 'characterData', target: tn_r1c1 }]);
+    flushTimers(pendingTimers);
+
+    // --- Post-conditions: excluded cells must NOT be rounded ---
+    eq('GV8: row-0 col-0 text unchanged after re-apply (firstRow exclusion honored)',
+      cell_r0c0.childNodes[0].nodeValue, 'Header');
+
+    eq('GV8: row-0 col-0 does NOT carry dr-ext-rounded after re-apply',
+      cell_r0c0.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV8: row-1 col-0 text unchanged after re-apply (firstColumn exclusion honored)',
+      cell_r1c0.childNodes[0].nodeValue, '12345678');
+
+    eq('GV8: row-1 col-0 does NOT carry dr-ext-rounded after re-apply',
+      cell_r1c0.classList.contains('dr-ext-rounded'), false);
+
+    // --- Post-condition: the in-range data cell MUST be re-rounded ---
+    eq('GV8: row-1 col-1 re-rounded after sort-revert + re-apply',
+      cell_r1c1.childNodes[0].nodeValue, roundedValue_r1c1);
+
+    eq('GV8: row-1 col-1 still carries dr-ext-rounded after re-apply',
+      cell_r1c1.classList.contains('dr-ext-rounded'), true);
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV9: Exclusion-gate parity — re-apply HONORS percent / currency gates.
+//
+// Grid layout (2 rows × 2 cols):
+//   row 0:  '75%'        '50%'        ← % cells excluded by simplifyMixedPercent:false
+//   row 1:  '12345678'   '$9,999,999' ← col 1 currency excluded by simplifyMixedCurrency:false
+//
+// Round with simplifyFirstRow:true, simplifyFirstColumn:true (skip those gates),
+// simplifyMixedPercent:false, simplifyMixedCurrency:false.
+//
+// After initial roundTable:
+//   - cellEls[0] (row0,col0) = % excluded  → NOT rounded
+//   - cellEls[1] (row0,col1) = % excluded  → NOT rounded
+//   - cellEls[2] (row1,col0) = plain int   → IS rounded
+//   - cellEls[3] (row1,col1) = $ excluded  → NOT rounded
+//
+// Simulate sort-revert on cellEls[2]; trigger observer + flush.
+// Assert:
+//   - cellEls[0] and cellEls[1] still NOT rounded (percent exclusion honored)
+//   - cellEls[3] still NOT rounded (currency exclusion honored)
+//   - cellEls[2] IS re-rounded (plain numeric, in-range)
+// ---------------------------------------------------------------------------
+(function gv9_reapply_honorsExclusionGates_percentCurrency() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid(
+      [
+        ['75%', '50%'],
+        ['12345678', '$9999999'],
+      ],
+      {
+        simplifyFirstRow: true,
+        simplifyFirstColumn: true,
+        simplifyMixedPercent: false,
+        simplifyMixedCurrency: false,
+      }
+    );
+    const { grid, pendingTimers } = ctx;
+
+    const cell_r0c0 = grid.cellEls[0];  // '75%'       — excluded percent
+    const cell_r0c1 = grid.cellEls[1];  // '50%'       — excluded percent
+    const cell_r1c0 = grid.cellEls[2];  // '12345678'  — should be rounded
+    const cell_r1c1 = grid.cellEls[3];  // '$9999999'  — excluded currency
+
+    // --- Pre-conditions after initial roundTable ---
+    eq('GV9 (pre): row-0 col-0 (75%) is NOT rounded by initial pass (percent excluded)',
+      cell_r0c0.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV9 (pre): row-0 col-1 (50%) is NOT rounded by initial pass (percent excluded)',
+      cell_r0c1.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV9 (pre): row-1 col-0 IS rounded by initial pass (plain numeric)',
+      cell_r1c0.classList.contains('dr-ext-rounded'), true);
+
+    eq('GV9 (pre): row-1 col-1 ($9999999) is NOT rounded by initial pass (currency excluded)',
+      cell_r1c1.classList.contains('dr-ext-rounded'), false);
+
+    // Capture the rounded value for re-apply verification.
+    const tn_r1c0 = cell_r1c0.childNodes[0];
+    const roundedValue_r1c0 = tn_r1c0.nodeValue;
+    const originalValue_r1c0 = cell_r1c0.dataset.drOriginal;
+
+    eq('GV9 (pre): row-1 col-0 rounded value differs from original',
+      roundedValue_r1c0 !== originalValue_r1c0, true);
+
+    // Simulate sort-revert on the plain numeric cell.
+    tn_r1c0.nodeValue = originalValue_r1c0;
+
+    // Trigger observer and flush debounce.
+    const obs = ctx.capturedObserver;
+    obs.trigger([{ type: 'characterData', target: tn_r1c0 }]);
+    flushTimers(pendingTimers);
+
+    // --- Post-conditions: excluded cells must NOT be rounded ---
+    eq('GV9: row-0 col-0 text unchanged after re-apply (percent exclusion honored)',
+      cell_r0c0.childNodes[0].nodeValue, '75%');
+
+    eq('GV9: row-0 col-0 does NOT carry dr-ext-rounded after re-apply',
+      cell_r0c0.classList.contains('dr-ext-rounded'), false);
+
+    eq('GV9: row-0 col-1 text unchanged after re-apply (percent exclusion honored)',
+      cell_r0c1.childNodes[0].nodeValue, '50%');
+
+    eq('GV9: row-1 col-1 text unchanged after re-apply (currency exclusion honored)',
+      cell_r1c1.childNodes[0].nodeValue, '$9999999');
+
+    eq('GV9: row-1 col-1 does NOT carry dr-ext-rounded after re-apply',
+      cell_r1c1.classList.contains('dr-ext-rounded'), false);
+
+    // --- Post-condition: the plain numeric cell MUST be re-rounded ---
+    eq('GV9: row-1 col-0 re-rounded after sort-revert + re-apply',
+      cell_r1c0.childNodes[0].nodeValue, roundedValue_r1c0);
+
+    eq('GV9: row-1 col-0 still carries dr-ext-rounded after re-apply',
+      cell_r1c0.classList.contains('dr-ext-rounded'), true);
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/docs/sprint-logs/grid-support-v2-grid-virtualization.md
+++ b/docs/sprint-logs/grid-support-v2-grid-virtualization.md
@@ -1,0 +1,27 @@
+# Sprint Log: grid-virtualization
+
+**Plan:** docs/sprint-plans/grid-support-v2.md
+**Sprint goal:** Keep a rounded grid rounded as the user scrolls and sorts — re-apply rounding to recycled/reverted cells via a debounced `childList`+`characterData` MutationObserver.
+**Date:** 2026-06-12
+**Result:** Completed (after 1 retry)
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Added `GRID_REAPPLY_DEBOUNCE_MS = 100`, `gridObservers`/`gridReapplyTimers` WeakMaps, a re-apply pass, and a grid-only MutationObserver (`childList`+`characterData`, debounced via `setTimeout`) attached after the initial round; teardown in `resetTable` and the removed-node observer; disconnect-before-write / reconnect guard.
+- **Tests:** pass (924) — GV1–GV7 (recycle, sort-revert, debounce, no-self-loop, reset teardown, native-no-observer, removed-grid teardown), via capturing MutationObserver + setTimeout stubs.
+- **Reviewer verdict:** BLOCK
+- **Reviewer notes:** `reapplyGridRounding` diverged from the initial `roundTable` pass — it skipped the exclusion gates (`isInRanges`, `getExclusionReason` → firstRow/firstColumn/percent/currency) and recomputed `max_mag` over an unfiltered set. On sort/recycle it would round cells the user excluded or produce a different value. The GV1–GV7 fixtures disabled every divergent gate (`simplifyFirstRow/Column:true`, plain integers), so the gap was untested.
+
+### Attempt 2
+- **Developer:** Extracted `computeGridRoundedValues(wrapperEl, opts)` as the single shared classify+compute path. BOTH the initial `roundTable` grid write pass and `reapplyGridRounding` now call it, so they cannot diverge. It applies the full gate set (`isInRanges`, `getExclusionReason`, whole-cell-quote, date/time, link/`<sup>`, `mode:'extracted'` skip-on-grid) and computes `max_mag`/`ranges` over the same filtered (in-range, non-excluded, pure-numeric) set. Excluded/out-of-range cells return `targetValue: null` and are never written by either pass. The stale `computeGridCellRoundedValue` was removed. Disconnect guard / debounce / teardown / native path preserved.
+- **Tests:** pass (948) — added GV8 (firstRow/firstColumn exclusion honored on re-apply) and GV9 (percent/currency exclusion honored), each asserting the excluded cell is NOT re-rounded after a sort-revert while an in-range data cell IS. Both would fail against the pre-fix re-apply.
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:**
+  - Single shared path confirmed; initial-pass value == reapply target by construction; no second grid rounding implementation remains.
+  - Disconnect-before-write/reconnect guard, 100ms debounce, grid-only observer (native `<table>` gets none), reset + removed-node teardown all intact; grid writes `nodeValue`-only.
+  - `mode:'extracted'` still skipped on grids (deferred, tracked in issue #120) — not newly implemented here.
+  - Minor (non-blocking): `computeGridRoundedValues` builds the scroll container twice per re-apply and reaches a `_`-prefixed adapter method from outside the class — could cache; not load-bearing.
+
+## PR
+(opened against main — see PR link)


### PR DESCRIPTION
Plan: docs/sprint-plans/grid-support-v2.md

Keeps a rounded data grid rounded as the user **scrolls** and **sorts**. A grid-only, 100 ms-debounced `MutationObserver` watches the scroll container for `childList` (row recycling) and `characterData` (in-place sort revert) mutations and re-applies rounding via the `nodeValue` write path. Builds on merged grid-rounding (#119).

Re-apply and the initial round share one classify+compute function (`computeGridRoundedValues`), so they cannot diverge — re-apply honors the same exclusion gates (`isInRanges`, firstRow/firstColumn/percent/currency) and `max_mag` filtering as the initial pass.

## Acceptance criteria
- [x] `node chrome-extension/tests.js` passes (948 / 0)
- [x] Scrolling re-rounds newly-visible rows (childList); sorting a rounded column keeps it rounded (characterData)
- [x] Re-application does not loop/thrash — observer disconnected during writes, reconnected after
- [x] Toggling off (`resetTable`) stops all re-application (observer disconnected, timer cleared)
- [x] No observer attached for native `<table>` adapters (no perf regression)
- [x] Named constant `GRID_REAPPLY_DEBOUNCE_MS = 100`; `setTimeout` debounce (not rAF)

## Reviewer notes
- Initial BLOCK → fixed on retry: `reapplyGridRounding` originally skipped the exclusion gates and recomputed `max_mag` over an unfiltered set, so it would re-round user-excluded cells on sort. Now both passes run the single `computeGridRoundedValues` path; excluded/out-of-range cells return `null` and are never written. Regression tests GV8 (firstRow/firstColumn) and GV9 (percent/currency) lock this in.
- Re-rounds by computed VALUE, not by `.dr-ext-rounded` class presence — covers both recycled rows (no class) and sort-reverted cells (class retained, value stale).
- `nodeValue`-only grid writes; teardown on reset and on grid removal (timer clear + observer disconnect).
- `mode:'extracted'` cells remain skipped on grids (deferred — issue #120), not newly implemented here.
- Minor (non-blocking): `computeGridRoundedValues` builds the scroll container twice per re-apply; could cache. Not load-bearing.
