### PR TITLE
fix: currency-symbol-only cells no longer render as "$0" in simplified state

### DIFF
--- a/chrome-extension/core.js
+++ b/chrome-extension/core.js
@@ -87,6 +87,7 @@ function toNumber(value) {
       .replace(/[‐-―−﹘﹣－]/g, "-")
       .replace(CLEAN_REGEX, "")
       .replace(PARENS_REGEX, "-$1");
+    if (cleaned === "") return null;
     const parsed = Number(cleaned);
     return isFinite(parsed) ? parsed : null;
   }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -373,6 +373,9 @@ eq('extractAll: zero is excluded',
 eq('toNumber: parens with comma', toNumber('(1,234)'), -1234);
 eq('toNumber: empty string returns null', toNumber(''), null);
 eq('toNumber: whitespace only returns null', toNumber('   '), null);
+eq('toNumber: dollar sign only returns null', toNumber('$'), null);
+eq('toNumber: euro sign only returns null', toNumber('€'), null);
+eq('toNumber: currency symbol with spaces returns null', toNumber(' $ '), null);
 
 // --- restoreFormatting roundtrips for common shapes ---
 eq('restoreFormatting: pure integer keeps commas',


### PR DESCRIPTION
## Summary

- `toNumber("$")` was returning `0` because `CLEAN_REGEX` stripped the `$` to `""` and `Number("") === 0` (finite), causing the cell to be classified as `mode:'pure'` with `num:0`
- In simplified state this rendered the formatting-only `<td>` as `"$0"` instead of leaving it unchanged
- Added a one-line guard in `toNumber` (`core.js`): if the cleaned string is empty after stripping formatting characters, return `null` — the cell is skipped rather than treated as zero

## Test plan

- [ ] Three new `toNumber` unit tests added: `"$"`, `"€"`, and `" $ "` all return `null`
- [ ] All 1024 existing tests still pass (`node chrome-extension/tests.js`)
- [ ] On the SEC filing at the linked URL, the `$` cells adjacent to `Cash` (and similar rows) should remain `$` in simplified state, not become `$0`