### PR TITLE
fix(chrome-extension): filter phantom a11y tables in MutationObserver path (#128)

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -152,6 +152,44 @@ function applySidebarRounding(table, options) {
   syncSwitchForTable(table);
 }
 
+// Detect and attach toggles for tables/grids inside (or equal to) a node added
+// to the DOM. Mirrors injectTableToggles' two passes, including the phantom
+// a11y-table filtering required by issue #128 so dynamically-rendered SPA grids
+// (e.g. Kaggle's Data Explorer) are auto-detected and off-screen chart a11y
+// tables are not. Extracted as a named function so the detection is unit-testable
+// independently of the live MutationObserver wiring below.
+function injectTogglesForAddedNode(node) {
+  if (!node || node.nodeType !== Node.ELEMENT_NODE) return;
+  // Pass 1: native <table> elements; phantom a11y tables are skipped.
+  if (node.tagName === 'TABLE' && !tableToggles.has(node) && !isPhantomA11yTable(node)) {
+    createToggleForTable(node);
+  }
+  if (typeof node.querySelectorAll === 'function') {
+    node.querySelectorAll('table').forEach(table => {
+      if (!tableToggles.has(table) && !isPhantomA11yTable(table)) {
+        createToggleForTable(table);
+      }
+    });
+    // Pass 2: cheap ARIA pass for added nodes — mirror injectTableToggles Pass 2.
+    // A grid that only embeds phantom a11y tables must still be detected.
+    node.querySelectorAll(GRID_ARIA_SELECTOR).forEach(el => {
+      if (el.classList.contains('dr-ext-grid')) return;
+      if (el.tagName === 'TABLE') return;
+      if (Array.from(el.querySelectorAll('table')).some(t => !isPhantomA11yTable(t))) return;
+      el.classList.add('dr-ext-grid');
+      createToggleForTable(el);
+    });
+  }
+  // The added node itself may be a [role="grid"/"table"] non-table element.
+  if (node.tagName !== 'TABLE' && typeof node.matches === 'function' &&
+      node.matches(GRID_ARIA_SELECTOR) && !node.classList.contains('dr-ext-grid')) {
+    if (!Array.from(node.querySelectorAll('table')).some(t => !isPhantomA11yTable(t))) {
+      node.classList.add('dr-ext-grid');
+      createToggleForTable(node);
+    }
+  }
+}
+
 if (typeof MutationObserver !== 'undefined') {
   ensureScrollResizeListeners();
 
@@ -160,33 +198,7 @@ if (typeof MutationObserver !== 'undefined') {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {
         if (node.nodeType !== Node.ELEMENT_NODE) continue;
-        // Pass 1: native <table> elements (unchanged).
-        if (node.tagName === 'TABLE' && !tableToggles.has(node)) {
-          createToggleForTable(node);
-        }
-        if (typeof node.querySelectorAll === 'function') {
-          node.querySelectorAll('table').forEach(table => {
-            if (!tableToggles.has(table)) {
-              createToggleForTable(table);
-            }
-          });
-          // Pass 2: cheap ARIA pass for added nodes — mirror injectTableToggles Pass 2.
-          node.querySelectorAll(GRID_ARIA_SELECTOR).forEach(el => {
-            if (el.classList.contains('dr-ext-grid')) return;
-            if (el.tagName === 'TABLE') return;
-            if (el.querySelector('table')) return;
-            el.classList.add('dr-ext-grid');
-            createToggleForTable(el);
-          });
-        }
-        // The added node itself may be a [role="grid"/"table"] non-table element.
-        if (node.tagName !== 'TABLE' && typeof node.matches === 'function' &&
-            node.matches(GRID_ARIA_SELECTOR) && !node.classList.contains('dr-ext-grid')) {
-          if (!node.querySelector('table')) {
-            node.classList.add('dr-ext-grid');
-            createToggleForTable(node);
-          }
-        }
+        injectTogglesForAddedNode(node);
       }
       for (const node of mutation.removedNodes) {
         if (node.nodeType !== Node.ELEMENT_NODE) continue;

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -72,6 +72,7 @@ globalThis.createToggleForTable = createToggleForTable;
 globalThis.runToggleAction = runToggleAction;
 globalThis.toggleOriginalValues = toggleOriginalValues;
 globalThis.injectTableToggles = injectTableToggles;
+globalThis.injectTogglesForAddedNode = injectTogglesForAddedNode;
 globalThis.isDataTable = isDataTable;
 globalThis.collectNumericCells = collectNumericCells;
 globalThis.extractPreviewSamples = extractPreviewSamples;
@@ -9335,6 +9336,102 @@ function withToggleDocumentMock(fn) {
     gridTable.classList.contains('dr-ext-grid'), false);
   eq('pass2-aria: element with tagName=TABLE does not get a toggle via Pass 2',
     tableToggles.has(gridTable), false);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint observer-phantom-filter (issue #128): MutationObserver added-node path
+// applies the SAME phantom filtering as injectTableToggles.
+//
+// The initial-load fix only touched injectTableToggles(). Kaggle is a React SPA
+// that renders its Data Explorer grid AFTER load, so detection runs through the
+// MutationObserver added-node handler — extracted here as injectTogglesForAddedNode().
+// These tests drive that function directly with element-node stubs.
+// ---------------------------------------------------------------------------
+
+// Helper: turn a makeAriaGrid() result into an added-node stub: it must look
+// like an element node and match GRID_ARIA_SELECTOR via node.matches().
+function asAddedGridNode(grid) {
+  grid.nodeType = global.Node.ELEMENT_NODE;
+  grid.tagName = 'DIV';
+  grid.matches = function(sel) { return sel === '[role="grid"], [role="table"]'; };
+  return grid;
+}
+
+// AC1 (the Kaggle case): an added [role="table"] grid whose ONLY embedded
+// <table>s are phantom chart a11y tables → gets dr-ext-grid + a toggle.
+(function observer_AC1_addedGridOnlyPhantomTables_getsToggle() {
+  const phantom1 = makePhantomEmbeddedTable();
+  const phantom2 = makePhantomEmbeddedTable();
+  const grid = asAddedGridNode(makeAriaGrid([phantom1, phantom2]));
+
+  withToggleDocumentMock(function() {
+    injectTogglesForAddedNode(grid);
+  });
+
+  eq('observer: added grid with only phantom tables gets dr-ext-grid class',
+    grid.classList.contains('dr-ext-grid'), true);
+  eq('observer: added grid with only phantom tables gets a toggle',
+    tableToggles.has(grid), true);
+})();
+
+// AC2: an added grid wrapping a REAL table → observer bows out (no class/toggle
+// on the grid itself; the real embedded table is owned by Pass 1).
+(function observer_AC2_addedGridRealTable_bowsOut() {
+  const realTbl = makePass1DataTable(); // non-phantom, has .rows for isDataTable
+  const grid = asAddedGridNode(makeAriaGrid([realTbl]));
+
+  withToggleDocumentMock(function() {
+    injectTogglesForAddedNode(grid);
+  });
+
+  eq('observer: added grid wrapping a real table does NOT get dr-ext-grid',
+    grid.classList.contains('dr-ext-grid'), false);
+  eq('observer: added grid wrapping a real table does NOT get a toggle',
+    tableToggles.has(grid), false);
+
+  cleanupPass1Tables([realTbl]);
+})();
+
+// AC3: a phantom native <table> reached via querySelectorAll on the added node
+// gets NO toggle (Pass 1 phantom skip in the observer path).
+(function observer_AC3_addedSubtreePhantomTable_noToggle() {
+  const phantom = makePhantomEmbeddedTable();
+  const container = {
+    nodeType: global.Node.ELEMENT_NODE,
+    tagName: 'DIV',
+    classList: { _c: [], add(c){this._c.push(c);}, remove(c){this._c=this._c.filter(x=>x!==c);}, contains(c){return this._c.includes(c);} },
+    matches() { return false; },
+    querySelectorAll(sel) { return sel === 'table' ? [phantom] : []; },
+  };
+
+  withToggleDocumentMock(function() {
+    injectTogglesForAddedNode(container);
+  });
+
+  eq('observer: phantom <table> in added subtree gets NO toggle',
+    tableToggles.has(phantom), false);
+})();
+
+// AC4: a real native <table> reached via querySelectorAll on the added node
+// DOES get a toggle (Pass 1 survivor in the observer path).
+(function observer_AC4_addedSubtreeRealTable_getsToggle() {
+  const realTbl = makePass1DataTable();
+  const container = {
+    nodeType: global.Node.ELEMENT_NODE,
+    tagName: 'DIV',
+    classList: { _c: [], add(c){this._c.push(c);}, remove(c){this._c=this._c.filter(x=>x!==c);}, contains(c){return this._c.includes(c);} },
+    matches() { return false; },
+    querySelectorAll(sel) { return sel === 'table' ? [realTbl] : []; },
+  };
+
+  withToggleDocumentMock(function() {
+    injectTogglesForAddedNode(container);
+  });
+
+  eq('observer: real <table> in added subtree gets a toggle',
+    tableToggles.has(realTbl), true);
+
+  cleanupPass1Tables([realTbl]);
 })();
 
 // --- Report ---


### PR DESCRIPTION
## Summary

Fixes #128. The earlier merges (#135–#137) applied phantom-table filtering only to `injectTableToggles()` — the **initial-load** detection pass. Kaggle's Data Explorer is a React SPA that renders its data grid *after* page load, so detection actually runs through the **MutationObserver added-node handler** in `content.js`, which still used the old logic:

- it created toggles for native `<table>`s without checking `isPhantomA11yTable`, so the 8 off-screen chart a11y tables still got phantom toggles, and
- it bailed out of the ARIA pass on *any* embedded `<table>` (`if (el.querySelector('table')) return;`), so the real `role="table"` grid was skipped because it contains those off-screen chart tables.

This reproduced the reported symptom exactly: the real grid was only detected via right-click (`findTargetTable`), while 8 phantom toggles were appended off-screen.

## Changes

- Extract the observer's added-node detection into a named `injectTogglesForAddedNode()`.
- Apply the same Pass 1 / Pass 2 phantom filtering as `injectTableToggles`: skip phantom tables in the native pass, and let an ARIA grid through when **all** its embedded `<table>`s are phantom.
- Add 6 regression tests driving the observer path directly (the Kaggle "grid with only phantom tables → gets toggle" case, the real-table bow-out case, and Pass 1 phantom-skip / real-keep).

## Testing

`node tests.js` → **1012 passed, 0 failed**.
