### PR TITLE
fix: preview band skips already-round sample values

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -342,6 +342,19 @@ function extractPreviewSamples(table) {
     return { samples: { top: [], bottom: [] }, maxMag: null };
   }
   const numTop = DR_DEFAULTS.numTop || 1;
+  const topOffset = typeof DR_DEFAULTS.offsetTop === 'number' ? DR_DEFAULTS.offsetTop : -0.5;
+  const otherOffset = typeof DR_DEFAULTS.offsetOther === 'number' ? DR_DEFAULTS.offsetOther : -0.5;
+
+  // Reorder a magnitude bucket so cells that visibly *change* under the band's
+  // default offset come first. Picking the raw document-order cell can land on
+  // an already-round value (e.g. 250,000,000 → 250,000,000), making the preview
+  // row look like rounding does nothing. Array.prototype.sort is stable, so
+  // cells with the same "demonstrates rounding" verdict keep document order.
+  const demoFirst = (bucket, offset) => bucket.slice().sort((a, b) => {
+    const ca = roundWithOffset(a.num, offset) !== a.num ? 0 : 1;
+    const cb = roundWithOffset(b.num, offset) !== b.num ? 0 : 1;
+    return ca - cb;
+  });
 
   const byMag = new Map();
   let maxMag = null;
@@ -361,11 +374,11 @@ function extractPreviewSamples(table) {
   const top = [];
   for (const m of topMags) {
     if (top.length >= 2) break;
-    top.push(byMag.get(m)[0]);
+    top.push(demoFirst(byMag.get(m), topOffset)[0]);
   }
   if (top.length < 2 && topMags.length > 0) {
     // Same magnitude has multiple cells — fill from the top bucket.
-    const bucket = byMag.get(topMags[0]);
+    const bucket = demoFirst(byMag.get(topMags[0]), topOffset);
     for (let i = 1; i < bucket.length && top.length < 2; i++) {
       top.push(bucket[i]);
     }
@@ -379,10 +392,10 @@ function extractPreviewSamples(table) {
   const bottom = [];
   for (const m of bottomMags) {
     if (bottom.length >= 3) break;
-    bottom.push(byMag.get(m)[0]);
+    bottom.push(demoFirst(byMag.get(m), otherOffset)[0]);
   }
   if (bottom.length < 3 && bottomMags.length > 0) {
-    const bucket = byMag.get(bottomMags[0]);
+    const bucket = demoFirst(byMag.get(bottomMags[0]), otherOffset);
     for (let i = 1; i < bucket.length && bottom.length < 3; i++) {
       bottom.push(bucket[i]);
     }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -4003,6 +4003,45 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   eq('extractPreviewSamples: bottom[2] is 56', result.samples.bottom[2].num, 56);
 })();
 
+(function previewBand_extractPreviewSamples_prefersDemonstrative() {
+  // Within a magnitude bucket, an already-round value (250,000,000) would make
+  // a useless "X -> X" preview row. extractPreviewSamples should surface a cell
+  // that visibly changes under the default offset instead, even when the
+  // already-round cell appears first in document order.
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [
+      // Top bucket (mag 8): round value first, then a value that changes.
+      { cells: [tdCell('250,000,000'), tdCell('269,690,569')] },
+      // Bottom bucket (mag 5): round value first, then a value that changes.
+      { cells: [tdCell('350,000'), tdCell('235,132')] },
+    ],
+  };
+  const result = extractPreviewSamples(table);
+  eq('extractPreviewSamples (demo): top[0] skips already-round 250M',
+    result.samples.top[0].num, 269690569);
+  eq('extractPreviewSamples (demo): bottom[0] skips already-round 350k',
+    result.samples.bottom[0].num, 235132);
+})();
+
+(function previewBand_extractPreviewSamples_allRoundFallback() {
+  // If every cell in a bucket is already round, fall back to document order
+  // rather than dropping the row.
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [
+      { cells: [tdCell('250,000,000'), tdCell('500,000')] },
+    ],
+  };
+  const result = extractPreviewSamples(table);
+  eq('extractPreviewSamples (all-round): top[0] is first cell',
+    result.samples.top[0].num, 250000000);
+})();
+
 (function previewBand_extractPreviewSamples_largeMagOnly() {
   // All cells in the top magnitude bucket -> bottom band ends up empty.
   function tdCell(text) {


### PR DESCRIPTION
## Problem

In the sidebar preview band, the "before" values already looked rounded — e.g. `250,000,000 → 250,000,000 (50M)`, `20,000,000 → 20,000,000`, `2,000,000 → 2,000,000`. Those rows demonstrate nothing, because the chosen sample is already a clean multiple of the rounding step.

## Cause

`extractPreviewSamples` (`chrome-extension/content.js`) picked the **first** cell in each magnitude bucket (`byMag.get(m)[0]`). On real tables (e.g. an SEC balance sheet), the first cell in a bucket is frequently an already-round figure such as authorized shares (250,000,000), so the preview rendered a useless `X → X` row.

## Fix

Within each bucket, reorder so cells that **visibly change** under the band's default offset surface first, using the shared `roundWithOffset` + `DR_DEFAULTS.offsetTop`/`offsetOther`. The sort is stable so document order is preserved on ties, and if every cell in a bucket is already round it falls back to document order — a row is never dropped.

## Tests

Added two cases (prefers the demonstrative cell over an already-round one; all-round fallback). Full suite: **1021 passed, 0 failed** (`node chrome-extension/tests.js`).
