### PR TITLE
Align slider thumbs to tick marks (vertical + horizontal)

### DIFF
--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -144,9 +144,10 @@
       height: 4px; background: #d6d9de; border-radius: 999px;
     }
     .dual-ticks {
-      position: absolute; left: 0; right: 0; top: 22px;
+      position: absolute; left: 0; right: 0; top: 20px;
       display: grid; grid-template-columns: repeat(9, 1fr);
       pointer-events: none;
+      /* top: 20px centres each 12px tick (top + 6px) on the thumb centre at 26px */
     }
     .dual-ticks .t {
       height: 12px; width: 2px; background: #b5b9c0;

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -51,9 +51,9 @@ function snap(v) {
 function pct(v) {
   // Map each stop to the centre of its grid cell so thumb centres sit exactly
   // over the tick marks. With 9 equal columns the cell centres fall at
-  // 1/18, 3/18, …, 17/18 of the track width, i.e. pct = ((v+1)/2 * 8 + 1)/9 * 100.
+  // 1/18, 3/18, …, 17/18 of the track width, i.e. pct = ((v+1)/2 * 8 + 0.5)/9 * 100.
   // This places −1 → 5.556% and +1 → 94.444%, matching the tick grid centres.
-  return ((v + 1) / 2 * 8 + 1) / 9 * 100;
+  return ((v + 1) / 2 * 8 + 0.5) / 9 * 100;
 }
 function fmtOffset(o) {
   let s = o.toFixed(2).replace(/\.?0+$/, '');

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -49,8 +49,11 @@ function snap(v) {
   return best;
 }
 function pct(v) {
-  // Map -1 → 0%, +1 → 100%.
-  return ((v + 1) / 2) * 100;
+  // Map each stop to the centre of its grid cell so thumb centres sit exactly
+  // over the tick marks. With 9 equal columns the cell centres fall at
+  // 1/18, 3/18, …, 17/18 of the track width, i.e. pct = ((v+1)/2 * 8 + 1)/9 * 100.
+  // This places −1 → 5.556% and +1 → 94.444%, matching the tick grid centres.
+  return ((v + 1) / 2 * 8 + 1) / 9 * 100;
 }
 function fmtOffset(o) {
   let s = o.toFixed(2).replace(/\.?0+$/, '');

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -9575,6 +9575,119 @@ function makeKaggleLikeGrid(dataRows) {
     adapter.getRows()[0].getCells()[1].getText(), '10');
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint dots-tick-alignment: pct() mapping and CSS vertical alignment
+// ---------------------------------------------------------------------------
+
+(function sprintDotsTickAlignment() {
+  const sidebarJsSrc = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
+  const sidebarHtmlSrc = fs.readFileSync(path.join(__dirname, 'sidebar.html'), 'utf8');
+
+  // --- Extract pct() from sidebar.js and instantiate it for runtime testing ---
+  // We locate the function body with a regex (same pattern used elsewhere for
+  // source-level extraction) and wrap it in a new Function so we can call it.
+  const pctMatch = sidebarJsSrc.match(/function pct\(v\)\s*\{([\s\S]*?)\n\}/);
+  if (!pctMatch) {
+    failed++;
+    failures.push({ name: 'dots-tick: pct() function found in sidebar.js', actual: false, expected: true });
+  } else {
+    passed++;
+    const pct = new Function('v', pctMatch[1]);
+
+    // The 9 stops in order (k=0..8):
+    const stops = [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+    const TOL = 1e-6;
+
+    // AC1a: Each stop maps to the centre of its grid cell in a 9-equal-column grid.
+    // Cell k centre = (k + 0.5) / 9 * 100.
+    stops.forEach((v, k) => {
+      const expected = (k + 0.5) / 9 * 100;
+      const actual = pct(v);
+      const ok = Math.abs(actual - expected) < TOL;
+      if (ok) {
+        passed++;
+      } else {
+        failed++;
+        failures.push({
+          name: `dots-tick: pct(${v}) === cell-${k}-centre (${expected.toFixed(6)}%)`,
+          actual: actual,
+          expected: expected,
+        });
+      }
+    });
+
+    // AC1b: Key exact values — extremes and centre.
+    const pctNeg1 = pct(-1);
+    const pctZero = pct(0);
+    const pctPos1 = pct(1);
+
+    eq('dots-tick: pct(-1) ≈ 5.5556% (1st cell centre)',
+      Math.abs(pctNeg1 - 100/18) < TOL, true);
+    eq('dots-tick: pct(0) === 50% (centre cell)',
+      pctZero, 50);
+    eq('dots-tick: pct(1) ≈ 94.4444% (9th cell centre)',
+      Math.abs(pctPos1 - 100*17/18) < TOL, true);
+
+    // AC1c: old formula (v+1)/2*100 must NOT produce these values at the extremes.
+    // If the old formula were still in use, pct(-1) would be 0 and pct(1) would be
+    // 100 — verify the new formula does NOT produce those.
+    eq('dots-tick: pct(-1) is NOT 0 (old formula would give 0)',
+      pct(-1) !== 0, true);
+    eq('dots-tick: pct(1) is NOT 100 (old formula would give 100)',
+      pct(1) !== 100, true);
+
+    // AC2: Monotonic — pct is strictly increasing across all 9 stops.
+    let monotonic = true;
+    for (let i = 1; i < stops.length; i++) {
+      if (pct(stops[i]) <= pct(stops[i - 1])) { monotonic = false; break; }
+    }
+    eq('dots-tick: pct() is strictly increasing across all 9 stops', monotonic, true);
+
+    // AC3: Symmetric — pct(-v) + pct(v) === 100 for all non-zero stops.
+    // Use tolerance for float arithmetic.
+    const symStops = [-0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1];
+    let symmetric = true;
+    for (const v of symStops) {
+      if (Math.abs(pct(-v) + pct(v) - 100) > TOL) { symmetric = false; break; }
+    }
+    eq('dots-tick: pct(-v) + pct(v) === 100 (symmetric about 50%)', symmetric, true);
+  }
+
+  // --- AC4: 9-column grid assumption — verify tick markup matches formula ---
+  // The pct formula assumes 9 equal columns. Adversarial check: count the actual
+  // tick spans and verify the CSS declares exactly repeat(9, 1fr).
+  const tickSpans = (sidebarHtmlSrc.match(/class="t"/g) || []).length;
+  eq('dots-tick: .dual-ticks contains exactly 9 tick spans (matches pct() formula)',
+    tickSpans, 9);
+
+  eq('dots-tick: .dual-ticks CSS uses repeat(9, 1fr) grid',
+    /\.dual-ticks\s*\{[^}]*grid-template-columns\s*:\s*repeat\(9,\s*1fr\)/.test(sidebarHtmlSrc), true);
+
+  // --- AC5: Vertical CSS — .dual-ticks uses top: 20px (not 22px) ---
+  eq('dots-tick: .dual-ticks CSS top is 20px',
+    /\.dual-ticks\s*\{[^}]*top:\s*20px/.test(sidebarHtmlSrc), true);
+
+  eq('dots-tick: .dual-ticks CSS top is NOT 22px (old value)',
+    /\.dual-ticks\s*\{[^}]*top:\s*22px/.test(sidebarHtmlSrc), false);
+
+  // --- AC6: pct() is only used for thumb positioning (not for fill/label/other) ---
+  // Adversarial: if pct() were wired to a range-fill width or label position, the
+  // non-0/100 extremes would produce a visually broken fill. Verify here that all
+  // pct() call sites in sidebar.js are limited to style.left on thumbs.
+  // Use a negative lookbehind to exclude the function definition itself.
+  const pctCallSites = sidebarJsSrc.match(/(?<!function )pct\([^)]+\)/g) || [];
+  // Every call site should appear only inside thumb left-position assignments.
+  // We check there are exactly 2 call sites (topThumb and botThumb style.left).
+  eq('dots-tick: pct() is called exactly twice in sidebar.js (both thumb style.left)',
+    pctCallSites.length, 2);
+
+  // Both call sites must be inside a style.left assignment.
+  const thumbLeftPattern = /\.style\.left\s*=\s*pct\(/g;
+  const thumbLeftMatches = (sidebarJsSrc.match(thumbLeftPattern) || []).length;
+  eq('dots-tick: both pct() calls are style.left assignments (not fill/label)',
+    thumbLeftMatches, 2);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/docs/sprint-logs/sidebar-ux-sprint-dots-tick-alignment.md
+++ b/docs/sprint-logs/sidebar-ux-sprint-dots-tick-alignment.md
@@ -1,0 +1,25 @@
+# Sprint Log: dots-tick-alignment
+
+**Plan:** docs/sprint-plans/sidebar-ux-sprint.md
+**Sprint goal:** The slider dot/thumb positions align exactly over the corresponding tick marks.
+**Date:** 2026-06-23
+**Result:** Completed (approved on attempt 2)
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Vertical — `.dual-ticks` `top: 22px` → `20px` (tick centre now 26px = thumb centre). Horizontal — changed `pct(v)` to map the 9 STOPs to the 9 grid-cell centres (`repeat(9,1fr)` grid).
+- **Tests:** test-writer (extracting the real `pct` from source) caught an off-by-one — the formula used `+ 1` instead of `+ 0.5`, giving `pct(-1)=11.11%`, `pct(1)=100%` instead of the cell centres `5.5556%`/`94.4444%`. 14 tests failed. The developer's own comment contradicted the code.
+- **Verdict:** BLOCK (off-by-one).
+
+### Attempt 2
+- **Developer:** Changed `+ 1` → `+ 0.5` in `pct()` and aligned the comment. Vertical change retained.
+- **Tests:** pass — 1051 passed, 0 failed.
+- **Reviewer verdict:** APPROVE — independently verified all 9 stops land on grid-cell centres (`pct(0)===50`, symmetry `pct(-v)+pct(v)===100`); vertical geometry exact (tick centre 20+6 = 26px = thumb centre); `pct()` used only for the two thumb `style.left` assignments (no range-fill/label inconsistency); drag/snap uses its own linear pixel→value inverse, unaffected by pct's changed range.
+
+## PR
+(see PR link in stack summary)
+
+## Reviewer notes (non-blocking)
+- A test asserts `pct()` is called exactly twice — tight coupling that a future third use would trip. FYI.
+- The centre tick (nth-child(5)) is 14px vs 12px and top-anchored, so its centre is at 27px not 26px — purely cosmetic and pre-existing; tick-height changes are out of scope.


### PR DESCRIPTION
Plan: docs/sprint-plans/sidebar-ux-sprint.md

## Acceptance criteria
- [x] At every stop (−1, −0.75, …, +1) the centre of the blue top thumb sits directly above the corresponding tick mark
- [x] The bot thumb, when linked, also sits on a tick
- [x] Alignment holds at the extremes (−1, +1) and centre (0)
- [x] Existing tests pass (1051 passed, 0 failed)

## Reviewer notes
- Approved on attempt 2. Attempt 1 had an off-by-one in the `pct()` tick-centre formula (`+1` vs `+0.5`), caught by failing tests. Final formula maps the 9 STOPs to the 9 grid-cell centres; vertical change `.dual-ticks top:22px→20px` makes the tick centre (26px) coincide with the thumb centre. `pct()` is used only for the two thumb `style.left` assignments; drag/snap is unaffected.