### PR TITLE
fix(chrome-extension): detect bare-<tr> ARIA grid rows; scope to rowgroup

### DIFF
--- a/chrome-extension/dom-adapters.js
+++ b/chrome-extension/dom-adapters.js
@@ -147,19 +147,43 @@ class GridAdapter {
 
   /**
    * Extract rows from a container element.
-   * Prefers [role="row"] / .dg--virtual-row; else repetitive children.
+   *
+   * Row source order: [role="row"] → .dg--virtual-row → <tr> → repetitive
+   * children. The <tr> source covers ARIA grids (role="grid"/"table") that
+   * render their rows as bare <tr> elements without role="row" — e.g. Kaggle's
+   * Data Explorer, whose movie rows are orphan <tr> inside the grid.
+   *
+   * Scoping: when the container groups rows in one or more [role="rowgroup"]
+   * elements (the ARIA analog of <tbody>), row discovery is restricted to those
+   * groups. This keeps header rows and per-column summary/stats rows — which
+   * sit OUTSIDE the rowgroup — from being treated as data rows. Both signals are
+   * standard ARIA, so this stays general (not site-specific).
+   *
    * @param {Element} container
    * @returns {Element[]}
    */
   _getRowEls(container) {
     if (!container) return [];
-    // Try ARIA/library rows first
-    let rows = container.querySelectorAll && container.querySelectorAll('[role="row"]');
-    if (rows && rows.length > 0) return Array.from(rows);
-    rows = container.querySelectorAll && container.querySelectorAll('.dg--virtual-row');
-    if (rows && rows.length > 0) return Array.from(rows);
-    // Fallback: repetitive children (direct children only)
-    if (container.children) return Array.from(container.children);
+    if (!container.querySelectorAll) {
+      return container.children ? Array.from(container.children) : [];
+    }
+    // Scope to ARIA rowgroup(s) when present so header/summary rows outside the
+    // group are excluded; otherwise search the whole container.
+    const rowgroups = container.querySelectorAll('[role="rowgroup"]');
+    const scopes = (rowgroups && rowgroups.length > 0)
+      ? Array.from(rowgroups)
+      : [container];
+
+    for (const sel of ['[role="row"]', '.dg--virtual-row', 'tr']) {
+      let rows = [];
+      for (const scope of scopes) {
+        if (scope.querySelectorAll) rows = rows.concat(Array.from(scope.querySelectorAll(sel)));
+      }
+      if (rows.length > 0) return rows;
+    }
+    // Fallback: repetitive children of the first scope.
+    const first = scopes[0];
+    if (first && first.children) return Array.from(first.children);
     return [];
   }
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -9434,6 +9434,97 @@ function asAddedGridNode(grid) {
   cleanupPass1Tables([realTbl]);
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint grid-rowgroup-tr-extraction: GridAdapter._getRowEls handles ARIA grids
+// whose data rows are bare <tr> inside a [role="rowgroup"], with header/summary
+// rows OUTSIDE the rowgroup (e.g. Kaggle's Data Explorer). Standard ARIA only.
+// ---------------------------------------------------------------------------
+
+// Build a <tr>-style row element whose cells are its element children.
+function makeTrRow(cellTexts) {
+  const cellEls = cellTexts.map(makeGridCellWithTextNode);
+  const row = makeElementNode('', cellEls);
+  row.tagName = 'TR';
+  row.children = cellEls;
+  row.querySelectorAll = function(sel) {
+    if (sel === '[role="cell"]' || sel === '.dg--cell') return [];
+    return [];
+  };
+  return row;
+}
+
+// Build a Kaggle-shaped ARIA grid:
+//   grid[role=table]
+//     div[role=row]            ← lone description block (NOT a data row)
+//     div[role=none] > tr(th)  ← header row, OUTSIDE any rowgroup
+//     div[role=none] > tr(td)  ← per-column stats row, OUTSIDE any rowgroup
+//     div[role=rowgroup] > span > tr(td) ...  ← the real data rows
+function makeKaggleLikeGrid(dataRows) {
+  const descRow = makeElementNode('', [makeGridCellWithTextNode('About this file')]);
+  descRow.querySelectorAll = () => [];
+
+  const headerTr = makeTrRow(['Release_Date', 'Popularity', 'Vote_Count']);
+  const statsTr  = makeTrRow(['9515', '9824', '9827']);
+
+  const dataTrs = dataRows.map(makeTrRow);
+  const rowgroup = makeElementNode('', dataTrs);
+  rowgroup.querySelectorAll = function(sel) {
+    if (sel === 'tr') return dataTrs;
+    return []; // no [role="row"] / .dg--virtual-row inside
+  };
+
+  const allTrs = [headerTr, statsTr, ...dataTrs];
+  const wrapper = makeElementNode('grid', [descRow, headerTr, statsTr, rowgroup]);
+  wrapper.tagName = 'DIV';
+  wrapper.matches = () => false;
+  wrapper.querySelector = () => null;
+  wrapper.querySelectorAll = function(sel) {
+    if (sel === '[role="rowgroup"]') return [rowgroup];
+    if (sel === '[role="row"]') return [descRow];
+    if (sel === 'tr') return allTrs;
+    return [];
+  };
+  return wrapper;
+}
+
+(function gridRowgroup_dataRowsOnly() {
+  const grid = makeKaggleLikeGrid([
+    ['2021-12-15', '5083.954', '8940'],
+    ['2022-03-01', '3827.658', '1151'],
+    ['2022-02-25', '2618.087', '122'],
+  ]);
+  const adapter = makeAdapter(grid);
+  const rows = adapter.getRows();
+
+  eq('grid-rowgroup: getRows() returns ONLY the 3 data rows (header/stats/desc excluded)',
+    rows.length, 3);
+  eq('grid-rowgroup: first data row first cell is the date (not "About this file")',
+    rows[0].getCells()[0].getText(), '2021-12-15');
+  eq('grid-rowgroup: data row exposes its numeric cell',
+    rows[0].getCells()[1].getText(), '5083.954');
+  eq('grid-rowgroup: grid with bare-<tr> data rows is a data table',
+    isDataTable(grid), true);
+})();
+
+// Without a rowgroup, bare <tr> rows are still discovered (orphan-tr fallback).
+(function gridOrphanTr_noRowgroup() {
+  const dataTrs = [makeTrRow(['a', '10']), makeTrRow(['b', '20'])];
+  const wrapper = makeElementNode('grid', dataTrs);
+  wrapper.tagName = 'DIV';
+  wrapper.matches = () => false;
+  wrapper.querySelector = () => null;
+  wrapper.querySelectorAll = function(sel) {
+    if (sel === 'tr') return dataTrs;
+    return []; // no rowgroup, no role="row", no dg classes
+  };
+
+  const adapter = makeAdapter(wrapper);
+  eq('grid-orphan-tr: getRows() finds bare <tr> rows when no rowgroup present',
+    adapter.getRows().length, 2);
+  eq('grid-orphan-tr: numeric cell readable',
+    adapter.getRows()[0].getCells()[1].getText(), '10');
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);


### PR DESCRIPTION
## Summary

Fixes the deeper blocker behind the Kaggle Data Explorer not rounding (issue #128 follow-up). Complements the already-merged phantom-a11y-table observer fix (#142): that lets auto-detection *select* the grid; **this** lets `isDataTable` recognize it and rounding target the right rows.

## Root cause

`GridAdapter._getRowEls` only recognized `[role="row"]` / `.dg--virtual-row` rows. Kaggle's grid is `role="table"` but its movie rows are **bare `<tr>` elements with no `role`**, inside `<div role="rowgroup">`. The only `[role="row"]` on the page is the "About this file" description block — so:

- `getRows()` returned a single non-data row,
- `isDataTable()` returned false,
- and every path bailed: no auto-toggle, dead right-click, sidebar stuck on "Right-click a table first."

## Fix

- Add `<tr>` as a row source in `_getRowEls`.
- When the grid groups rows in `[role="rowgroup"]` (the ARIA `<tbody>` analog), scope row discovery to those groups, so the header row and per-column summary/stats rows — which sit **outside** the rowgroup — are not treated as data rows.

Both signals are standard ARIA, so the heuristic stays general (not Kaggle-specific) and is backward-compatible: grids without a rowgroup fall through to the existing behavior.

## Verification

- Full suite: **1018 passed, 0 failed** (6 new tests: rowgroup-scoped extraction + orphan-`<tr>` fallback).
- End-to-end against the real Kaggle markup (jsdom, full extension, live MutationObserver):
  - grid auto-tagged + one toggle; no phantom toggles;
  - only the 5 data rows read (header/stats/description excluded);
  - rounding writes to data cells (`3827.658 → 4,000`), column maxima preserved by design, stats summary numbers (`9515`) untouched.

