### PR TITLE
Redesign advanced preview bands: strategy header, OoM labels, descending order, colour coding

### DIFF
--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -200,6 +200,10 @@
     .results-band .arrow { color: #5f6368; text-align: center; }
     .results-band .num { color: #202124; text-align: right; }
     .results-band .step { color: #5f6368; text-align: left; }
+    .results-band .step.top { color: #1a73e8; }
+    .results-band .step.bot { color: #b3623d; }
+    .results-band .oom-label { color: #b3623d; }
+    .results-band .strategy { color: #1a73e8; grid-column: 1 / -1; font-style: italic; }
     .results-band .empty {
       color: #80868b;
       font-style: italic;

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -173,37 +173,48 @@ function formatOomLabel(mag) {
  * Build the strategy header string for the top band.
  * e.g. "100k+ → nearest 25k (i.e. a quarter of 100k)"
  *
- * The "i.e." clause is derived by computing step/oomVal as a fraction and
- * expressing it as a human-readable ratio of the OoM value.
+ * The "i.e." clause is derived by computing step/oomVal (the ratio of the step
+ * to the OoM magnitude) and looking it up in STRATEGY_RATIO_PHRASES.  The ratio
+ * is drawn from the fixed slider-stop set {0.1, 0.25, 0.5, 0.75, 1, 2.5, 5,
+ * 7.5, 10} regardless of maxMag, so a direct lookup is both correct and simple.
+ *
+ * When ratio == 1 (step equals the OoM) the clause is omitted entirely.
+ * When ratio is not in the table (fallback) the clause is also omitted.
  */
 function formatStrategyHeader(maxMag, offset) {
+  // Lookup table: step/oomVal ratio → "(i.e. …)" clause phrase builder.
+  // Matched with tolerance 1e-9 since these are clean binary floats.
+  const STRATEGY_RATIO_PHRASES = [
+    { ratio: 0.1,  phrase: (b) => 'a tenth of ' + b },
+    { ratio: 0.25, phrase: (b) => 'a quarter of ' + b },
+    { ratio: 0.5,  phrase: (b) => 'a half of ' + b },
+    { ratio: 0.75, phrase: (b) => 'three quarters of ' + b },
+    // ratio == 1: clause omitted — not listed here.
+    { ratio: 2.5,  phrase: (b) => '2.5× ' + b },
+    { ratio: 5,    phrase: (b) => '5× ' + b },
+    { ratio: 7.5,  phrase: (b) => '7.5× ' + b },
+    { ratio: 10,   phrase: (b) => '10× ' + b },
+  ];
   const oomLabel = formatOomLabel(maxMag);
   const oomVal = Math.pow(10, maxMag);
   // Use the representative top value (oomVal itself) to compute the step.
   const step = stepForOffset(oomVal, offset);
   const stepLabel = formatStep(step);
-  // Derive the "i.e. a <fraction> of <oom>" clause.
-  // ratio = oomVal / step: how many steps fit in one OoM.
-  const ratio = oomVal / step;
-  let fractionStr;
-  if (ratio <= 1) {
-    // step >= oomVal: e.g. ratio=0.5 → "twice" or use multiplier language
-    fractionStr = trimNum(ratio) + ' of';
-  } else {
-    // step < oomVal: e.g. ratio=4 → "a quarter of", ratio=2 → "a half of",
-    //               ratio=10 → "a tenth of", ratio=5 → "a fifth of".
-    const denom = Math.round(ratio);
-    const ordinals = {
-      2: 'half', 3: 'third', 4: 'quarter', 5: 'fifth',
-      6: 'sixth', 7: 'seventh', 8: 'eighth', 9: 'ninth', 10: 'tenth',
-    };
-    if (ordinals[denom]) {
-      fractionStr = 'a ' + ordinals[denom] + ' of';
-    } else {
-      fractionStr = '1/' + denom + ' of';
+  // ratio = step / oomVal: how large the step is relative to the OoM.
+  const ratio = step / oomVal;
+  // OoM label without the trailing "+" for use inside the clause.
+  const oomBare = oomLabel.replace(/\+$/, '');
+  // Look up the phrase for this ratio.
+  let clausePhrase = null;
+  for (const entry of STRATEGY_RATIO_PHRASES) {
+    if (Math.abs(ratio - entry.ratio) < 1e-9) {
+      clausePhrase = entry.phrase(oomBare);
+      break;
     }
   }
-  return oomLabel + ' → nearest ' + stepLabel + ' (i.e. ' + fractionStr + ' ' + formatStep(oomVal) + ')';
+  // ratio == 1 (or any unmatched ratio): omit the "(i.e. …)" clause entirely.
+  const base = oomLabel + ' → nearest ' + stepLabel;
+  return clausePhrase ? base + ' (i.e. ' + clausePhrase + ')' : base;
 }
 
 /**

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -141,20 +141,150 @@ function formatOriginal(numOrStr) {
   return sign + intStr + '.' + fracStr;
 }
 
-function renderBand(el, rows, offset) {
-  if (!el) return;
-  if (!rows || rows.length === 0) {
-    el.innerHTML = '';
-    return;
+// CSS class name constants for band colouring.
+const STEP_CLASS_TOP = 'step top';
+const STEP_CLASS_BOT = 'step bot';
+const OOM_LABEL_CLASS = 'oom-label';
+const STRATEGY_CLASS = 'strategy';
+
+/**
+ * Return a human-readable OoM label for a given magnitude (floor(log10(|n|))).
+ * Examples: mag=5 → "100k+", mag=3 → "1k+", mag=0 → "1+", mag=-1 → "0.1+"
+ */
+function formatOomLabel(mag) {
+  const val = Math.pow(10, mag);
+  let str;
+  if (val >= 1e9) {
+    str = trimNum(val / 1e9) + 'B';
+  } else if (val >= 1e6) {
+    str = trimNum(val / 1e6) + 'M';
+  } else if (val >= 1e3) {
+    str = trimNum(val / 1e3) + 'k';
+  } else if (val >= 1) {
+    str = trimNum(val);
+  } else {
+    // Sub-integer magnitudes: e.g. mag=-1 → 0.1, mag=-2 → 0.01
+    str = trimNum(val);
   }
+  return str + '+';
+}
+
+/**
+ * Build the strategy header string for the top band.
+ * e.g. "100k+ → nearest 25k (i.e. a quarter of 100k)"
+ *
+ * The "i.e." clause is derived by computing step/oomVal as a fraction and
+ * expressing it as a human-readable ratio of the OoM value.
+ */
+function formatStrategyHeader(maxMag, offset) {
+  const oomLabel = formatOomLabel(maxMag);
+  const oomVal = Math.pow(10, maxMag);
+  // Use the representative top value (oomVal itself) to compute the step.
+  const step = stepForOffset(oomVal, offset);
+  const stepLabel = formatStep(step);
+  // Derive the "i.e. a <fraction> of <oom>" clause.
+  // ratio = oomVal / step: how many steps fit in one OoM.
+  const ratio = oomVal / step;
+  let fractionStr;
+  if (ratio <= 1) {
+    // step >= oomVal: e.g. ratio=0.5 → "twice" or use multiplier language
+    fractionStr = trimNum(ratio) + ' of';
+  } else {
+    // step < oomVal: e.g. ratio=4 → "a quarter of", ratio=2 → "a half of",
+    //               ratio=10 → "a tenth of", ratio=5 → "a fifth of".
+    const denom = Math.round(ratio);
+    const ordinals = {
+      2: 'half', 3: 'third', 4: 'quarter', 5: 'fifth',
+      6: 'sixth', 7: 'seventh', 8: 'eighth', 9: 'ninth', 10: 'tenth',
+    };
+    if (ordinals[denom]) {
+      fractionStr = 'a ' + ordinals[denom] + ' of';
+    } else {
+      fractionStr = '1/' + denom + ' of';
+    }
+  }
+  return oomLabel + ' → nearest ' + stepLabel + ' (i.e. ' + fractionStr + ' ' + formatStep(oomVal) + ')';
+}
+
+/**
+ * Render the top preview band: strategy header row followed by a single
+ * example row. Step labels are coloured blue (STEP_CLASS_TOP).
+ */
+function renderTopBand(el, rows, offset) {
+  if (!el) return;
   el.innerHTML = '';
-  for (const row of rows) {
+  if (!rows || rows.length === 0) return;
+
+  // Strategy header: spans all 4 grid columns.
+  if (cachedMaxMag !== null && cachedMaxMag !== undefined) {
+    const headerPair = document.createElement('div');
+    headerPair.className = 'pair';
+    const headerEl = document.createElement('span');
+    headerEl.className = STRATEGY_CLASS;
+    headerEl.textContent = formatStrategyHeader(cachedMaxMag, offset);
+    headerPair.appendChild(headerEl);
+    el.appendChild(headerPair);
+  }
+
+  // Single example row (PREVIEW_NUM_TOP = 1).
+  const row = rows[0];
+  const pair = document.createElement('div');
+  pair.className = 'pair';
+
+  const from = document.createElement('span');
+  from.className = 'from';
+  from.textContent = formatOriginal(row.original);
+  pair.appendChild(from);
+
+  const arrow = document.createElement('span');
+  arrow.className = 'arrow';
+  arrow.textContent = '→';
+  pair.appendChild(arrow);
+
+  const numEl = document.createElement('span');
+  numEl.className = 'num';
+  numEl.textContent = formatOriginal(roundWithOffset(row.num, offset));
+  pair.appendChild(numEl);
+
+  const stepEl = document.createElement('span');
+  stepEl.className = STEP_CLASS_TOP;
+  stepEl.textContent = '(' + formatStep(stepForOffset(row.num, offset)) + ')';
+  pair.appendChild(stepEl);
+
+  el.appendChild(pair);
+}
+
+/**
+ * Render the bottom preview band: rows sorted DESCENDING by magnitude,
+ * each showing the original with an OoM label and the step in brown.
+ */
+function renderBotBand(el, rows, offset, maxMag) {
+  if (!el) return;
+  el.innerHTML = '';
+  if (!rows || rows.length === 0) return;
+
+  // Sort descending by OoM magnitude so higher-magnitude rows appear first.
+  const sorted = rows.slice().sort((a, b) => {
+    const magA = a.num !== 0 ? Math.floor(Math.log10(Math.abs(a.num))) : -Infinity;
+    const magB = b.num !== 0 ? Math.floor(Math.log10(Math.abs(b.num))) : -Infinity;
+    return magB - magA;
+  });
+
+  for (const row of sorted) {
     const pair = document.createElement('div');
     pair.className = 'pair';
 
+    // "from" cell: "266,453 (100k+)" where the OoM label is brown.
     const from = document.createElement('span');
     from.className = 'from';
     from.textContent = formatOriginal(row.original);
+    if (row.num !== 0) {
+      const mag = Math.floor(Math.log10(Math.abs(row.num)));
+      const oomSpan = document.createElement('span');
+      oomSpan.className = OOM_LABEL_CLASS;
+      oomSpan.textContent = ' (' + formatOomLabel(mag) + ')';
+      from.appendChild(oomSpan);
+    }
     pair.appendChild(from);
 
     const arrow = document.createElement('span');
@@ -164,14 +294,11 @@ function renderBand(el, rows, offset) {
 
     const numEl = document.createElement('span');
     numEl.className = 'num';
-    const rounded = roundWithOffset(row.num, offset);
-    // Use the same noise-free formatting path as the `from` cell so both
-    // display values behave identically per the preview spec.
-    numEl.textContent = formatOriginal(rounded);
+    numEl.textContent = formatOriginal(roundWithOffset(row.num, offset));
     pair.appendChild(numEl);
 
     const stepEl = document.createElement('span');
-    stepEl.className = 'step';
+    stepEl.className = STEP_CLASS_BOT;
     stepEl.textContent = '(' + formatStep(stepForOffset(row.num, offset)) + ')';
     pair.appendChild(stepEl);
 
@@ -182,12 +309,12 @@ function renderBand(el, rows, offset) {
 function renderPreviewBands() {
   if (!topBandEl || !botBandEl) return;
   if (!cachedSamples) {
-    renderBand(topBandEl, null);
-    renderBand(botBandEl, null);
+    topBandEl.innerHTML = '';
+    botBandEl.innerHTML = '';
     return;
   }
-  renderBand(topBandEl, cachedSamples.top, topVal);
-  renderBand(botBandEl, cachedSamples.bottom, botVal);
+  renderTopBand(topBandEl, cachedSamples.top, topVal);
+  renderBotBand(botBandEl, cachedSamples.bottom, botVal, cachedMaxMag);
 }
 
 function fetchPreviewSamples() {

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -9968,6 +9968,102 @@ function makeKaggleLikeGrid(dataRows) {
   })();
 
   // -------------------------------------------------------------------------
+  // AC2-ALL-STOPS: All 9 slider stops × 2 maxMag values.
+  // For each stop we independently derive step/stepLabel via the real
+  // stepForOffset/formatStep so the assertions are spec-arithmetic-derived,
+  // not copied from implementation output.  The human phrase fragments are
+  // hardcoded because those ARE the spec contract.
+  //
+  // Stops: offset ∈ {-1, -0.75, -0.5, -0.25, 0, +0.25, +0.5, +0.75, +1}
+  //   offset -1   → ratio 0.1   → "a tenth of"
+  //   offset -0.75→ ratio 0.75  → "three quarters of"
+  //   offset -0.5 → ratio 0.5   → "a half of"
+  //   offset -0.25→ ratio 0.25  → "a quarter of"
+  //   offset  0   → ratio 1     → no "(i.e." clause
+  //   offset +0.25→ ratio 2.5   → "2.5×"
+  //   offset +0.5 → ratio 5     → "5×"
+  //   offset +0.75→ ratio 7.5   → "7.5×"
+  //   offset +1   → ratio 10    → "10×"
+  // -------------------------------------------------------------------------
+  (function hdrAllStops() {
+    const stops = [
+      { offset: -1,    phrase: 'a tenth of',       hasClause: true  },
+      { offset: -0.75, phrase: 'three quarters of', hasClause: true  },
+      { offset: -0.5,  phrase: 'a half of',         hasClause: true  },
+      { offset: -0.25, phrase: 'a quarter of',      hasClause: true  },
+      { offset:  0,    phrase: null,                hasClause: false },
+      { offset:  0.25, phrase: '2.5×',          hasClause: true  },
+      { offset:  0.5,  phrase: '5×',            hasClause: true  },
+      { offset:  0.75, phrase: '7.5×',          hasClause: true  },
+      { offset:  1,    phrase: '10×',           hasClause: true  },
+    ];
+
+    // Test against TWO different maxMag values to confirm maxMag-independence of phrases.
+    const testMags = [6, 5]; // 1M and 100k
+
+    for (const mag of testMags) {
+      const oomVal = Math.pow(10, mag);
+      const oomLabel = fmtOom(mag);                  // e.g. "1M+" or "100k+"
+      const oomBare  = oomLabel.replace(/\+$/, ''); // e.g. "1M"  or "100k"
+
+      for (const stop of stops) {
+        const tag = 'AC2-ALL mag=' + mag + ' offset=' + stop.offset;
+        const step      = stepForOffset(oomVal, stop.offset);
+        const stepLabel = formatStep(step);
+        const header    = fmtHdr(mag, stop.offset);
+
+        // 1. Header always starts with "<oomLabel> →" (with the "+").
+        eq(tag + ': header contains oomLabel "' + oomLabel + '"',
+          header.includes(oomLabel), true);
+
+        // 2. Header always contains "→".
+        eq(tag + ': header contains arrow "→"',
+          header.includes('→'), true);
+
+        // 3. Header always contains "nearest <stepLabel>" using REAL stepForOffset.
+        eq(tag + ': header contains "nearest ' + stepLabel + '"',
+          header.includes('nearest ' + stepLabel), true);
+
+        // 4a. Clause presence / absence.
+        if (stop.hasClause) {
+          eq(tag + ': header contains "(i.e."',
+            header.includes('(i.e.'), true);
+          // 4b. The specific human phrase must appear.
+          eq(tag + ': header contains phrase "' + stop.phrase + '"',
+            header.includes(stop.phrase), true);
+          // 4c. The phrase must reference the bare OoM label (no trailing "+").
+          eq(tag + ': phrase references oomBare "' + oomBare + '"',
+            header.includes(oomBare), true);
+        } else {
+          // offset=0 → ratio=1 → clause omitted entirely.
+          eq(tag + ': offset=0 → no "(i.e." clause',
+            header.includes('(i.e.'), false);
+        }
+      }
+    }
+  })();
+
+  // -------------------------------------------------------------------------
+  // AC2-NO-GARBLE: None of the 9 outputs for any of the two test mags should
+  // contain known garbled fragments from the old broken implementation.
+  // -------------------------------------------------------------------------
+  (function hdrNoGarble() {
+    const allOffsets = [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+    const testMags   = [6, 5];
+    const badPatterns = ['1/1', '0.1 of', '0.133', 'NaN', 'undefined'];
+
+    for (const mag of testMags) {
+      for (const offset of allOffsets) {
+        const header = fmtHdr(mag, offset);
+        for (const bad of badPatterns) {
+          eq('AC2-NO-GARBLE mag=' + mag + ' offset=' + offset + ': no "' + bad + '"',
+            header.includes(bad), false);
+        }
+      }
+    }
+  })();
+
+  // -------------------------------------------------------------------------
   // AC3: renderBotBand DESCENDING sort by magnitude.
   // Extract renderBotBand from sidebar.js, provide DOM stubs, call with rows
   // in ASCENDING order, assert rendered order is DESCENDING.

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -9935,12 +9935,11 @@ function makeKaggleLikeGrid(dataRows) {
     eq('AC2-C: header contains "a quarter of"', header.includes('a quarter of'), true);
   })();
 
-  // Scenario D (adversarial): maxMag=6, offset=-0.75 → step=750k, ratio≈1.333
-  // Math.round(1.333)=1, ordinals[1] is undefined → emits "1/1 of" which is
-  // garbled/wrong. This scenario exposes a bug in the "(i.e.)" clause when the
-  // ratio is not a clean integer.  The test asserts the ACTUAL behaviour so
-  // CI notices if the bug is fixed (test will fail and should be updated) or
-  // if the garbled output persists.
+  // Scenario D: maxMag=6, offset=-0.75 → step=750k, ratio = step/oom = 0.75.
+  // The direct ratio→phrase lookup emits the correct "three quarters of 1M"
+  // clause. (This previously regressed to a garbled "1/1 of" when the clause
+  // was derived via Math.round of an inverted ratio — guarded here so it
+  // can't come back.)
   (function hdrScenarioD_adversarial() {
     const maxMag = 6; const offset = -0.75;
     const oomVal = Math.pow(10, maxMag);        // 1000000

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -9809,6 +9809,392 @@ function makeKaggleLikeGrid(dataRows) {
      fmtOrig(49.99995), '49.9999');
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint advanced-preview-redesign
+// AC1: formatOomLabel exhaustive suffix-boundary check
+// AC2: formatStrategyHeader structure + "(i.e. …)" clause correctness
+// AC3: renderBotBand DESCENDING sort (real DOM-stub eval)
+// AC4: step-label CSS classes (step top / step bot)
+// Adversarial: sort-mutation side-effect check
+// ---------------------------------------------------------------------------
+(function advancedPreviewRedesignTests() {
+  const sidebarSrc = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
+  const roundingSrc = fs.readFileSync(path.join(__dirname, 'rounding.js'), 'utf8');
+
+  // -------------------------------------------------------------------------
+  // Extract formatOomLabel and formatStrategyHeader from sidebar.js source.
+  // They depend on trimNum (from rounding.js), stepForOffset and formatStep
+  // (also rounding.js).  We pass them as parameters to new Function.
+  // -------------------------------------------------------------------------
+  const constBlock = sidebarSrc.match(
+    /const STEP_CLASS_TOP\s*=[\s\S]*?const STRATEGY_CLASS\s*=.*?;/
+  );
+  const formatOomLabelFn = sidebarSrc.match(
+    /function formatOomLabel\([\s\S]*?\n\}/
+  );
+  const formatStrategyHeaderFn = sidebarSrc.match(
+    /function formatStrategyHeader\([\s\S]*?\n\}/
+  );
+
+  if (!constBlock || !formatOomLabelFn || !formatStrategyHeaderFn) {
+    eq('sidebar-ap-extract: able to extract formatOomLabel + formatStrategyHeader', false, true);
+    return;
+  }
+
+  // Build a helper bundle: rounding helpers + sidebar functions.
+  // stepForOffset, formatStep, trimNum come from rounding.js (already evaled
+  // into the test scope's globalThis; we pass them in to avoid scope issues).
+  const apHelperSrc = '(function(trimNum, stepForOffset, formatStep) {\n' +
+    constBlock[0] + '\n' +
+    formatOomLabelFn[0] + '\n' +
+    formatStrategyHeaderFn[0] + '\n' +
+    'return { formatOomLabel: formatOomLabel, formatStrategyHeader: formatStrategyHeader };\n' +
+    '})(trimNum, stepForOffset, formatStep)';
+
+  let apHelpers;
+  try {
+    apHelpers = (new Function('trimNum', 'stepForOffset', 'formatStep',
+      'return ' + apHelperSrc + ';'
+    ))(trimNum, stepForOffset, formatStep);
+  } catch (e) {
+    eq('sidebar-ap-extract: new Function eval succeeded', false, true);
+    return;
+  }
+
+  const fmtOom = apHelpers.formatOomLabel;
+  const fmtHdr = apHelpers.formatStrategyHeader;
+
+  eq('ap-extract: formatOomLabel is a function', typeof fmtOom, 'function');
+  eq('ap-extract: formatStrategyHeader is a function', typeof fmtHdr, 'function');
+
+  // -------------------------------------------------------------------------
+  // AC1: Exhaustive formatOomLabel mapping for mag = 9,8,7,6,5,4,3,2,1,0,-1,-2
+  // Expected values derived from the spec pattern (10^mag with k/M/B suffix),
+  // NOT from reading the implementation.
+  // -------------------------------------------------------------------------
+  // Suffix boundaries: mag 9 → 1B+, mag 6 → 1M+, mag 3 → 1k+
+  eq('AC1-oom: mag=9 → "1B+" (1e9 boundary)', fmtOom(9), '1B+');
+  eq('AC1-oom: mag=8 → "100M+" (within B range, 1e8=100M)', fmtOom(8), '100M+');
+  eq('AC1-oom: mag=7 → "10M+" (within M range, 1e7=10M)', fmtOom(7), '10M+');
+  eq('AC1-oom: mag=6 → "1M+" (1e6 boundary)', fmtOom(6), '1M+');
+  eq('AC1-oom: mag=5 → "100k+" (within k range, 1e5=100k)', fmtOom(5), '100k+');
+  eq('AC1-oom: mag=4 → "10k+" (within k range, 1e4=10k)', fmtOom(4), '10k+');
+  eq('AC1-oom: mag=3 → "1k+" (1e3 boundary)', fmtOom(3), '1k+');
+  eq('AC1-oom: mag=2 → "100+" (1e2, no suffix)', fmtOom(2), '100+');
+  eq('AC1-oom: mag=1 → "10+" (1e1, no suffix)', fmtOom(1), '10+');
+  eq('AC1-oom: mag=0 → "1+" (1e0=1, no suffix)', fmtOom(0), '1+');
+  eq('AC1-oom: mag=-1 → "0.1+" (sub-unit, 1e-1=0.1)', fmtOom(-1), '0.1+');
+  eq('AC1-oom: mag=-2 → "0.01+" (sub-unit, 1e-2=0.01)', fmtOom(-2), '0.01+');
+
+  // -------------------------------------------------------------------------
+  // AC2: formatStrategyHeader structure and "(i.e. …)" clause correctness.
+  // We compute the expected step independently via stepForOffset/formatStep.
+  // -------------------------------------------------------------------------
+
+  // Scenario A: maxMag=5, offset=-0.5 → step=50k, ratio=2 → "a half of"
+  // stepForOffset(1e5, -0.5): f=0.5, target_mag=5+ceil(-0.5)=5+0=5, step=0.5*1e5=50000
+  (function hdrScenarioA() {
+    const maxMag = 5; const offset = -0.5;
+    const oomLabel = '100k+';
+    const oomVal = Math.pow(10, maxMag);       // 100000
+    const step = stepForOffset(oomVal, offset); // 50000
+    const stepLabel = formatStep(step);         // '50k'
+    const oomStepLabel = formatStep(oomVal);   // '100k'
+    const header = fmtHdr(maxMag, offset);
+    eq('AC2-A: header contains oom label (100k+)', header.includes(oomLabel), true);
+    eq('AC2-A: header contains arrow →', header.includes('→'), true);
+    eq('AC2-A: header contains "nearest ' + stepLabel + '"', header.includes('nearest ' + stepLabel), true);
+    eq('AC2-A: header contains "(i.e."', header.includes('(i.e.'), true);
+    // ratio=2 → "a half of" (ordinal mapping)
+    eq('AC2-A: header contains "a half of"', header.includes('a half of'), true);
+    eq('AC2-A: header references oom step label (' + oomStepLabel + ')',
+      header.includes(oomStepLabel), true);
+  })();
+
+  // Scenario B: maxMag=3, offset=-0.5 → step=500, ratio=2 → "a half of"
+  (function hdrScenarioB() {
+    const maxMag = 3; const offset = -0.5;
+    const oomLabel = '1k+';
+    const oomVal = Math.pow(10, maxMag);
+    const step = stepForOffset(oomVal, offset); // 500
+    const stepLabel = formatStep(step);         // '500'
+    const header = fmtHdr(maxMag, offset);
+    eq('AC2-B: header contains oom label (1k+)', header.includes(oomLabel), true);
+    eq('AC2-B: header contains "nearest ' + stepLabel + '"', header.includes('nearest ' + stepLabel), true);
+    eq('AC2-B: header contains "a half of"', header.includes('a half of'), true);
+  })();
+
+  // Scenario C: maxMag=5, offset=-0.25 → step=25k, ratio=4 → "a quarter of"
+  (function hdrScenarioC() {
+    const maxMag = 5; const offset = -0.25;
+    const oomVal = Math.pow(10, maxMag);
+    const step = stepForOffset(oomVal, offset); // 25000
+    const stepLabel = formatStep(step);         // '25k'
+    const header = fmtHdr(maxMag, offset);
+    eq('AC2-C: header contains "nearest ' + stepLabel + '"', header.includes('nearest ' + stepLabel), true);
+    eq('AC2-C: header contains "a quarter of"', header.includes('a quarter of'), true);
+  })();
+
+  // Scenario D (adversarial): maxMag=6, offset=-0.75 → step=750k, ratio≈1.333
+  // Math.round(1.333)=1, ordinals[1] is undefined → emits "1/1 of" which is
+  // garbled/wrong. This scenario exposes a bug in the "(i.e.)" clause when the
+  // ratio is not a clean integer.  The test asserts the ACTUAL behaviour so
+  // CI notices if the bug is fixed (test will fail and should be updated) or
+  // if the garbled output persists.
+  (function hdrScenarioD_adversarial() {
+    const maxMag = 6; const offset = -0.75;
+    const oomVal = Math.pow(10, maxMag);        // 1000000
+    const step = stepForOffset(oomVal, offset); // 750000
+    const ratio = oomVal / step;                // ~1.333
+    const denom = Math.round(ratio);            // 1
+    const header = fmtHdr(maxMag, offset);
+    // The "(i.e.)" clause with ratio≈1.333 rounds denom to 1, which is NOT in
+    // ordinals; the fallback emits "1/1 of" which is mathematically wrong.
+    // We assert the actual emission so a regression or fix is caught.
+    eq('AC2-D-adversarial: ratio=1.333 → fallback "1/1 of" emitted (BUG MARKER)',
+      header.includes('1/1 of'), true);
+    // Also confirm step label is present
+    eq('AC2-D-adversarial: header contains "nearest 750k"', header.includes('nearest 750k'), true);
+  })();
+
+  // Scenario E: offset=0 (integer) → step=oomVal, ratio=1 ≤ 1 → "1 of"
+  (function hdrScenarioE() {
+    const maxMag = 2; const offset = 0;
+    const oomVal = Math.pow(10, maxMag); // 100
+    const step = stepForOffset(oomVal, offset); // 100
+    const stepLabel = formatStep(step);          // '100'
+    const header = fmtHdr(maxMag, offset);
+    eq('AC2-E: offset=0 header contains "nearest ' + stepLabel + '"',
+      header.includes('nearest ' + stepLabel), true);
+    // ratio=1, ratio<=1 branch: trimNum(1)+' of' = '1 of'
+    eq('AC2-E: offset=0 ratio=1 → "1 of" clause', header.includes('1 of'), true);
+  })();
+
+  // -------------------------------------------------------------------------
+  // AC3: renderBotBand DESCENDING sort by magnitude.
+  // Extract renderBotBand from sidebar.js, provide DOM stubs, call with rows
+  // in ASCENDING order, assert rendered order is DESCENDING.
+  // Also check for sort-mutation side-effect on the caller's array.
+  // -------------------------------------------------------------------------
+  const renderBotBandFn = sidebarSrc.match(
+    /function renderBotBand\([\s\S]*?\n\}/
+  );
+  const renderTopBandFn = sidebarSrc.match(
+    /function renderTopBand\([\s\S]*?\n\}/
+  );
+
+  if (!renderBotBandFn || !renderTopBandFn) {
+    eq('sidebar-ap-extract: able to extract renderBotBand + renderTopBand', false, true);
+    return;
+  }
+
+  // Build a minimal DOM stub sufficient for renderBotBand.
+  // We collect appended children in order so we can inspect the render sequence.
+  function makeEl(tag) {
+    const children = [];
+    const el = {
+      _tag: tag,
+      _children: children,
+      _classNames: [],
+      className: '',
+      textContent: '',
+      innerHTML: '',
+      appendChild(child) { children.push(child); return child; },
+      set className(v) { this._classNames.push(v); },
+      get className() { return this._classNames[this._classNames.length - 1] || ''; },
+    };
+    return el;
+  }
+
+  // Collect elements appended to the band container in order.
+  function makeBandEl() {
+    const appended = [];
+    return {
+      _appended: appended,
+      innerHTML: '',
+      appendChild(child) { appended.push(child); return child; },
+    };
+  }
+
+  // Stub document.createElement for the eval scope.
+  const stubDocument = {
+    createElement(tag) { return makeEl(tag); }
+  };
+
+  // Extract the sidebar consts and render functions + their helpers.
+  // We need: STEP_CLASS_TOP/BOT, OOM_LABEL_CLASS, STRATEGY_CLASS,
+  //          formatOomLabel, formatStrategyHeader, renderTopBand, renderBotBand.
+  // External deps we pass in: formatOriginal, roundWithOffset, stepForOffset,
+  //                            formatStep, cachedMaxMag (null = no strategy header).
+  const renderSrc = '(function(document, formatOriginal, roundWithOffset, stepForOffset, formatStep, trimNum, cachedMaxMag) {\n' +
+    constBlock[0] + '\n' +
+    formatOomLabelFn[0] + '\n' +
+    formatStrategyHeaderFn[0] + '\n' +
+    renderTopBandFn[0] + '\n' +
+    renderBotBandFn[0] + '\n' +
+    'return { renderBotBand: renderBotBand, renderTopBand: renderTopBand };\n' +
+    '})';
+
+  let renderHelpers;
+  try {
+    // We need formatOriginal from the already-evaled sidebar helpers.
+    // However, formatOriginal in sidebar.js depends on toNumber (from content.js,
+    // already on globalThis). Extract it from sidebar.js source.
+    const sidebarConstBlock2 = sidebarSrc.match(
+      /const PREVIEW_DECIMAL_THRESHOLD\s*=.*?;\s*const PREVIEW_MAX_DECIMALS\s*=.*?;/
+    );
+    const fmtCommasFn2 = sidebarSrc.match(/function formatNumberWithCommas\([\s\S]*?\n\}/);
+    const formatOriginalFn2 = sidebarSrc.match(/function formatOriginal\([\s\S]*?\n\}/);
+
+    const fmtOrigSrc = '(function(toNumber) {\n' +
+      sidebarConstBlock2[0] + '\n' +
+      fmtCommasFn2[0] + '\n' +
+      formatOriginalFn2[0] + '\n' +
+      'return formatOriginal;\n' +
+      '})(toNumber)';
+    const realFormatOriginal = (new Function('toNumber', 'return ' + fmtOrigSrc + ';'))(toNumber);
+
+    renderHelpers = (new Function(
+      'document', 'formatOriginal', 'roundWithOffset', 'stepForOffset',
+      'formatStep', 'trimNum', 'cachedMaxMag',
+      'return ' + renderSrc + '(document, formatOriginal, roundWithOffset, stepForOffset, formatStep, trimNum, cachedMaxMag);'
+    ))(stubDocument, realFormatOriginal, roundWithOffset, stepForOffset, formatStep, trimNum, null);
+  } catch (e) {
+    eq('sidebar-ap-extract: renderBotBand eval succeeded', String(e), '');
+    return;
+  }
+
+  const realRenderBotBand = renderHelpers.renderBotBand;
+  const realRenderTopBand = renderHelpers.renderTopBand;
+
+  eq('ap-extract: renderBotBand is a function', typeof realRenderBotBand, 'function');
+  eq('ap-extract: renderTopBand is a function', typeof realRenderTopBand, 'function');
+
+  // Rows fed in ASCENDING magnitude order: 50 (mag=1), 500 (mag=2), 5000 (mag=3), 50000 (mag=4)
+  const rowsAscending = [
+    { num: 50,    original: '50' },
+    { num: 500,   original: '500' },
+    { num: 5000,  original: '5,000' },
+    { num: 50000, original: '50,000' },
+  ];
+  // Deep-copy original array reference so we can check mutation.
+  const originalArray = rowsAscending.slice();
+
+  const bandEl = makeBandEl();
+  realRenderBotBand(bandEl, rowsAscending, -0.5, 4);
+
+  // The band container should have 4 "pair" div children.
+  eq('AC3-sort: renderBotBand appended 4 pair elements', bandEl._appended.length, 4);
+
+  // Each pair div contains children: from-span, arrow-span, num-span, step-span.
+  // The from-span's textContent reflects the original number.
+  // We can extract the rendered order by reading from-span textContent on each pair.
+  function getFromText(pairEl) {
+    // first child is the "from" span
+    return pairEl._children[0] ? pairEl._children[0].textContent : '';
+  }
+
+  const renderedFromTexts = bandEl._appended.map(getFromText);
+  // Expected descending order: 50,000 first, then 5,000, 500, 50
+  eq('AC3-sort: first rendered row is highest magnitude (50,000)',
+    renderedFromTexts[0], '50,000');
+  eq('AC3-sort: second rendered row is next (5,000)',
+    renderedFromTexts[1], '5,000');
+  eq('AC3-sort: third rendered row (500)',
+    renderedFromTexts[2], '500');
+  eq('AC3-sort: fourth rendered row is lowest magnitude (50)',
+    renderedFromTexts[3], '50');
+
+  // -------------------------------------------------------------------------
+  // Adversarial: sort-mutation check.
+  // renderBotBand uses rows.slice().sort(...) which must NOT mutate the caller's
+  // array. If it sorts in place, cachedSamples would be corrupted across renders.
+  // -------------------------------------------------------------------------
+  eq('AC3-mutation: renderBotBand does NOT mutate caller rows[0] (still 50 after render)',
+    rowsAscending[0].num, 50);
+  eq('AC3-mutation: renderBotBand does NOT mutate caller rows[3] (still 50000 after render)',
+    rowsAscending[3].num, 50000);
+  // Belt-and-suspenders: the entire original order is preserved.
+  const originalNums = originalArray.map(r => r.num);
+  const afterNums = rowsAscending.map(r => r.num);
+  eq('AC3-mutation: full array order unchanged after renderBotBand',
+    afterNums, originalNums);
+
+  // -------------------------------------------------------------------------
+  // AC3-edge: zero rows and null el guard
+  // -------------------------------------------------------------------------
+  const emptyEl = makeBandEl();
+  realRenderBotBand(emptyEl, [], -0.5, 0);
+  eq('AC3-edge: empty rows renders nothing', emptyEl._appended.length, 0);
+
+  realRenderBotBand(null, rowsAscending, -0.5, 4); // should not throw
+  eq('AC3-edge: null el is a no-op (no throw)', true, true);
+
+  // -------------------------------------------------------------------------
+  // AC4: step-label CSS classes.
+  // Bottom band: step span uses STEP_CLASS_BOT = 'step bot'.
+  // Top band: step span uses STEP_CLASS_TOP = 'step top'.
+  // -------------------------------------------------------------------------
+
+  // AC4a: bottom band step class
+  function getStepClassName(pairEl) {
+    // fourth child (index 3) is the step span
+    return pairEl._children[3] ? pairEl._children[3].className : '';
+  }
+  const botBandEl2 = makeBandEl();
+  realRenderBotBand(botBandEl2, [{ num: 1000, original: '1,000' }], -0.5, 3);
+  eq('AC4-bot: step span has class "step bot"',
+    getStepClassName(botBandEl2._appended[0]), 'step bot');
+
+  // AC4b: top band step class (only the example row, not the strategy header pair).
+  // renderTopBand with cachedMaxMag=null skips the strategy header, so appended[0]
+  // is the example pair.
+  const topBandEl2 = makeBandEl();
+  realRenderTopBand(topBandEl2, [{ num: 100000, original: '100,000' }], -0.5);
+  // Without cachedMaxMag (null in our eval context) there is no header pair,
+  // so appended[0] is the example row pair.
+  eq('AC4-top: top band appended at least one pair element',
+    topBandEl2._appended.length >= 1, true);
+  const topExamplePair = topBandEl2._appended[topBandEl2._appended.length - 1];
+  eq('AC4-top: step span in top example row has class "step top"',
+    getStepClassName(topExamplePair), 'step top');
+
+  // AC4c: source-level constant values are correct (structural)
+  eq('AC4-src: STEP_CLASS_TOP constant is "step top" in source',
+    /const STEP_CLASS_TOP\s*=\s*['"]step top['"]/.test(sidebarSrc), true);
+  eq('AC4-src: STEP_CLASS_BOT constant is "step bot" in source',
+    /const STEP_CLASS_BOT\s*=\s*['"]step bot['"]/.test(sidebarSrc), true);
+  eq('AC4-src: OOM_LABEL_CLASS constant is "oom-label" in source',
+    /const OOM_LABEL_CLASS\s*=\s*['"]oom-label['"]/.test(sidebarSrc), true);
+  eq('AC4-src: STRATEGY_CLASS constant is "strategy" in source',
+    /const STRATEGY_CLASS\s*=\s*['"]strategy['"]/.test(sidebarSrc), true);
+
+  // AC4d: oom-label span is appended inside the from-span for non-zero rows.
+  const oomLabelBandEl = makeBandEl();
+  realRenderBotBand(oomLabelBandEl, [{ num: 5000, original: '5,000' }], -0.5, 3);
+  const fromSpan = oomLabelBandEl._appended[0]._children[0];
+  eq('AC4-oom-label: from-span has oom-label child appended',
+    fromSpan._children.length >= 1, true);
+  eq('AC4-oom-label: oom-label child has class "oom-label"',
+    fromSpan._children[0] ? fromSpan._children[0].className : '', 'oom-label');
+  eq('AC4-oom-label: oom-label text contains "(1k+)"',
+    fromSpan._children[0] ? fromSpan._children[0].textContent.includes('1k+') : false, true);
+
+  // -------------------------------------------------------------------------
+  // AC5: renderBand removed, renderTopBand + renderBotBand present in source
+  // -------------------------------------------------------------------------
+  eq('AC5-structure: renderBand is removed from sidebar.js source',
+    /function renderBand\b/.test(sidebarSrc), false);
+  eq('AC5-structure: renderTopBand is defined in sidebar.js source',
+    /function renderTopBand\b/.test(sidebarSrc), true);
+  eq('AC5-structure: renderBotBand is defined in sidebar.js source',
+    /function renderBotBand\b/.test(sidebarSrc), true);
+  eq('AC5-structure: renderPreviewBands calls renderTopBand',
+    /renderTopBand\(/.test(sidebarSrc), true);
+  eq('AC5-structure: renderPreviewBands calls renderBotBand',
+    /renderBotBand\(/.test(sidebarSrc), true);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -9945,19 +9945,16 @@ function makeKaggleLikeGrid(dataRows) {
     const maxMag = 6; const offset = -0.75;
     const oomVal = Math.pow(10, maxMag);        // 1000000
     const step = stepForOffset(oomVal, offset); // 750000
-    const ratio = oomVal / step;                // ~1.333
-    const denom = Math.round(ratio);            // 1
+    // ratio = step/oomVal = 0.75 → "three quarters of 1M"
     const header = fmtHdr(maxMag, offset);
-    // The "(i.e.)" clause with ratio≈1.333 rounds denom to 1, which is NOT in
-    // ordinals; the fallback emits "1/1 of" which is mathematically wrong.
-    // We assert the actual emission so a regression or fix is caught.
-    eq('AC2-D-adversarial: ratio=1.333 → fallback "1/1 of" emitted (BUG MARKER)',
-      header.includes('1/1 of'), true);
+    // Fixed: direct ratio→phrase lookup emits the correct clause.
+    eq('AC2-D: ratio=0.75 → "three quarters of" emitted',
+      header.includes('three quarters of'), true);
     // Also confirm step label is present
     eq('AC2-D-adversarial: header contains "nearest 750k"', header.includes('nearest 750k'), true);
   })();
 
-  // Scenario E: offset=0 (integer) → step=oomVal, ratio=1 ≤ 1 → "1 of"
+  // Scenario E: offset=0 (integer) → step=oomVal, ratio=1 → clause omitted
   (function hdrScenarioE() {
     const maxMag = 2; const offset = 0;
     const oomVal = Math.pow(10, maxMag); // 100
@@ -9966,8 +9963,8 @@ function makeKaggleLikeGrid(dataRows) {
     const header = fmtHdr(maxMag, offset);
     eq('AC2-E: offset=0 header contains "nearest ' + stepLabel + '"',
       header.includes('nearest ' + stepLabel), true);
-    // ratio=1, ratio<=1 branch: trimNum(1)+' of' = '1 of'
-    eq('AC2-E: offset=0 ratio=1 → "1 of" clause', header.includes('1 of'), true);
+    // ratio=1: "(i.e. …)" clause is omitted entirely.
+    eq('AC2-E: offset=0 ratio=1 → no "(i.e." clause', header.includes('(i.e.'), false);
   })();
 
   // -------------------------------------------------------------------------

--- a/docs/sprint-logs/sidebar-ux-sprint-advanced-preview-redesign.md
+++ b/docs/sprint-logs/sidebar-ux-sprint-advanced-preview-redesign.md
@@ -1,0 +1,31 @@
+# Sprint Log: advanced-preview-redesign
+
+**Plan:** docs/sprint-plans/sidebar-ux-sprint.md
+**Sprint goal:** Restyle the advanced preview bands: colour step/OoM labels blue (top) or brown (bottom); top-band strategy header instead of a second example; OoM labels on bottom-band originals; fix ordering so lower-OoM rows never appear above higher-OoM rows.
+**Date:** 2026-06-23
+**Result:** Completed (approved on attempt 2)
+
+## Attempts
+
+### Attempt 1
+- **Developer:** Split `renderBand` into `renderTopBand`/`renderBotBand`; added `formatOomLabel`, `formatStrategyHeader`; bottom band sorts descending by OoM (`rows.slice().sort`, non-mutating) and appends brown `.oom-label` spans; step classes `step top`/`step bot`; `.strategy` header span (blue, `grid-column:1/-1`). Reused `formatOriginal` from sprint 5.
+- **Tests:** test-writer caught a real defect — `formatStrategyHeader` emitted a correct "(i.e. …)" clause for only 3 of the 9 slider stops.
+- **Reviewer verdict:** BLOCK — enumerated all 9 stops: `offset -0.75` produced the false `"1/1 of 1M"` (it's three-quarters), and all four positive offsets inverted the fraction (`"0.1 of 1M"` etc.). `cachedMaxMag` is populated in production, so the garbled header ships.
+
+### Attempt 2
+- **Developer:** Replaced the `Math.round(oomVal/step)`-into-ordinals logic with `ratio = step/oomVal` matched against a fixed `STRATEGY_RATIO_PHRASES` lookup over the 9 slider-stop ratios {0.1,0.25,0.5,0.75,1,2.5,5,7.5,10}; ratio==1 and unmatched ratios omit the clause; the clause's OoM label drops the trailing "+". Verified across all 9 offsets.
+- **Tests:** test-writer added all-9-stops × 2-maxMag coverage + no-garble guards (steps computed via real `stepForOffset`/`formatStep`, phrases hardcoded as the spec contract). 1332 passed, 0 failed.
+- **Reviewer verdict:** APPROVE — independently verified the 9-offset outputs at maxMag 6 and 5, leading "+" vs bare clause label, no garble fragments, steps matching independent computation; AC2/AC3/AC4 and `formatOomLabel` boundaries intact.
+
+## Post-review fix-forward
+- Replaced a stale comment block in tests.js (Scenario D) that still described the old `1/1 of` bug. Comment-only, suite stays green (1332 passed).
+
+## PR
+(see PR link in stack summary)
+
+## Reviewer notes (non-blocking)
+- `formatOomLabel`'s sub-integer `else` branch duplicates the `val >= 1` branch (`trimNum(val)`) — harmless, pre-existing style.
+- `cachedMaxMag === 0` is a valid magnitude and correctly passes the `renderTopBand` guard (no falsy-zero bug).
+
+## Note on base
+This sprint branches off `feature/advanced-number-format` (sprint 5), per the no-wait-for-merge rule. Its PR targets that branch and will auto-retarget to `main` after sprint 5's PR merges.


### PR DESCRIPTION
Plan: docs/sprint-plans/sidebar-ux-sprint.md

> Base is `feature/advanced-number-format` (sprint 5, PR #158) because this sprint depends on it. It will auto-retarget to `main` once #158 merges.

## Acceptance criteria
- [x] Top band: first line is the strategy header in blue (e.g. `100k+ → nearest 25k (i.e. a quarter of 100k)`); the single example row below is default/grey
- [x] Bottom band: each row shows `[original w/ commas] ([OoM+]) → [rounded] ([step])` with OoM labels brown
- [x] Bottom-band rows appear in descending OoM order (highest magnitude first)
- [x] Step labels blue in the top band, brown in the bottom band
- [x] Existing tests pass (1332 passed, 0 failed)

## Reviewer notes
- Approved on attempt 2. Attempt 1 was BLOCKED: `formatStrategyHeader` produced a correct "(i.e. …)" clause for only 3 of the 9 slider stops (`-0.75` → garbled "1/1 of 1M"; the four positive offsets inverted the fraction). The fix replaced the `Math.round`-into-ordinals logic with `ratio = step/oom` matched against a fixed `STRATEGY_RATIO_PHRASES` lookup; `ratio == 1` and unmatched ratios omit the clause. Verified across all 9 offsets at two magnitudes, with no-garble guards.