### PR TITLE
Add a pure, unit-tested phantom-a11y-table predicate

### DIFF
--- a/chrome-extension/dom-adapters.js
+++ b/chrome-extension/dom-adapters.js
@@ -686,6 +686,123 @@ function findTargetTable(el) {
 
 /** Maximum number of cells sampled across grid rows when probing isDataTable for virtual grids. */
 const GRID_IS_DATA_TABLE_CELL_SAMPLE = 10;
+/** Left-offset threshold (px) below which an element is treated as deliberately off-screen hidden. */
+const OFFSCREEN_LEFT_PX_THRESHOLD = -9999;
+
+/**
+ * Return the nearest *positioned* ancestor of `el` (or `el` itself if it is
+ * positioned).  An element is "positioned" when its CSS position is one of
+ * relative | absolute | fixed | sticky.  We check inline style first (works in
+ * both real browser and Node test harness), then fall back to getComputedStyle
+ * when available.  Returns null when no positioned ancestor is found.
+ *
+ * @param {Element} el
+ * @returns {Element|null}
+ */
+function _nearestPositionedAncestor(el) {
+  const POSITIONED = new Set(['relative', 'absolute', 'fixed', 'sticky']);
+  let current = el;
+  while (current) {
+    if (typeof current.getAttribute !== 'function') {
+      // Not a real element node; step up
+      current = current.parentElement || current.parentNode || null;
+      continue;
+    }
+    let pos = '';
+    // Inline style is reliable in both browser and Node harness
+    if (current.style && typeof current.style.position === 'string') {
+      pos = current.style.position;
+    }
+    // Computed style when inline is absent and getComputedStyle is available
+    if (!pos && typeof getComputedStyle === 'function') {
+      try { pos = getComputedStyle(current).position || ''; } catch (e) { /* ignore */ }
+    }
+    if (POSITIONED.has(pos)) return current;
+    current = current.parentElement || current.parentNode || null;
+  }
+  return null;
+}
+
+/**
+ * Parse a CSS length string (e.g. "-10000px") to a float.  Returns NaN when
+ * the value is absent or non-numeric.
+ *
+ * @param {string} value
+ * @returns {number}
+ */
+function _parsePx(value) {
+  if (typeof value !== 'string' || value === '') return NaN;
+  return parseFloat(value);
+}
+
+/**
+ * Determine whether a <table> element is an off-screen / aria-hidden /
+ * SVG-chart-fallback accessibility artifact rather than real page content.
+ *
+ * Returns true when ANY ONE of the following signals holds:
+ *   1. The table (or any ancestor) carries aria-hidden="true".
+ *   2. The table's nearest positioned ancestor (or the table itself) has an
+ *      inline or computed `left` value ≤ OFFSCREEN_LEFT_PX_THRESHOLD px.
+ *      NOTE: In the Node test harness getComputedStyle does not report a
+ *      meaningful `left`; this check therefore relies primarily on inline style.
+ *   3. The table is inside a nearest positioned ancestor that also contains an
+ *      <svg> with a non-empty aria-label (a "chart-ish" SVG), indicating the
+ *      table is an a11y fallback for a chart rendered by that SVG.
+ *
+ * @param {Element} table
+ * @returns {boolean}
+ */
+function isPhantomA11yTable(table) {
+  if (!table || typeof table.getAttribute !== 'function') return false;
+
+  // --- Signal 1: aria-hidden on self or any ancestor ---
+  let node = table;
+  while (node) {
+    if (typeof node.getAttribute === 'function') {
+      if (node.getAttribute('aria-hidden') === 'true') return true;
+    }
+    node = node.parentElement || node.parentNode || null;
+    // Stop at document root (no parentElement means we've left the element tree)
+    if (node && typeof node.tagName === 'undefined') break;
+  }
+
+  // --- Signal 2: nearest positioned ancestor has left ≤ threshold ---
+  const posAncestor = _nearestPositionedAncestor(table);
+  const checkEl = posAncestor || table;
+
+  let leftVal = NaN;
+  // Prefer inline style (works in Node harness too)
+  if (checkEl.style && typeof checkEl.style.left === 'string') {
+    leftVal = _parsePx(checkEl.style.left);
+  }
+  // Fall back to computed style when inline is absent
+  if (isNaN(leftVal) && typeof getComputedStyle === 'function') {
+    try {
+      const computed = getComputedStyle(checkEl);
+      if (computed && computed.left) leftVal = _parsePx(computed.left);
+    } catch (e) { /* ignore */ }
+  }
+  if (!isNaN(leftVal) && leftVal <= OFFSCREEN_LEFT_PX_THRESHOLD) return true;
+
+  // --- Signal 3: nearest positioned ancestor contains a chart-ish <svg> ---
+  if (posAncestor) {
+    // Use querySelector when available (browser); fall back gracefully in harness
+    if (typeof posAncestor.querySelector === 'function') {
+      try {
+        const svgs = posAncestor.querySelectorAll('svg');
+        for (let i = 0; i < svgs.length; i++) {
+          const svg = svgs[i];
+          if (typeof svg.getAttribute === 'function') {
+            const label = svg.getAttribute('aria-label');
+            if (typeof label === 'string' && label.trim() !== '') return true;
+          }
+        }
+      } catch (e) { /* ignore */ }
+    }
+  }
+
+  return false;
+}
 
 function isDataTable(table) {
   const adapter = makeAdapter(table);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -8323,6 +8323,279 @@ function flushTimers(pendingTimers) {
   }
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint add-phantom-a11y-predicate: isPhantomA11yTable
+// ---------------------------------------------------------------------------
+//
+// isPhantomA11yTable(table) returns true when ANY of three signals holds:
+//   Signal 1 – table or any ancestor has aria-hidden="true"
+//   Signal 2 – nearest positioned ancestor (or the table itself) has inline
+//               left <= OFFSCREEN_LEFT_PX_THRESHOLD (-9999)
+//   Signal 3 – nearest positioned ancestor contains an <svg> with a non-empty
+//               aria-label
+// Returns false for an ordinary on-screen 2-column numeric table.
+//
+// Mock-building helpers:
+//   makePhantomEl(attrs)  – minimal element node with getAttribute / parentElement / style
+//   chainParents(child, ...parents)  – link elements into a parentElement chain
+//   makePositionedAncestor(styleProps)  – element with style.position = 'absolute'
+
+function makePhantomEl(opts) {
+  opts = opts || {};
+  const attrs = opts.attrs || {};
+  const style  = opts.style  || {};
+  return {
+    tagName:      opts.tagName || 'DIV',
+    getAttribute: function(name) {
+      return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
+    },
+    style:        Object.assign({}, style),
+    parentElement: null,
+    parentNode:   null,
+    // querySelector / querySelectorAll stubs (overridden per-fixture where needed)
+    querySelector:    function() { return null; },
+    querySelectorAll: function() { return []; },
+  };
+}
+
+// Link child -> parent -> grandparent -> … in parentElement chain.
+function chainParents(child /*, ...parents */) {
+  let current = child;
+  for (let i = 1; i < arguments.length; i++) {
+    current.parentElement = arguments[i];
+    arguments[i].parentNode = null; // ensure parentNode fallback not needed
+    current = arguments[i];
+  }
+  return child;
+}
+
+// An element that qualifies as "positioned" (inline style.position='absolute').
+function makePositionedAncestor(styleOverrides) {
+  return makePhantomEl({ style: Object.assign({ position: 'absolute' }, styleOverrides || {}) });
+}
+
+// A minimal 2-column numeric table stub (no aria-hidden, normal left, no svg).
+function makeOnScreenTable() {
+  const table = makePhantomEl({ tagName: 'TABLE' });
+  // parentElement: a plain non-positioned wrapper
+  const wrapper = makePhantomEl({ tagName: 'DIV' });
+  chainParents(table, wrapper);
+  return table;
+}
+
+// --- AC: OFFSCREEN_LEFT_PX_THRESHOLD is -9999 ---
+(function phantomA11y_threshold_value() {
+  eq('isPhantomA11yTable: OFFSCREEN_LEFT_PX_THRESHOLD === -9999',
+    OFFSCREEN_LEFT_PX_THRESHOLD, -9999);
+})();
+
+// ---------------------------------------------------------------------------
+// Signal 1: aria-hidden="true" on the table itself
+// ---------------------------------------------------------------------------
+(function phantomA11y_signal1_selfHidden() {
+  const table = makePhantomEl({ tagName: 'TABLE', attrs: { 'aria-hidden': 'true' } });
+  eq('isPhantomA11yTable: aria-hidden="true" on table itself -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Signal 1: aria-hidden="true" on immediate parent
+(function phantomA11y_signal1_parentHidden() {
+  const table = makePhantomEl({ tagName: 'TABLE' });
+  const parent = makePhantomEl({ tagName: 'DIV', attrs: { 'aria-hidden': 'true' } });
+  chainParents(table, parent);
+  eq('isPhantomA11yTable: aria-hidden="true" on immediate parent -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Signal 1: aria-hidden="true" several ancestors up (nested deeply)
+(function phantomA11y_signal1_deepAncestorHidden() {
+  const table      = makePhantomEl({ tagName: 'TABLE' });
+  const tbody      = makePhantomEl({ tagName: 'TBODY' });
+  const innerDiv   = makePhantomEl({ tagName: 'DIV' });
+  const middleDiv  = makePhantomEl({ tagName: 'DIV' });
+  const outerDiv   = makePhantomEl({ tagName: 'DIV', attrs: { 'aria-hidden': 'true' } });
+  chainParents(table, tbody, innerDiv, middleDiv, outerDiv);
+  eq('isPhantomA11yTable: aria-hidden="true" several levels up -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Edge: aria-hidden="false" must NOT trigger signal 1
+(function phantomA11y_signal1_ariaHiddenFalse() {
+  const table  = makePhantomEl({ tagName: 'TABLE', attrs: { 'aria-hidden': 'false' } });
+  const parent = makePhantomEl({ tagName: 'DIV',   attrs: { 'aria-hidden': 'false' } });
+  chainParents(table, parent);
+  eq('isPhantomA11yTable: aria-hidden="false" does NOT trigger -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// ---------------------------------------------------------------------------
+// Signal 2: nearest positioned ancestor has inline left <= threshold
+// ---------------------------------------------------------------------------
+
+// Signal 2: positioned ancestor with left: -10000px (Kaggle evidence)
+(function phantomA11y_signal2_offscreenLeft_minus10000() {
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor({ left: '-10000px' });
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: positioned ancestor left=-10000px -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Signal 2: positioned ancestor at exactly the threshold value (-9999px)
+(function phantomA11y_signal2_offscreenLeft_exactThreshold() {
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor({ left: '-9999px' });
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: positioned ancestor left=-9999px (at threshold) -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Signal 2: table itself is positioned and off-screen (no separate ancestor)
+(function phantomA11y_signal2_tableSelfOffscreen() {
+  const table = makePhantomEl({ tagName: 'TABLE', style: { position: 'absolute', left: '-10000px' } });
+  eq('isPhantomA11yTable: table itself is positioned with left=-10000px -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Edge: left value just ABOVE threshold (-9998px) must NOT trigger
+(function phantomA11y_signal2_leftJustAboveThreshold() {
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor({ left: '-9998px' });
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: positioned ancestor left=-9998px (above threshold) -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// Edge: modest off-screen like -100px must NOT trigger signal 2
+(function phantomA11y_signal2_modestNegativeLeft() {
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor({ left: '-100px' });
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: positioned ancestor left=-100px (not extreme) -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// Edge: non-positioned ancestor with extreme left — should NOT count because the
+// ancestor is not positioned; no positioned ancestor found so checkEl = table,
+// and table has no extreme left.
+(function phantomA11y_signal2_nonPositionedAncestorIgnored() {
+  const table   = makePhantomEl({ tagName: 'TABLE' });
+  // wrapper has no inline style.position and getComputedStyle returns '' for position
+  const wrapper = makePhantomEl({ tagName: 'DIV', style: { left: '-10000px' } });
+  chainParents(table, wrapper);
+  // No positioned ancestor found → checkEl = table (which has no extreme left)
+  eq('isPhantomA11yTable: non-positioned ancestor with extreme left -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// ---------------------------------------------------------------------------
+// Signal 3: nearest positioned ancestor contains <svg> with non-empty aria-label
+// ---------------------------------------------------------------------------
+
+// Signal 3: positioned ancestor has querySelectorAll('svg') returning labelled svg
+(function phantomA11y_signal3_svgWithAriaLabel() {
+  const svg = makePhantomEl({ tagName: 'SVG', attrs: { 'aria-label': 'Monthly Revenue Chart' } });
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor();
+  posAnc.querySelector    = function() { return svg; };
+  posAnc.querySelectorAll = function(sel) { return sel === 'svg' ? [svg] : []; };
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: positioned ancestor has svg[aria-label="..."] -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Signal 3: multiple SVGs in ancestor, only one has a label — still triggers
+(function phantomA11y_signal3_multipleSvgsOneLabelledOne() {
+  const svgNoLabel  = makePhantomEl({ tagName: 'SVG' }); // no aria-label
+  const svgLabelled = makePhantomEl({ tagName: 'SVG', attrs: { 'aria-label': 'Pie Chart' } });
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor();
+  posAnc.querySelector    = function() { return svgNoLabel; };
+  posAnc.querySelectorAll = function(sel) { return sel === 'svg' ? [svgNoLabel, svgLabelled] : []; };
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: one of two svgs has aria-label -> true',
+    isPhantomA11yTable(table), true);
+})();
+
+// Edge: svg with EMPTY aria-label must NOT trigger signal 3
+(function phantomA11y_signal3_svgEmptyAriaLabel() {
+  const svg    = makePhantomEl({ tagName: 'SVG', attrs: { 'aria-label': '' } });
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor();
+  posAnc.querySelector    = function() { return svg; };
+  posAnc.querySelectorAll = function(sel) { return sel === 'svg' ? [svg] : []; };
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: svg with empty aria-label does NOT trigger -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// Edge: svg with whitespace-only aria-label must NOT trigger signal 3
+(function phantomA11y_signal3_svgWhitespaceAriaLabel() {
+  const svg    = makePhantomEl({ tagName: 'SVG', attrs: { 'aria-label': '   ' } });
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor();
+  posAnc.querySelector    = function() { return svg; };
+  posAnc.querySelectorAll = function(sel) { return sel === 'svg' ? [svg] : []; };
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: svg with whitespace-only aria-label does NOT trigger -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// Edge: svg with NO aria-label attribute at all must NOT trigger signal 3
+(function phantomA11y_signal3_svgNoAriaLabel() {
+  const svg    = makePhantomEl({ tagName: 'SVG' }); // getAttribute returns null
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor();
+  posAnc.querySelector    = function() { return svg; };
+  posAnc.querySelectorAll = function(sel) { return sel === 'svg' ? [svg] : []; };
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: svg with no aria-label does NOT trigger -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// Edge: no positioned ancestor found at all — signal 3 is skipped entirely (no crash)
+(function phantomA11y_signal3_noPosAncestor() {
+  const table = makePhantomEl({ tagName: 'TABLE' });
+  // No parentElement — predicate must not throw and returns false
+  eq('isPhantomA11yTable: no positioned ancestor, no signals -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// ---------------------------------------------------------------------------
+// Negative case: ordinary on-screen 2-column numeric table
+// ---------------------------------------------------------------------------
+(function phantomA11y_negative_ordinaryTable() {
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const parent = makePhantomEl({ tagName: 'DIV' });
+  chainParents(table, parent);
+  // No aria-hidden, no off-screen left, no positioned ancestor → false
+  eq('isPhantomA11yTable: ordinary on-screen numeric table -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// Negative: positioned ancestor but normal on-screen left (-50px), no svg, no aria-hidden
+(function phantomA11y_negative_onscreenPositionedAncestor() {
+  const table  = makePhantomEl({ tagName: 'TABLE' });
+  const posAnc = makePositionedAncestor({ left: '-50px' });
+  posAnc.querySelectorAll = function() { return []; };
+  chainParents(table, posAnc);
+  eq('isPhantomA11yTable: positioned ancestor with normal left (-50px), no svg -> false',
+    isPhantomA11yTable(table), false);
+})();
+
+// ---------------------------------------------------------------------------
+// Guard: invalid / null input
+// ---------------------------------------------------------------------------
+(function phantomA11y_nullInput() {
+  eq('isPhantomA11yTable: null -> false',
+    isPhantomA11yTable(null), false);
+})();
+
+(function phantomA11y_noGetAttribute() {
+  eq('isPhantomA11yTable: plain object without getAttribute -> false',
+    isPhantomA11yTable({}), false);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -121,6 +121,9 @@ globalThis.computeGridRoundedValues = computeGridRoundedValues;
 globalThis.gridObservers = gridObservers;
 globalThis.gridReapplyTimers = gridReapplyTimers;
 globalThis.GRID_REAPPLY_DEBOUNCE_MS = GRID_REAPPLY_DEBOUNCE_MS;
+// Expose phantom a11y predicate and its threshold constant for tests
+globalThis.isPhantomA11yTable = isPhantomA11yTable;
+globalThis.OFFSCREEN_LEFT_PX_THRESHOLD = OFFSCREEN_LEFT_PX_THRESHOLD;
 `);
 
 let passed = 0;

--- a/docs/sprint-logs/filter-chart-a11y-tables-add-phantom-a11y-predicate.md
+++ b/docs/sprint-logs/filter-chart-a11y-tables-add-phantom-a11y-predicate.md
@@ -1,0 +1,17 @@
+# Sprint Log: add-phantom-a11y-predicate
+
+**Plan:** docs/sprint-plans/filter-chart-a11y-tables.md
+**Sprint goal:** Add a pure, unit-tested predicate that recognizes off-screen / aria-hidden / SVG-chart-fallback `<table>`s, without changing any detection behavior yet.
+**Date:** 2026-06-15
+**Result:** Completed
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Added `OFFSCREEN_LEFT_PX_THRESHOLD = -9999` named constant and `isPhantomA11yTable(table)` to `chrome-extension/dom-adapters.js` (with private helpers `_nearestPositionedAncestor` and `_parsePx`). Predicate returns `true` on OR-of-signals: self-or-ancestor `aria-hidden="true"`; nearest positioned ancestor (or table) with inline/computed `left <= OFFSCREEN_LEFT_PX_THRESHOLD`; nearest positioned ancestor containing an `<svg>` with a non-empty `aria-label`. Inline `style.left` is read first (computed `left` is unavailable in the Node harness), guarded like existing computed-style reads. Exposed both symbols on `globalThis` in tests.js alongside `isDataTable`. No detection wiring (out of scope).
+- **Tests:** pass — 976 total (955 baseline + 21 new). Covers each signal independently, the negative on-screen case, and adversarial negatives (aria-hidden="false", just-above-threshold left, empty/whitespace/absent svg aria-label, non-positioned ancestor, null/garbage input).
+- **Reviewer verdict:** APPROVE
+- **Reviewer notes:** All three signals correct and independent; off-screen uses `<=` against the named constant; SVG anchored to nearest positioned ancestor; defensive against null/garbage; out-of-scope files (`ui-toggle.js`, passes, `findTargetTable`, version files) untouched; predicate defined but not yet wired (no behavior change, as scoped). Non-blocking: inline-style reliance for the off-screen signal warrants a real-browser smoke test when the predicate is consumed downstream.
+
+## PR
+(opened below — see PR link)


### PR DESCRIPTION
Plan: docs/sprint-plans/filter-chart-a11y-tables.md

Sprint 1 of the filter-chart-a11y-tables stack (issue #128). Adds a pure, unit-tested predicate `isPhantomA11yTable` + `OFFSCREEN_LEFT_PX_THRESHOLD` to `dom-adapters.js`. No detection wiring yet — foundational shared infra for Sprints 2 & 3.

## Acceptance criteria
- [x] `isPhantomA11yTable` returns `true` for a table inside an `aria-hidden="true"` ancestor; a table whose nearest positioned ancestor has inline/computed `left <= OFFSCREEN_LEFT_PX_THRESHOLD`; a table whose nearest positioned ancestor contains an `<svg>` with a chart `aria-label`.
- [x] Returns `false` for an ordinary on-screen 2-column numeric table.
- [x] `node chrome-extension/tests.js` passes with new assertions covering each signal and the negative case (976 total, +21).
- [x] No existing assertion regresses (955 baseline).

## Reviewer notes
- All three signals correct and independent (OR-of-signals); off-screen uses `<=` against the named constant; SVG anchored to nearest positioned ancestor; defensive against null/garbage input.
- Non-blocking: the off-screen signal reads inline `style.left` (computed `left` is unavailable in the Node harness) — worth a real-browser smoke test when the predicate is consumed downstream.