### PR TITLE
refactor(chrome-extension): extract domain core into core.js

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -6,13 +6,11 @@
  */
 
 // Constants
-const CLEAN_REGEX = /[$€£¥,\s%]/g;
-const PARENS_REGEX = /^\((.+)\)$/;
+// CLEAN_REGEX, PARENS_REGEX, DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP, and
+// VALIDATION_LIMIT live in core.js (loaded ahead of this file); they are used
+// here too via shared global scope.
 const NUMBER_IN_TEXT_REGEX = /-?\d[\d,]*(?:\.\d+)?/;
 const NUMBER_IN_TEXT_REGEX_GLOBAL = /-?\d[\d,]*(?:\.\d+)?/g;
-const DEFAULT_OFFSET_TOP = -0.5;
-const DEFAULT_NUM_TOP = 1;
-const VALIDATION_LIMIT = 20;
 
 // Grid detection constants
 /** Minimum number of direct children for an element to be a grid candidate. */
@@ -2337,87 +2335,10 @@ function toggleOriginalValues(table) {
   syncSwitchForTable(table);
 }
 
-// --- Core Algorithm Inlined ---
-
-function ROUND_DYNAMIC(values, offset_top, offset_other, num_top) {
-  const firstIsArray = Array.isArray(values);
-
-  if (firstIsArray) {
-    return datasetMode(values, offset_top, offset_other, num_top);
-  } else {
-    return singleValueMode(values, offset_top);
-  }
-}
-
-function singleValueMode(value, offset) {
-  offset = (offset === undefined || offset === "") ? DEFAULT_OFFSET_TOP : offset;
-  validateOffset(offset, "offset");
-
-  if (value === "" || value === null) return "";
-
-  const num = toNumber(value);
-  if (num === null) return value;
-  if (num === 0) return 0;
-
-  return roundWithOffset(num, offset);
-}
-
-function datasetMode(range, offset_top, offset_other, num_top) {
-  offset_top = (offset_top === undefined || offset_top === "") ? DEFAULT_OFFSET_TOP : offset_top;
-  offset_other = (offset_other === undefined || offset_other === "") ? offset_top : offset_other;
-  num_top = (num_top === undefined || num_top === "") ? DEFAULT_NUM_TOP : num_top;
-  validateOffset(offset_top, "offset_top");
-  validateOffset(offset_other, "offset_other");
-
-  if (!Array.isArray(range[0])) {
-    range = [range];
-  }
-
-  const numericRange = range.map(row => row.map(cell => toNumber(cell)));
-  const max_mag = findMaxMagnitude(numericRange);
-
-  return range.map((row, r) =>
-    row.map((cell, c) => roundCellSetAware(cell, numericRange[r][c], max_mag, offset_top, offset_other, num_top))
-  );
-}
-
-function findMaxMagnitude(numericRange) {
-  let max_mag = null;
-  for (let row of numericRange) {
-    for (let num of row) {
-      if (num !== null && num !== 0 && isFinite(num)) {
-        const mag = Math.floor(Math.log10(Math.abs(num)));
-        if (max_mag === null || mag > max_mag) {
-          max_mag = mag;
-        }
-      }
-    }
-  }
-  return max_mag;
-}
-
-// roundCellSetAware and roundWithOffset live in rounding.js.
-
-function toNumber(value) {
-  if (typeof value === "number") {
-    return isFinite(value) ? value : null;
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    let cleaned = value.trim()
-      .replace(/[‐-―−﹘﹣－]/g, "-")
-      .replace(CLEAN_REGEX, "")
-      .replace(PARENS_REGEX, "-$1");
-    const parsed = Number(cleaned);
-    return isFinite(parsed) ? parsed : null;
-  }
-  return null;
-}
-
-function validateOffset(offset, paramName) {
-  if (offset < -VALIDATION_LIMIT || offset > VALIDATION_LIMIT) {
-    throw new Error(paramName + " must be between -" + VALIDATION_LIMIT + " and " + VALIDATION_LIMIT + ", got " + offset);
-  }
-}
+// ROUND_DYNAMIC, singleValueMode, datasetMode, findMaxMagnitude, toNumber, and
+// validateOffset (plus DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP, VALIDATION_LIMIT,
+// CLEAN_REGEX, PARENS_REGEX) live in core.js, loaded by manifest content_scripts
+// ahead of this file so the sidebar can call the same ROUND_DYNAMIC core.
 
 /**
  * Restore the formatting of a pure-numeric cell after rounding.

--- a/chrome-extension/core.js
+++ b/chrome-extension/core.js
@@ -1,0 +1,100 @@
+/**
+ * DynamicRounding domain core (dispatch + coercion layer).
+ *
+ * Loaded by both content.js (page context, via manifest content_scripts) and
+ * sidebar.js (extension side-panel context, via <script> tag), AFTER rounding.js
+ * and BEFORE content.js. Must remain framework-free and side-effect-free: no
+ * chrome.*, no DOM access. All symbols land on the global object of whichever
+ * script loads this file, so both contexts call the same ROUND_DYNAMIC the
+ * standalone js/round_dynamic.js implements.
+ *
+ * The arithmetic primitives (roundWithOffset, roundCellSetAware) live in
+ * rounding.js, which must load before this file.
+ */
+
+// Constants owned by the core dispatch/coercion layer.
+const CLEAN_REGEX = /[$€£¥,\s%]/g;
+const PARENS_REGEX = /^\((.+)\)$/;
+const DEFAULT_OFFSET_TOP = -0.5;
+const DEFAULT_NUM_TOP = 1;
+const VALIDATION_LIMIT = 20;
+
+function ROUND_DYNAMIC(values, offset_top, offset_other, num_top) {
+  const firstIsArray = Array.isArray(values);
+
+  if (firstIsArray) {
+    return datasetMode(values, offset_top, offset_other, num_top);
+  } else {
+    return singleValueMode(values, offset_top);
+  }
+}
+
+function singleValueMode(value, offset) {
+  offset = (offset === undefined || offset === "") ? DEFAULT_OFFSET_TOP : offset;
+  validateOffset(offset, "offset");
+
+  if (value === "" || value === null) return "";
+
+  const num = toNumber(value);
+  if (num === null) return value;
+  if (num === 0) return 0;
+
+  return roundWithOffset(num, offset);
+}
+
+function datasetMode(range, offset_top, offset_other, num_top) {
+  offset_top = (offset_top === undefined || offset_top === "") ? DEFAULT_OFFSET_TOP : offset_top;
+  offset_other = (offset_other === undefined || offset_other === "") ? offset_top : offset_other;
+  num_top = (num_top === undefined || num_top === "") ? DEFAULT_NUM_TOP : num_top;
+  validateOffset(offset_top, "offset_top");
+  validateOffset(offset_other, "offset_other");
+
+  if (!Array.isArray(range[0])) {
+    range = [range];
+  }
+
+  const numericRange = range.map(row => row.map(cell => toNumber(cell)));
+  const max_mag = findMaxMagnitude(numericRange);
+
+  return range.map((row, r) =>
+    row.map((cell, c) => roundCellSetAware(cell, numericRange[r][c], max_mag, offset_top, offset_other, num_top))
+  );
+}
+
+function findMaxMagnitude(numericRange) {
+  let max_mag = null;
+  for (let row of numericRange) {
+    for (let num of row) {
+      if (num !== null && num !== 0 && isFinite(num)) {
+        const mag = Math.floor(Math.log10(Math.abs(num)));
+        if (max_mag === null || mag > max_mag) {
+          max_mag = mag;
+        }
+      }
+    }
+  }
+  return max_mag;
+}
+
+// roundCellSetAware and roundWithOffset live in rounding.js.
+
+function toNumber(value) {
+  if (typeof value === "number") {
+    return isFinite(value) ? value : null;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    let cleaned = value.trim()
+      .replace(/[‐-―−﹘﹣－]/g, "-")
+      .replace(CLEAN_REGEX, "")
+      .replace(PARENS_REGEX, "-$1");
+    const parsed = Number(cleaned);
+    return isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function validateOffset(offset, paramName) {
+  if (offset < -VALIDATION_LIMIT || offset > VALIDATION_LIMIT) {
+    throw new Error(paramName + " must be between -" + VALIDATION_LIMIT + " and " + VALIDATION_LIMIT + ", got " + offset);
+  }
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -20,6 +20,7 @@
       "js": [
         "defaults.js",
         "rounding.js",
+        "core.js",
         "content.js"
       ]
     }

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -346,6 +346,7 @@
 
   <script src="defaults.js"></script>
   <script src="rounding.js"></script>
+  <script src="core.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -45,8 +45,9 @@ global.Node = { ELEMENT_NODE: 1 };
 // inside the eval'd code so the auto-table-toggle test section can access them.
 const defaultsCode = fs.readFileSync(path.join(__dirname, 'defaults.js'), 'utf8');
 const roundingCode = fs.readFileSync(path.join(__dirname, 'rounding.js'), 'utf8');
+const coreCode = fs.readFileSync(path.join(__dirname, 'core.js'), 'utf8');
 const code = fs.readFileSync(path.join(__dirname, 'content.js'), 'utf8');
-eval(defaultsCode + '\n' + roundingCode + '\n' + code + `
+eval(defaultsCode + '\n' + roundingCode + '\n' + coreCode + '\n' + code + `
 globalThis.DR_DEFAULTS = DR_DEFAULTS;
 // Expose toggle infrastructure for tests
 globalThis.tableToggles = tableToggles;
@@ -1612,10 +1613,11 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     /defaults\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
   eq('sidebar-defaults: sidebar.js applies DR_DEFAULTS to the UI on load',
     /applyDefaultsToUI[\s\S]*DR_DEFAULTS/.test(sidebarJsSource), true);
-  eq('sidebar-defaults: manifest content_scripts loads defaults.js, rounding.js, content.js in order',
+  eq('sidebar-defaults: manifest content_scripts loads defaults.js, rounding.js, core.js, content.js in order',
     manifest.content_scripts[0].js[0] === 'defaults.js' &&
     manifest.content_scripts[0].js[1] === 'rounding.js' &&
-    manifest.content_scripts[0].js[2] === 'content.js', true);
+    manifest.content_scripts[0].js[2] === 'core.js' &&
+    manifest.content_scripts[0].js[3] === 'content.js', true);
 
   // AC3: (sidebar-tidyup) the old "section-heading" with "Include numbers in cells containing:"
   // was removed in the sidebar-tidyup sprint — no replacement test needed here.
@@ -4011,6 +4013,27 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest.json'), 'utf8'));
   eq('manifest content_scripts loads rounding.js between defaults.js and content.js',
     manifest.content_scripts[0].js[1], 'rounding.js');
+})();
+
+// core.js (domain dispatch/coercion layer) must load AFTER rounding.js (whose
+// roundWithOffset it calls) and BEFORE content.js, in all three load points:
+// manifest content_scripts, sidebar.html <script> tags, and this test harness's
+// own eval concatenation. Keep them in lockstep.
+(function coreLoadOrderAcrossEntryPoints() {
+  const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest.json'), 'utf8'));
+  const js = manifest.content_scripts[0].js;
+  eq('manifest content_scripts loads core.js between rounding.js and content.js',
+    js.indexOf('rounding.js') < js.indexOf('core.js') &&
+    js.indexOf('core.js') < js.indexOf('content.js'), true);
+
+  const sidebarHtml = fs.readFileSync(path.join(__dirname, 'sidebar.html'), 'utf8');
+  eq('sidebar.html loads core.js after rounding.js and before sidebar.js',
+    /rounding\.js[\s\S]*core\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
+
+  const testsSource = fs.readFileSync(path.join(__dirname, 'tests.js'), 'utf8');
+  eq('tests.js eval concatenation includes core.js after rounding.js, before content.js',
+    /roundingCode[\s\S]*coreCode[\s\S]*code\b/.test(
+      testsSource.slice(testsSource.indexOf('eval('))), true);
 })();
 
 (function previewBand_sidebarHtmlHasBands() {


### PR DESCRIPTION
## Phase 1: refactor: extract the domain core out of the `content.js` monolith

First step toward making the "isolated core + ports-and-adapters" description actually true. This is a **pure file move — no behavior change.**

### What moved
A new framework-free, side-effect-free `core.js` (no `chrome.*`, no DOM) now holds the dispatch/coercion layer that was inlined in `content.js` under the `// --- Core Algorithm Inlined ---` banner:

- `ROUND_DYNAMIC`, `singleValueMode`, `datasetMode`, `findMaxMagnitude`, `toNumber`, `validateOffset`
- the constants they own: `CLEAN_REGEX`, `PARENS_REGEX`, `DEFAULT_OFFSET_TOP`, `DEFAULT_NUM_TOP`, `VALIDATION_LIMIT`

The arithmetic primitives already lived in `rounding.js`; `core.js` loads **after** `rounding.js` (whose `roundWithOffset` it calls) and **before** `content.js`. Result: a single domain core, isolated from the DOM/UI code and available to both the content script and the side panel.

### Load order kept in lockstep
`core.js` wired into all three entry points:
- `manifest.json` content_scripts
- `sidebar.html` `<script>` tags
- `tests.js` eval concatenation

A new guard test asserts the relative order (`rounding.js` → `core.js` → `content.js`) agrees across all three, so they can't drift.

### Tests
- `node chrome-extension/tests.js` → **951 passed / 0 failed**
- `node js/tests.js` → **158 passed / 0 failed**

### Not in this PR
Splitting the rest of `content.js` into `parsing.js` / `dom-adapters.js` / `ui-toggle.js` is Phase 2.