### PR TITLE
fix: preserve surrounding text when simplifying mixed date cells

### DIFF
--- a/chrome-extension/parsing.js
+++ b/chrome-extension/parsing.js
@@ -188,13 +188,13 @@ function parseDateLike(text) {
   // Boundary-aware: allow surrounding non-word chars but not word chars
   const isoDash = t.match(/(?:^|(?<=[^\w]))(\d{4})-(\d{2})-(\d{2})(?=$|[^\w])/);
   if (isoDash) {
-    return { year: parseInt(isoDash[1], 10), month: parseInt(isoDash[2], 10), day: parseInt(isoDash[3], 10) };
+    return { year: parseInt(isoDash[1], 10), month: parseInt(isoDash[2], 10), day: parseInt(isoDash[3], 10), raw: isoDash[0] };
   }
 
   // ISO slash: YYYY/MM/DD
   const isoSlash = t.match(/(?:^|(?<=[^\w]))(\d{4})\/(\d{2})\/(\d{2})(?=$|[^\w])/);
   if (isoSlash) {
-    return { year: parseInt(isoSlash[1], 10), month: parseInt(isoSlash[2], 10), day: parseInt(isoSlash[3], 10) };
+    return { year: parseInt(isoSlash[1], 10), month: parseInt(isoSlash[2], 10), day: parseInt(isoSlash[3], 10), raw: isoSlash[0] };
   }
 
   // Named-month forms (case-insensitive): Month DD, YYYY
@@ -202,7 +202,7 @@ function parseDateLike(text) {
   const mnMatch = t.match(mnRe);
   if (mnMatch) {
     const month = resolveMonthName(mnMatch[1]);
-    if (month !== null) return { year: parseInt(mnMatch[3], 10), month, day: parseInt(mnMatch[2], 10) };
+    if (month !== null) return { year: parseInt(mnMatch[3], 10), month, day: parseInt(mnMatch[2], 10), raw: mnMatch[0] };
   }
 
   // Day Month Year: 21 June 2020
@@ -210,7 +210,7 @@ function parseDateLike(text) {
   const dmyMatch = t.match(dmyRe);
   if (dmyMatch) {
     const month = resolveMonthName(dmyMatch[2]);
-    if (month !== null) return { year: parseInt(dmyMatch[3], 10), month, day: parseInt(dmyMatch[1], 10) };
+    if (month !== null) return { year: parseInt(dmyMatch[3], 10), month, day: parseInt(dmyMatch[1], 10), raw: dmyMatch[0] };
   }
 
   // Year Month Day: 2020 June 21
@@ -218,7 +218,7 @@ function parseDateLike(text) {
   const ymdMatch = t.match(ymdRe);
   if (ymdMatch) {
     const month = resolveMonthName(ymdMatch[2]);
-    if (month !== null) return { year: parseInt(ymdMatch[1], 10), month, day: parseInt(ymdMatch[3], 10) };
+    if (month !== null) return { year: parseInt(ymdMatch[1], 10), month, day: parseInt(ymdMatch[3], 10), raw: ymdMatch[0] };
   }
 
   // Month Year: Jun 2020
@@ -226,7 +226,7 @@ function parseDateLike(text) {
   const myMatch = t.match(myRe);
   if (myMatch) {
     const month = resolveMonthName(myMatch[1]);
-    if (month !== null) return { year: parseInt(myMatch[2], 10), month, day: 1 };
+    if (month !== null) return { year: parseInt(myMatch[2], 10), month, day: 1, raw: myMatch[0] };
   }
 
   // Bare year: 2020 (1900–2099) — STRICT anchors preserved to avoid false positives
@@ -234,7 +234,7 @@ function parseDateLike(text) {
   const bareYear = t.match(/^(\d{4})$/);
   if (bareYear) {
     const y = parseInt(bareYear[1], 10);
-    if (y >= 1900 && y <= 2099) return { year: y, month: 1, day: 1 };
+    if (y >= 1900 && y <= 2099) return { year: y, month: 1, day: 1, raw: bareYear[0] };
   }
 
   return null;
@@ -281,10 +281,11 @@ function isTimeLike(text) {
  * @returns {string} Always returns a string (the rounded year as digits).
  */
 function roundDateText(text, granularity, prefilled) {
-  const parsed = prefilled || parseDateLike(text);
-  if (!parsed) return text; // fallback: shouldn't happen for mode:'date' cells
+  const parsed = parseDateLike(text);
+  const date = parsed || prefilled;
+  if (!date) return text; // fallback: shouldn't happen for mode:'date' cells
 
-  const { year, month } = parsed;
+  const { year, month } = date;
 
   // fractional = year + 0.5 if month >= 7, else year + 0
   const fractional = year + (month >= 7 ? 0.5 : 0);
@@ -299,8 +300,17 @@ function roundDateText(text, granularity, prefilled) {
     roundedYear = Math.round(fractional);
   }
 
-  const d = new Date(roundedYear, 0, 1);
-  return String(d.getFullYear());
+  const roundedYearStr = String(new Date(roundedYear, 0, 1).getFullYear());
+
+  // When the cell has surrounding text (e.g. "Payment Disbursed on: 2025-04-02"),
+  // replace only the matched date portion rather than the entire cell value.
+  if (parsed && parsed.raw) {
+    const rawIdx = text.indexOf(parsed.raw);
+    if (rawIdx >= 0) {
+      return text.slice(0, rawIdx) + roundedYearStr + text.slice(rawIdx + parsed.raw.length);
+    }
+  }
+  return roundedYearStr;
 }
 
 function roundTimeText(text, granularity) {

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -235,6 +235,11 @@
       margin-top: 12px;
       min-height: 1em;
     }
+    .divider {
+      border: none;
+      border-top: 1px solid #e8eaed;
+      margin: 4px 0;
+    }
   </style>
 </head>
 <body>
@@ -254,6 +259,7 @@
       </label>
       <span class="toggle-label">words</span>
     </div>
+    <hr class="divider">
     <div class="toggle-row">
       <label class="switch">
         <input type="checkbox" id="simplifyMixedCurrency">
@@ -291,6 +297,7 @@
         <option value="minute">minute</option>
       </select>
     </div>
+    <hr class="divider">
     <div class="toggle-row">
       <label class="switch">
         <input type="checkbox" id="simplifyFirstRow">

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -557,10 +557,10 @@ eq('isTimeLike: 12345 -> false', isTimeLike('12345'), false);
 // --- Sprint B: per-type granularity ---
 
 // Date granularity
-// NEW CONTRACT (sprint date-round-to-year-display): roundDateText always returns a
-// 4-digit year string. It no longer returns null or a full date string like
-// "March 14, 2020". The caller (roundTable) compares formattedValue === originalValue
-// to detect the no-op case.
+// CONTRACT: roundDateText replaces only the date portion of the cell text with the
+// rounded year. For pure date cells the result is a 4-digit year string. For mixed
+// cells (label + date) the surrounding text is preserved and only the date is replaced.
+// The caller (roundTable) compares formattedValue === originalValue to detect no-ops.
 eq('roundDateText: year granularity returns a 4-digit year string',
   roundDateText('2018', 'year'), '2018');
 eq('roundDateText: decade rounds bare year 2018 -> 2020',
@@ -577,6 +577,14 @@ eq('roundDateText: unparseable input returns the original text unchanged',
   roundDateText('hello world', 'decade'), 'hello world');
 eq('roundDateText: 2020 at decade granularity still returns "2020" (caller handles no-op)',
   roundDateText('2020', 'decade'), '2020');
+eq('roundDateText: mixed cell preserves label, replaces date (ISO dash, decade)',
+  roundDateText('Payment Disbursed on: 2025-04-02', 'decade'), 'Payment Disbursed on: 2030');
+eq('roundDateText: mixed cell preserves label, replaces date (ISO dash, year)',
+  roundDateText('Due date: 2024-11-15', 'year'), 'Due date: 2025');
+eq('roundDateText: mixed cell preserves label, replaces date (named month, decade)',
+  roundDateText('Filed: March 14, 2024', 'decade'), 'Filed: 2020');
+eq('roundDateText: mixed cell preserves trailing text after date',
+  roundDateText('2024-03-14 (estimated)', 'decade'), '2020 (estimated)');
 
 // Time granularity
 eq('roundTimeText: minute granularity is a no-op',
@@ -2908,8 +2916,8 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 })();
 
 // ---------------------------------------------------------------------------
-// AC4: roundDateText always returns a 4-digit year string, never null.
-// Test via prefilled date objects (bypassing text parsing).
+// AC4: roundDateText returns a 4-digit year string for pure date cells and
+// prefilled date objects. Test via prefilled date objects (bypassing text parsing).
 // ---------------------------------------------------------------------------
 (function dateRoundReturnType() {
   // Boundary: Dec 31 → fractional = year + 0.5 (month=12 >= 7)
@@ -3104,10 +3112,10 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     /function\s+parseDateLike\b/.test(src), true);
   eq('static: parseAmbiguousNumericDate is defined in content.js',
     /function\s+parseAmbiguousNumericDate\b/.test(src), true);
-  eq('static: roundDateText returns string (no null return for parsed dates)',
-    // The function must NOT have "return null" after the parsed guard
-    // (it uses "return text" as fallback for unparseable input).
-    /function roundDateText[\s\S]{0,800}return String\(/.test(src), true);
+  eq('static: roundDateText uses String() conversion for year (no null return for parsed dates)',
+    // The function must use String() to convert the rounded year.
+    // Uses "return text" as fallback for unparseable input.
+    /function roundDateText[\s\S]{0,900}String\(new Date\(/.test(src), true);
 })();
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug fix:** cells containing text + a date (e.g. `"Payment Disbursed on: 2025-04-02"`) were losing the label text and being replaced by just the rounded year (e.g. `"2030"`). The fix preserves surrounding text and replaces only the date portion.
- **How:** `parseDateLike` now returns a `raw` field (the matched date substring). `roundDateText` uses `text.indexOf(raw)` to splice in the rounded year, falling back to the old whole-value return for pure date cells and the prefilled path.
- **UI:** added thin `<hr>` dividers in the sidebar between *words* / *currencies* and *times* / *first row* to visually group the toggle options.

## Test plan

- [x] `node chrome-extension/tests.js` — 1028 passed, 0 failed (4 new mixed-cell tests added)
- [ ] Manually verify `"Payment Disbursed on: 2025-04-02"` → `"Payment Disbursed on: 2030"` in a data grid
- [ ] Verify pure date cells (e.g. `"2024-03-14"`) still simplify to just `"2020"`
- [ ] Verify sidebar dividers render correctly
