### PR TITLE
Clean up advanced "largest numbers" preview text

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -328,7 +328,13 @@ function collectNumericCells(table) {
     const cells = row.getCells();
     for (const cellObj of cells) {
       if (cellObj.tagName !== 'TD') continue;
-      const text = cellObj.getText();
+      // Issue #2: when the table is already simplified, read the stored original
+      // rather than the rounded text now showing in the cell. Native-table rounded
+      // cells stash it on dataset.originalValue; grid cells already return their
+      // pre-round text from getText() (dataset.drOriginal).
+      const cellEl = cellObj.el;
+      const storedOriginal = cellEl && cellEl.dataset ? cellEl.dataset.originalValue : undefined;
+      const text = storedOriginal !== undefined ? storedOriginal : cellObj.getText();
       const trimmed = typeof text === 'string' ? text.trim() : '';
       if (!trimmed) continue;
       if (isDateLike(trimmed) || isTimeLike(trimmed)) continue;
@@ -338,7 +344,10 @@ function collectNumericCells(table) {
         out.push({ text: trimmed, num });
       } else {
         const extracted = extractNumbersInText(trimmed);
-        for (const { num: extractedNum } of extracted) {
+        for (const { num: extractedNum, numStr, index } of extracted) {
+          // Issue #4: era-marked years (e.g. "2898 AD") are dates, not numbers —
+          // exclude them from magnitude detection and the preview examples.
+          if (isEraYear(trimmed, index, numStr)) continue;
           out.push({ text: trimmed, num: extractedNum });
         }
       }
@@ -828,6 +837,9 @@ function roundTable(table, options) {
               if (superRanges.length > 0) {
                 matches = matches.filter(m => !overlapsQuoteRange(superRanges, m.index, m.index + m.numStr.length));
               }
+              // Issue #4: drop era-marked years (e.g. "2898 AD") — dates, not
+              // numbers to be offset-rounded.
+              matches = matches.filter(m => !isEraYear(text, m.index, m.numStr));
               if (matches.length > 0) {
                 rowInfo.push({ mode: 'extracted', matches });
               } else {
@@ -850,6 +862,9 @@ function roundTable(table, options) {
           if (superRanges.length > 0) {
             matches = matches.filter(m => !overlapsQuoteRange(superRanges, m.index, m.index + m.numStr.length));
           }
+          // Issue #4: drop era-marked years (e.g. "2898 AD") — dates, not
+          // numbers to be offset-rounded.
+          matches = matches.filter(m => !isEraYear(text, m.index, m.numStr));
           if (matches.length > 0) {
             rowInfo.push({ mode: 'extracted', matches });
           } else {

--- a/chrome-extension/parsing.js
+++ b/chrome-extension/parsing.js
@@ -419,6 +419,55 @@ function extractNumbersInText(text) {
   return matches;
 }
 
+// --- Era-marked calendar years (e.g. "2898 AD", "500 BC", "AD 79", "1200 CE") ---
+// A number bound to an era marker is a calendar year — a date — so it must be
+// rounded by date logic (decade/century), never by the numeric offset. These
+// helpers locate such year tokens so they can be excluded from numeric magnitude
+// detection, numeric rounding, and the sidebar preview examples (issue #4).
+const ERA_MARKER = '(?:A\\.?D\\.?|B\\.?C\\.?E\\.?|B\\.?C\\.?|C\\.?E\\.?|A\\.?H\\.?|B\\.?P\\.?)';
+// "<year> <era>": the digits are not part of a larger number (no leading digit
+// or decimal point) and the era marker is a standalone token (not followed by a
+// letter, so "ADELAIDE" / "ADD" never match).
+const ERA_YEAR_AFTER_RE = new RegExp('(?<![\\d.])(\\d[\\d,]*)\\s*' + ERA_MARKER + '(?![A-Za-z])', 'gi');
+// "<era> <year>": e.g. "AD 79". Era marker preceded by a non-letter boundary.
+const ERA_YEAR_BEFORE_RE = new RegExp('(?<![A-Za-z])' + ERA_MARKER + '\\s+(\\d[\\d,]*)', 'gi');
+
+/**
+ * Return {start, end} ranges (offsets into `text`) of every digit run that
+ * forms a calendar year bound to an era marker, in either order ("2898 AD" or
+ * "AD 79").
+ */
+function eraYearDigitRanges(text) {
+  if (typeof text !== 'string') return [];
+  const ranges = [];
+  let m;
+  const after = new RegExp(ERA_YEAR_AFTER_RE.source, 'gi');
+  while ((m = after.exec(text)) !== null) {
+    const start = m.index + m[0].indexOf(m[1]);
+    ranges.push({ start, end: start + m[1].length });
+  }
+  const before = new RegExp(ERA_YEAR_BEFORE_RE.source, 'gi');
+  while ((m = before.exec(text)) !== null) {
+    const start = m.index + m[0].lastIndexOf(m[1]);
+    ranges.push({ start, end: start + m[1].length });
+  }
+  return ranges;
+}
+
+/**
+ * True if the number occurrence [index, index + numStr.length) in `text` is a
+ * calendar year bound to an era marker (and therefore a date, not a numeric
+ * value to be offset-rounded).
+ */
+function isEraYear(text, index, numStr) {
+  if (typeof text !== 'string' || typeof numStr !== 'string') return false;
+  const end = index + numStr.length;
+  for (const r of eraYearDigitRanges(text)) {
+    if (index < r.end && end > r.start) return true;
+  }
+  return false;
+}
+
 /**
  * Returns the number of fractional digits in n's string representation.
  * Sign is stripped before counting. null/undefined/NaN all return 0.

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -182,7 +182,7 @@
        and the whole band is centered horizontally under the slider. */
     .results-band {
       display: grid;
-      grid-template-columns: auto auto auto auto;
+      grid-template-columns: auto auto auto;
       justify-content: center;
       column-gap: 6px;
       row-gap: 2px;
@@ -200,9 +200,6 @@
     }
     .results-band .arrow { color: #5f6368; text-align: center; }
     .results-band .num { color: #202124; text-align: right; }
-    .results-band .step { color: #5f6368; text-align: left; }
-    .results-band .step.top { color: #1a73e8; }
-    .results-band .step.bot { color: #b3623d; }
     .results-band .oom-label { color: #b3623d; }
     .results-band .strategy { color: #1a73e8; grid-column: 1 / -1; font-style: italic; }
     .results-band .empty {
@@ -347,7 +344,7 @@
     <summary>Advanced</summary>
     <div class="slider-block" id="sliderBlock">
       <div class="label-row">
-        <span class="lbl top" id="topLabel">largest numbers: −0.5</span>
+        <span class="lbl top" id="topLabel">largest numbers</span>
       </div>
       <div class="results-band" id="topBand"></div>
       <div class="dual-wrap" id="dualWrap">
@@ -363,7 +360,7 @@
              aria-label="largest numbers offset" aria-valuemin="-1" aria-valuemax="1" aria-valuenow="-0.5"></div>
       </div>
       <div class="label-row">
-        <span class="lbl bot" id="botLabel">all other numbers: −0.5</span>
+        <span class="lbl bot" id="botLabel">all other numbers</span>
       </div>
       <div class="results-band" id="botBand"></div>
     </div>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -76,19 +76,14 @@ function pct(v) {
   // This places −1 → 5.556% and +1 → 94.444%, matching the tick grid centres.
   return ((v + 1) / 2 * 8 + 0.5) / 9 * 100;
 }
-function fmtOffset(o) {
-  let s = o.toFixed(2).replace(/\.?0+$/, '');
-  if (s === '-0') s = '0';
-  return s.replace('-', '−');
-}
 function renderSliders() {
   if (!topThumb || !botThumb) return;
   topThumb.style.left = pct(topVal) + '%';
   botThumb.style.left = pct(botVal) + '%';
   botThumb.classList.toggle('linked', linked);
   if (sliderBlockEl) sliderBlockEl.classList.toggle('linked', linked);
-  if (topLabelEl) topLabelEl.textContent = 'largest numbers: ' + fmtOffset(topVal);
-  if (botLabelEl) botLabelEl.textContent = 'all other numbers: ' + fmtOffset(botVal);
+  if (topLabelEl) topLabelEl.textContent = 'largest numbers';
+  if (botLabelEl) botLabelEl.textContent = 'all other numbers';
   if (topThumb) topThumb.setAttribute('aria-valuenow', String(topVal));
   if (botThumb) botThumb.setAttribute('aria-valuenow', String(botVal));
   renderPreviewBands();
@@ -166,8 +161,6 @@ function formatOriginal(numOrStr) {
 }
 
 // CSS class name constants for band colouring.
-const STEP_CLASS_TOP = 'step top';
-const STEP_CLASS_BOT = 'step bot';
 const OOM_LABEL_CLASS = 'oom-label';
 const STRATEGY_CLASS = 'strategy';
 
@@ -194,72 +187,19 @@ function formatOomLabel(mag) {
 }
 
 /**
- * Build the strategy header string for the top band.
- * e.g. "100k+ → nearest 25k (i.e. a quarter of 100k)"
- *
- * The "i.e." clause is derived by computing step/oomVal (the ratio of the step
- * to the OoM magnitude) and looking it up in STRATEGY_RATIO_PHRASES.  The ratio
- * is drawn from the fixed slider-stop set {0.1, 0.25, 0.5, 0.75, 1, 2.5, 5,
- * 7.5, 10} regardless of maxMag, so a direct lookup is both correct and simple.
- *
- * When ratio == 1 (step equals the OoM) the clause is omitted entirely.
- * When ratio is not in the table (fallback) the clause is also omitted.
+ * Build the strategy header string for the top band, e.g.
+ * "1M+ → nearest 500k". The descriptive "(i.e. a half of 1M)" clause was
+ * removed per issue #1 — the OoM label and step alone convey the strategy.
  */
 function formatStrategyHeader(maxMag, offset) {
-  // Lookup table: step/oomVal ratio → "(i.e. …)" clause phrase builder.
-  // Only the four sub-OoM descriptive entries; ratio==1 and above-OoM ratios
-  // are handled separately below (re-based onto the next decade).
-  // Matched with tolerance 1e-9 since these are clean binary floats.
-  const STRATEGY_RATIO_PHRASES = [
-    { ratio: 0.1,  phrase: (b) => 'a tenth of ' + b },
-    { ratio: 0.25, phrase: (b) => 'a quarter of ' + b },
-    { ratio: 0.5,  phrase: (b) => 'a half of ' + b },
-    { ratio: 0.75, phrase: (b) => 'three quarters of ' + b },
-    // ratio == 1: clause omitted — not listed here.
-  ];
-  const oomLabel = formatOomLabel(maxMag);
-  const oomVal = Math.pow(10, maxMag);
-  // Use the representative top value (oomVal itself) to compute the step.
-  const step = stepForOffset(oomVal, offset);
-  const stepLabel = formatStep(step);
-  // ratio = step / oomVal: how large the step is relative to the OoM.
-  const ratio = step / oomVal;
-
-  let clausePhrase = null;
-  if (step > oomVal) {
-    // step > oomVal: re-base the clause onto the next decade (10 × oomVal).
-    // rebasedRatio = ratio / 10 maps {2.5, 5, 7.5, 10} → {0.25, 0.5, 0.75, 1.0}.
-    const rebasedRatio = ratio / 10;
-    // The clause base label is the next-decade OoM label without its trailing "+".
-    const nextDecadeLabel = formatOomLabel(maxMag + 1).replace(/\+$/, '');
-    // ratio == 10 → rebasedRatio == 1.0 → clause omitted (equals the next decade).
-    for (const entry of STRATEGY_RATIO_PHRASES) {
-      if (Math.abs(rebasedRatio - entry.ratio) < 1e-9) {
-        clausePhrase = entry.phrase(nextDecadeLabel);
-        break;
-      }
-    }
-  } else {
-    // step <= oomVal: look up ratio against the band's own OoM label.
-    // OoM label without the trailing "+" for use inside the clause.
-    const oomBare = oomLabel.replace(/\+$/, '');
-    // ratio == 1: clause omitted (not in table).
-    for (const entry of STRATEGY_RATIO_PHRASES) {
-      if (Math.abs(ratio - entry.ratio) < 1e-9) {
-        clausePhrase = entry.phrase(oomBare);
-        break;
-      }
-    }
-  }
-
-  // ratio == 1 (or any unmatched ratio): omit the "(i.e. …)" clause entirely.
-  const base = oomLabel + ' → nearest ' + stepLabel;
-  return clausePhrase ? base + ' (i.e. ' + clausePhrase + ')' : base;
+  const step = stepForOffset(Math.pow(10, maxMag), offset);
+  return formatOomLabel(maxMag) + ' → nearest ' + formatStep(step);
 }
 
 /**
  * Render the top preview band: strategy header row followed by a single
- * example row. Step labels are coloured blue (STEP_CLASS_TOP).
+ * example row ("e.g. <original> → <rounded>"). Per issues #1/#3 the example
+ * carries no step or magnitude annotation and shows the bare original number.
  */
 function renderTopBand(el, rows, offset) {
   if (!el) return;
@@ -284,7 +224,8 @@ function renderTopBand(el, rows, offset) {
 
   const from = document.createElement('span');
   from.className = 'from';
-  from.textContent = formatOriginal(row.original);
+  // Bare original number (text stripped per #3), prefixed "e.g." per #1.
+  from.textContent = 'e.g. ' + formatOriginal(row.num);
   pair.appendChild(from);
 
   const arrow = document.createElement('span');
@@ -297,17 +238,14 @@ function renderTopBand(el, rows, offset) {
   numEl.textContent = formatOriginal(roundWithOffset(row.num, offset));
   pair.appendChild(numEl);
 
-  const stepEl = document.createElement('span');
-  stepEl.className = STEP_CLASS_TOP;
-  stepEl.textContent = '(' + formatStep(stepForOffset(row.num, offset)) + ')';
-  pair.appendChild(stepEl);
-
   el.appendChild(pair);
 }
 
 /**
- * Render the bottom preview band: rows sorted DESCENDING by magnitude,
- * each showing the original with an OoM label and the step in brown.
+ * Render the bottom preview band: rows sorted DESCENDING by magnitude, each
+ * showing the bare original number with its OoM label (kept per the issue #3
+ * decision — strip the largest band, keep the tag for the other numbers). The
+ * trailing step annotation is removed.
  */
 function renderBotBand(el, rows, offset, maxMag) {
   if (!el) return;
@@ -325,10 +263,11 @@ function renderBotBand(el, rows, offset, maxMag) {
     const pair = document.createElement('div');
     pair.className = 'pair';
 
-    // "from" cell: "266,453 (100k+)" where the OoM label is brown.
+    // "from" cell: "266,453 (100k+)" where the OoM label is brown. The bare
+    // original number is shown (surrounding text stripped per #3).
     const from = document.createElement('span');
     from.className = 'from';
-    from.textContent = formatOriginal(row.original);
+    from.textContent = formatOriginal(row.num);
     if (row.num !== 0) {
       const mag = Math.floor(Math.log10(Math.abs(row.num)));
       const oomSpan = document.createElement('span');
@@ -347,11 +286,6 @@ function renderBotBand(el, rows, offset, maxMag) {
     numEl.className = 'num';
     numEl.textContent = formatOriginal(roundWithOffset(row.num, offset));
     pair.appendChild(numEl);
-
-    const stepEl = document.createElement('span');
-    stepEl.className = STEP_CLASS_BOT;
-    stepEl.textContent = '(' + formatStep(stepForOffset(row.num, offset)) + ')';
-    pair.appendChild(stepEl);
 
     el.appendChild(pair);
   }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -76,6 +76,8 @@ globalThis.injectTogglesForAddedNode = injectTogglesForAddedNode;
 globalThis.isDataTable = isDataTable;
 globalThis.collectNumericCells = collectNumericCells;
 globalThis.extractPreviewSamples = extractPreviewSamples;
+globalThis.isEraYear = isEraYear;
+globalThis.eraYearDigitRanges = eraYearDigitRanges;
 globalThis.formatStep = formatStep;
 globalThis.stepForOffset = stepForOffset;
 // Expose new toggle geometry constants (all are const, so direct assignment works)
@@ -1464,6 +1466,34 @@ function withLinkCreateTreeWalker(fn) {
       cells[0].classList.contains('dr-ext-rounded'), false);
     // Note: 42 is a single cell with a large magnitude; whether it rounds depends on
     // the set. The key invariant is the quoted cell is skipped.
+  });
+})();
+
+// --- 3b. Era-marked years are not parameter-rounded by roundTable (issue #4) ---
+
+(function eraYearNotParameterRounded() {
+  withCreateTreeWalker(function() {
+    // "Kalki 2898 AD": the 2898 is a calendar year (era marker), so it must NOT
+    // be rounded to 3,000 by the numeric offset. A real number in the same row
+    // still rounds (control), proving the exclusion is specific to the era year.
+    const table = makeMockTable([[
+      { tag: 'td', text: 'Kalki 2898 AD' },
+      { tag: 'td', text: '1,050,000,000' },
+    ]]);
+    const opts = {
+      enabled: true, simplifyMixedCells: true, simplifyDates: false, simplifyTimes: false,
+      simplifyFirstRow: true, simplifyFirstColumn: true, simplifyMixedPercent: true, simplifyMixedCurrency: true,
+      offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+      rangeExpr: ''
+    };
+    roundTable(table, opts);
+    const cells = table.rows[0].cells;
+    eq('era-round: "Kalki 2898 AD" cell is NOT rounded (era year, not a number)',
+      cells[0].classList.contains('dr-ext-rounded'), false);
+    eq('era-round: "Kalki 2898 AD" text left unchanged',
+      cells[0].innerText, 'Kalki 2898 AD');
+    eq('era-round: control 1,050,000,000 still rounds',
+      cells[1].classList.contains('dr-ext-rounded'), true);
   });
 })();
 
@@ -10724,7 +10754,7 @@ function fireMouseClick(buttonEl, fn) {
   // (also rounding.js).  We pass them as parameters to new Function.
   // -------------------------------------------------------------------------
   const constBlock = sidebarSrc.match(
-    /const STEP_CLASS_TOP\s*=[\s\S]*?const STRATEGY_CLASS\s*=.*?;/
+    /const OOM_LABEL_CLASS\s*=[\s\S]*?const STRATEGY_CLASS\s*=.*?;/
   );
   const formatOomLabelFn = sidebarSrc.match(
     /function formatOomLabel\([\s\S]*?\n\}/
@@ -10784,183 +10814,54 @@ function fireMouseClick(buttonEl, fn) {
   eq('AC1-oom: mag=-2 → "0.01+" (sub-unit, 1e-2=0.01)', fmtOom(-2), '0.01+');
 
   // -------------------------------------------------------------------------
-  // AC2: formatStrategyHeader structure and "(i.e. …)" clause correctness.
-  // We compute the expected step independently via stepForOffset/formatStep.
+  // AC2: formatStrategyHeader structure. Per issue #1 the descriptive
+  // "(i.e. a half of 1M)" clause was removed — the header is now exactly
+  // "<oomLabel> → nearest <stepLabel>" with no clause, for every stop.
+  // We derive the expected step independently via stepForOffset/formatStep.
   // -------------------------------------------------------------------------
 
-  // Scenario A: maxMag=5, offset=-0.5 → step=50k, ratio=2 → "a half of"
-  // stepForOffset(1e5, -0.5): f=0.5, target_mag=5+ceil(-0.5)=5+0=5, step=0.5*1e5=50000
+  // Scenario A: maxMag=5, offset=-0.5 → step=50k.
   (function hdrScenarioA() {
     const maxMag = 5; const offset = -0.5;
-    const oomLabel = '100k+';
-    const oomVal = Math.pow(10, maxMag);       // 100000
-    const step = stepForOffset(oomVal, offset); // 50000
-    const stepLabel = formatStep(step);         // '50k'
-    const oomStepLabel = formatStep(oomVal);   // '100k'
+    const oomVal = Math.pow(10, maxMag);        // 100000
+    const stepLabel = formatStep(stepForOffset(oomVal, offset)); // '50k'
     const header = fmtHdr(maxMag, offset);
-    eq('AC2-A: header contains oom label (100k+)', header.includes(oomLabel), true);
-    eq('AC2-A: header contains arrow →', header.includes('→'), true);
-    eq('AC2-A: header contains "nearest ' + stepLabel + '"', header.includes('nearest ' + stepLabel), true);
-    eq('AC2-A: header contains "(i.e."', header.includes('(i.e.'), true);
-    // ratio=2 → "a half of" (ordinal mapping)
-    eq('AC2-A: header contains "a half of"', header.includes('a half of'), true);
-    eq('AC2-A: header references oom step label (' + oomStepLabel + ')',
-      header.includes(oomStepLabel), true);
+    eq('AC2-A: header is exactly "100k+ → nearest 50k"',
+      header, '100k+ → nearest ' + stepLabel);
+    eq('AC2-A: header has no "(i.e." clause', header.includes('(i.e.'), false);
   })();
 
-  // Scenario B: maxMag=3, offset=-0.5 → step=500, ratio=2 → "a half of"
+  // Scenario B: maxMag=3, offset=-0.5 → step=500.
   (function hdrScenarioB() {
     const maxMag = 3; const offset = -0.5;
-    const oomLabel = '1k+';
-    const oomVal = Math.pow(10, maxMag);
-    const step = stepForOffset(oomVal, offset); // 500
-    const stepLabel = formatStep(step);         // '500'
+    const stepLabel = formatStep(stepForOffset(Math.pow(10, maxMag), offset)); // '500'
     const header = fmtHdr(maxMag, offset);
-    eq('AC2-B: header contains oom label (1k+)', header.includes(oomLabel), true);
-    eq('AC2-B: header contains "nearest ' + stepLabel + '"', header.includes('nearest ' + stepLabel), true);
-    eq('AC2-B: header contains "a half of"', header.includes('a half of'), true);
-  })();
-
-  // Scenario C: maxMag=5, offset=-0.25 → step=25k, ratio=4 → "a quarter of"
-  (function hdrScenarioC() {
-    const maxMag = 5; const offset = -0.25;
-    const oomVal = Math.pow(10, maxMag);
-    const step = stepForOffset(oomVal, offset); // 25000
-    const stepLabel = formatStep(step);         // '25k'
-    const header = fmtHdr(maxMag, offset);
-    eq('AC2-C: header contains "nearest ' + stepLabel + '"', header.includes('nearest ' + stepLabel), true);
-    eq('AC2-C: header contains "a quarter of"', header.includes('a quarter of'), true);
-  })();
-
-  // Scenario D: maxMag=6, offset=-0.75 → step=750k, ratio = step/oom = 0.75.
-  // The direct ratio→phrase lookup emits the correct "three quarters of 1M"
-  // clause. (This previously regressed to a garbled "1/1 of" when the clause
-  // was derived via Math.round of an inverted ratio — guarded here so it
-  // can't come back.)
-  (function hdrScenarioD_adversarial() {
-    const maxMag = 6; const offset = -0.75;
-    const oomVal = Math.pow(10, maxMag);        // 1000000
-    const step = stepForOffset(oomVal, offset); // 750000
-    // ratio = step/oomVal = 0.75 → "three quarters of 1M"
-    const header = fmtHdr(maxMag, offset);
-    // Fixed: direct ratio→phrase lookup emits the correct clause.
-    eq('AC2-D: ratio=0.75 → "three quarters of" emitted',
-      header.includes('three quarters of'), true);
-    // Also confirm step label is present
-    eq('AC2-D-adversarial: header contains "nearest 750k"', header.includes('nearest 750k'), true);
-  })();
-
-  // Scenario E: offset=0 (integer) → step=oomVal, ratio=1 → clause omitted
-  (function hdrScenarioE() {
-    const maxMag = 2; const offset = 0;
-    const oomVal = Math.pow(10, maxMag); // 100
-    const step = stepForOffset(oomVal, offset); // 100
-    const stepLabel = formatStep(step);          // '100'
-    const header = fmtHdr(maxMag, offset);
-    eq('AC2-E: offset=0 header contains "nearest ' + stepLabel + '"',
-      header.includes('nearest ' + stepLabel), true);
-    // ratio=1: "(i.e. …)" clause is omitted entirely.
-    eq('AC2-E: offset=0 ratio=1 → no "(i.e." clause', header.includes('(i.e.'), false);
+    eq('AC2-B: header is exactly "1k+ → nearest 500"',
+      header, '1k+ → nearest ' + stepLabel);
+    eq('AC2-B: header has no clause', header.includes('(i.e.'), false);
   })();
 
   // -------------------------------------------------------------------------
-  // AC2-ALL-STOPS: All 9 slider stops × 2 maxMag values.
-  // For each stop we independently derive step/stepLabel via the real
-  // stepForOffset/formatStep so the assertions are spec-arithmetic-derived,
-  // not copied from implementation output.  The human phrase fragments are
-  // hardcoded because those ARE the spec contract.
-  //
-  // Stops: offset ∈ {-1, -0.75, -0.5, -0.25, 0, +0.25, +0.5, +0.75, +1}
-  //   offset -1   → ratio 0.1   → "a tenth of <oomBare>"
-  //   offset -0.75→ ratio 0.75  → "three quarters of <oomBare>"
-  //   offset -0.5 → ratio 0.5   → "a half of <oomBare>"
-  //   offset -0.25→ ratio 0.25  → "a quarter of <oomBare>"
-  //   offset  0   → ratio 1     → no "(i.e." clause
-  //   offset +0.25→ ratio 2.5   → re-based: "a quarter of <nextDecadeLabel>"
-  //   offset +0.5 → ratio 5     → re-based: "a half of <nextDecadeLabel>"
-  //   offset +0.75→ ratio 7.5   → re-based: "three quarters of <nextDecadeLabel>"
-  //   offset +1   → ratio 10    → re-based ratio=1 → no "(i.e." clause
+  // AC2-ALL-STOPS: All 9 slider stops × 2 maxMag values. The header is always
+  // exactly "<oomLabel> → nearest <stepLabel>" with the step derived from the
+  // real stepForOffset/formatStep, and never contains a "(i.e." clause or a
+  // "×" multiplier.
   // -------------------------------------------------------------------------
   (function hdrAllStops() {
-    // phraseFor receives the context label (oomBare for negative offsets,
-    // nextDecadeLabel for positive) and returns the expected phrase fragment.
-    // null means the clause is omitted entirely.
-    const stops = [
-      { offset: -1,    phraseFor: (b) => 'a tenth of ' + b,         hasClause: true,  useNextDecade: false },
-      { offset: -0.75, phraseFor: (b) => 'three quarters of ' + b,  hasClause: true,  useNextDecade: false },
-      { offset: -0.5,  phraseFor: (b) => 'a half of ' + b,          hasClause: true,  useNextDecade: false },
-      { offset: -0.25, phraseFor: (b) => 'a quarter of ' + b,       hasClause: true,  useNextDecade: false },
-      { offset:  0,    phraseFor: () => null,                        hasClause: false, useNextDecade: false },
-      { offset:  0.25, phraseFor: (b) => 'a quarter of ' + b,       hasClause: true,  useNextDecade: true  },
-      { offset:  0.5,  phraseFor: (b) => 'a half of ' + b,          hasClause: true,  useNextDecade: true  },
-      { offset:  0.75, phraseFor: (b) => 'three quarters of ' + b,  hasClause: true,  useNextDecade: true  },
-      { offset:  1,    phraseFor: () => null,                        hasClause: false, useNextDecade: true  },
-    ];
-
-    // Test against TWO different maxMag values to confirm maxMag-independence of phrases.
+    const stops = [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
     const testMags = [6, 5]; // 1M and 100k
 
     for (const mag of testMags) {
       const oomVal = Math.pow(10, mag);
-      const oomLabel = fmtOom(mag);                         // e.g. "1M+" or "100k+"
-      const oomBare  = oomLabel.replace(/\+$/, '');         // e.g. "1M"  or "100k"
-      const nextDecadeLabel = fmtOom(mag + 1).replace(/\+$/, ''); // e.g. "10M" or "1M"
-
-      for (const stop of stops) {
-        const tag = 'AC2-ALL mag=' + mag + ' offset=' + stop.offset;
-        const step      = stepForOffset(oomVal, stop.offset);
-        const stepLabel = formatStep(step);
-        const header    = fmtHdr(mag, stop.offset);
-        const clauseBase = stop.useNextDecade ? nextDecadeLabel : oomBare;
-        const phrase = stop.phraseFor(clauseBase);
-
-        // 1. Header always starts with "<oomLabel> →" (with the "+").
-        eq(tag + ': header contains oomLabel "' + oomLabel + '"',
-          header.includes(oomLabel), true);
-
-        // 2. Header always contains "→".
-        eq(tag + ': header contains arrow "→"',
-          header.includes('→'), true);
-
-        // 3. Header always contains "nearest <stepLabel>" using REAL stepForOffset.
-        eq(tag + ': header contains "nearest ' + stepLabel + '"',
-          header.includes('nearest ' + stepLabel), true);
-
-        // 4a. Clause presence / absence.
-        if (stop.hasClause) {
-          eq(tag + ': header contains "(i.e."',
-            header.includes('(i.e.'), true);
-          // 4b. The specific human phrase must appear in full (includes the base label).
-          eq(tag + ': header contains phrase "' + phrase + '"',
-            header.includes(phrase), true);
-          // 4c. No bare N× multiplier strings should appear (old behavior, now removed).
-          eq(tag + ': header does NOT contain "×"',
-            header.includes('×'), false);
-        } else {
-          // offset=0 or offset=1 → ratio=1 re-based → clause omitted entirely.
-          eq(tag + ': no "(i.e." clause',
-            header.includes('(i.e.'), false);
-        }
-      }
-    }
-  })();
-
-  // -------------------------------------------------------------------------
-  // AC2-NO-GARBLE: None of the 9 outputs for any of the two test mags should
-  // contain known garbled fragments from the old broken implementation.
-  // -------------------------------------------------------------------------
-  (function hdrNoGarble() {
-    const allOffsets = [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
-    const testMags   = [6, 5];
-    const badPatterns = ['1/1', '0.1 of', '0.133', 'NaN', 'undefined'];
-
-    for (const mag of testMags) {
-      for (const offset of allOffsets) {
+      const oomLabel = fmtOom(mag);
+      for (const offset of stops) {
+        const tag = 'AC2-ALL mag=' + mag + ' offset=' + offset;
+        const stepLabel = formatStep(stepForOffset(oomVal, offset));
         const header = fmtHdr(mag, offset);
-        for (const bad of badPatterns) {
-          eq('AC2-NO-GARBLE mag=' + mag + ' offset=' + offset + ': no "' + bad + '"',
-            header.includes(bad), false);
-        }
+        eq(tag + ': header is exactly "' + oomLabel + ' → nearest ' + stepLabel + '"',
+          header, oomLabel + ' → nearest ' + stepLabel);
+        eq(tag + ': no "(i.e." clause', header.includes('(i.e.'), false);
+        eq(tag + ': no "×" multiplier', header.includes('×'), false);
       }
     }
   })();
@@ -11126,45 +11027,52 @@ function fireMouseClick(buttonEl, fn) {
   eq('AC3-edge: null el is a no-op (no throw)', true, true);
 
   // -------------------------------------------------------------------------
-  // AC4: step-label CSS classes.
-  // Bottom band: step span uses STEP_CLASS_BOT = 'step bot'.
-  // Top band: step span uses STEP_CLASS_TOP = 'step top'.
+  // AC4: example rows carry no trailing step annotation (issues #1/#3).
+  // Each band pair has exactly three children — from, arrow, num — and no
+  // fourth "step" span. The top example's "from" is prefixed "e.g."; the
+  // bottom band keeps its OoM label inside the "from" span.
   // -------------------------------------------------------------------------
 
-  // AC4a: bottom band step class
-  function getStepClassName(pairEl) {
-    // fourth child (index 3) is the step span
-    return pairEl._children[3] ? pairEl._children[3].className : '';
-  }
+  // AC4a: bottom band pair has no step span (only from/arrow/num).
   const botBandEl2 = makeBandEl();
   realRenderBotBand(botBandEl2, [{ num: 1000, original: '1,000' }], -0.5, 3);
-  eq('AC4-bot: step span has class "step bot"',
-    getStepClassName(botBandEl2._appended[0]), 'step bot');
+  eq('AC4-bot: bottom example pair has exactly 3 children (no step span)',
+    botBandEl2._appended[0]._children.length, 3);
 
-  // AC4b: top band step class (only the example row, not the strategy header pair).
-  // renderTopBand with cachedMaxMag=null skips the strategy header, so appended[0]
-  // is the example pair.
+  // AC4b: top band example pair has no step span and is prefixed "e.g.".
+  // renderTopBand with cachedMaxMag=null skips the strategy header, so the only
+  // appended element is the example pair.
   const topBandEl2 = makeBandEl();
   realRenderTopBand(topBandEl2, [{ num: 100000, original: '100,000' }], -0.5);
-  // Without cachedMaxMag (null in our eval context) there is no header pair,
-  // so appended[0] is the example row pair.
-  eq('AC4-top: top band appended at least one pair element',
-    topBandEl2._appended.length >= 1, true);
-  const topExamplePair = topBandEl2._appended[topBandEl2._appended.length - 1];
-  eq('AC4-top: step span in top example row has class "step top"',
-    getStepClassName(topExamplePair), 'step top');
+  eq('AC4-top: top band appended exactly one pair (no header, no step)',
+    topBandEl2._appended.length, 1);
+  const topExamplePair = topBandEl2._appended[0];
+  eq('AC4-top: top example pair has exactly 3 children (no step span)',
+    topExamplePair._children.length, 3);
+  eq('AC4-top: top example "from" is prefixed "e.g."',
+    topExamplePair._children[0].textContent, 'e.g. 100,000');
 
-  // AC4c: source-level constant values are correct (structural)
-  eq('AC4-src: STEP_CLASS_TOP constant is "step top" in source',
-    /const STEP_CLASS_TOP\s*=\s*['"]step top['"]/.test(sidebarSrc), true);
-  eq('AC4-src: STEP_CLASS_BOT constant is "step bot" in source',
-    /const STEP_CLASS_BOT\s*=\s*['"]step bot['"]/.test(sidebarSrc), true);
+  // AC4-strip (issue #3): the "from" shows the bare number, not the original
+  // surrounding text. renderTopBand keys off row.num, so a row whose original
+  // was "₹2,000 crore" still renders just "e.g. 2,000".
+  const stripBandEl = makeBandEl();
+  realRenderTopBand(stripBandEl, [{ num: 2000, original: '₹2,000 crore' }], -0.5);
+  eq('AC4-strip: top "from" strips surrounding text to bare "e.g. 2,000"',
+    stripBandEl._appended[0]._children[0].textContent, 'e.g. 2,000');
+
+  // AC4c: source-level constant values are correct (structural). The step-class
+  // constants were removed; the OoM-label and strategy classes remain.
+  eq('AC4-src: STEP_CLASS_TOP constant removed from source',
+    /const STEP_CLASS_TOP\b/.test(sidebarSrc), false);
+  eq('AC4-src: STEP_CLASS_BOT constant removed from source',
+    /const STEP_CLASS_BOT\b/.test(sidebarSrc), false);
   eq('AC4-src: OOM_LABEL_CLASS constant is "oom-label" in source',
     /const OOM_LABEL_CLASS\s*=\s*['"]oom-label['"]/.test(sidebarSrc), true);
   eq('AC4-src: STRATEGY_CLASS constant is "strategy" in source',
     /const STRATEGY_CLASS\s*=\s*['"]strategy['"]/.test(sidebarSrc), true);
 
-  // AC4d: oom-label span is appended inside the from-span for non-zero rows.
+  // AC4d: oom-label span is still appended inside the from-span for non-zero
+  // rows of the bottom band (kept per the issue #3 decision).
   const oomLabelBandEl = makeBandEl();
   realRenderBotBand(oomLabelBandEl, [{ num: 5000, original: '5,000' }], -0.5, 3);
   const fromSpan = oomLabelBandEl._appended[0]._children[0];
@@ -11666,15 +11574,13 @@ function fireMouseClick(buttonEl, fn) {
 })();
 
 // -------------------------------------------------------------------------
-// AC2 (Bug #3): formatStrategyHeader — exhaustive mag=3 (1k+) table.
-// Every offset stop is verified with exact clause text against the re-basing
-// spec: negative offsets reference the band's own OoM bare label ("1k"),
-// positive offsets re-base onto the next decade ("10k"), offset=0 and offset=1
-// omit the clause. No "×" multiplier form should appear in any header.
+// AC2: formatStrategyHeader — exhaustive mag=3 (1k+) table. Per issue #1 the
+// header is exactly "<oomLabel> → nearest <stepLabel>" for every offset stop,
+// with no "(i.e. …)" clause and no "×" multiplier.
 // -------------------------------------------------------------------------
 (function ac2_mag3_exhaustiveTable() {
   const sidebarSrc  = fs.readFileSync(path.join(__dirname, 'sidebar.js'),  'utf8');
-  const constBlock  = sidebarSrc.match(/const STEP_CLASS_TOP\s*=[\s\S]*?const STRATEGY_CLASS\s*=.*?;/);
+  const constBlock  = sidebarSrc.match(/const OOM_LABEL_CLASS\s*=[\s\S]*?const STRATEGY_CLASS\s*=.*?;/);
   const fmtOomFn    = sidebarSrc.match(/function formatOomLabel\([\s\S]*?\n\}/);
   const fmtHdrFn    = sidebarSrc.match(/function formatStrategyHeader\([\s\S]*?\n\}/);
 
@@ -11702,89 +11608,28 @@ function fireMouseClick(buttonEl, fn) {
   const fmtHdr = helpers.formatStrategyHeader;
 
   const mag = 3;
-  const oomVal         = Math.pow(10, mag);           // 1000
-  const oomLabel       = fmtOom(mag);                  // "1k+"
-  const oomBare        = oomLabel.replace(/\+$/, ''); // "1k"
-  const nextDecadeLabel = fmtOom(mag + 1).replace(/\+$/, ''); // "10k"
+  const oomVal   = Math.pow(10, mag);  // 1000
+  const oomLabel = fmtOom(mag);        // "1k+"
 
-  // Verify our derived labels are correct.
   eq('AC2-mag3: oomLabel is "1k+"', oomLabel, '1k+');
-  eq('AC2-mag3: nextDecadeLabel is "10k"', nextDecadeLabel, '10k');
 
-  const scenarios = [
-    // [offset, expectClause, expectedFragment, refLabel]
-    { offset: -1,    hasClause: true,  fragment: 'a tenth of',         base: oomBare        },
-    { offset: -0.25, hasClause: true,  fragment: 'a quarter of',       base: oomBare        },
-    { offset: -0.5,  hasClause: true,  fragment: 'a half of',          base: oomBare        },
-    { offset: -0.75, hasClause: true,  fragment: 'three quarters of',  base: oomBare        },
-    { offset:  0,    hasClause: false, fragment: null,                  base: null           },
-    { offset:  0.25, hasClause: true,  fragment: 'a quarter of',       base: nextDecadeLabel },
-    { offset:  0.5,  hasClause: true,  fragment: 'a half of',          base: nextDecadeLabel },
-    { offset:  0.75, hasClause: true,  fragment: 'three quarters of',  base: nextDecadeLabel },
-    { offset:  1,    hasClause: false, fragment: null,                  base: null           },
-  ];
+  const offsets = [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+  for (const offset of offsets) {
+    const tag     = 'AC2-mag3 offset=' + offset;
+    const stepLbl = formatStep(stepForOffset(oomVal, offset));
+    const header  = fmtHdr(mag, offset);
 
-  for (const sc of scenarios) {
-    const tag    = 'AC2-mag3 offset=' + sc.offset;
-    const step   = stepForOffset(oomVal, sc.offset);
-    const stepLbl = formatStep(step);
-    const header  = fmtHdr(mag, sc.offset);
-
-    // Band label always present.
-    eq(tag + ': header contains "' + oomLabel + '"',
-      header.includes(oomLabel), true);
-
-    // Step label always present.
-    eq(tag + ': header contains "nearest ' + stepLbl + '"',
-      header.includes('nearest ' + stepLbl), true);
-
-    if (sc.hasClause) {
-      // (i.e. …) clause present.
-      eq(tag + ': header contains "(i.e."',
-        header.includes('(i.e.'), true);
-
-      // Full clause phrase: "a half of 1k" or "a quarter of 10k" etc.
-      const fullPhrase = sc.fragment + ' ' + sc.base;
-      eq(tag + ': header contains "' + fullPhrase + '"',
-        header.includes(fullPhrase), true);
-
-      // No "×" multiplier form.
-      eq(tag + ': header does NOT contain "×"',
-        header.includes('×'), false);
-    } else {
-      // offset=0 and offset=1: clause omitted.
-      eq(tag + ': no "(i.e." clause',
-        header.includes('(i.e.'), false);
-
-      // No "×" either.
-      eq(tag + ': header does NOT contain "×"',
-        header.includes('×'), false);
-    }
+    eq(tag + ': header is exactly "' + oomLabel + ' → nearest ' + stepLbl + '"',
+      header, oomLabel + ' → nearest ' + stepLbl);
+    eq(tag + ': no "(i.e." clause', header.includes('(i.e.'), false);
+    eq(tag + ': no "×" multiplier', header.includes('×'), false);
   }
 
-  // Spot-check full expected strings for the spec table rows.
-  eq('AC2-mag3 offset=-1: full clause "a tenth of 1k"',
-    fmtHdr(mag, -1).includes('a tenth of 1k'), true);
-  eq('AC2-mag3 offset=-0.25: full clause "a quarter of 1k"',
-    fmtHdr(mag, -0.25).includes('a quarter of 1k'), true);
-  eq('AC2-mag3 offset=-0.5: full clause "a half of 1k"',
-    fmtHdr(mag, -0.5).includes('a half of 1k'), true);
-  eq('AC2-mag3 offset=-0.75: full clause "three quarters of 1k"',
-    fmtHdr(mag, -0.75).includes('three quarters of 1k'), true);
-  eq('AC2-mag3 offset=0.25: full clause "a quarter of 10k"',
-    fmtHdr(mag, 0.25).includes('a quarter of 10k'), true);
-  eq('AC2-mag3 offset=0.5: full clause "a half of 10k"',
-    fmtHdr(mag, 0.5).includes('a half of 10k'), true);
-  eq('AC2-mag3 offset=0.75: full clause "three quarters of 10k"',
-    fmtHdr(mag, 0.75).includes('three quarters of 10k'), true);
-
-  // offset=0.5 step label and band label unchanged (regression guard).
-  eq('AC2-mag3 offset=0.5: header contains "1k+ → nearest 5k"',
-    fmtHdr(mag, 0.5).includes('1k+ → nearest 5k'), true);
-
-  // offset=-1 step label and band label unchanged (regression guard).
-  eq('AC2-mag3 offset=-1: header contains "→ nearest 100"',
-    fmtHdr(mag, -1).includes('→ nearest 100'), true);
+  // Spot-check the exact step labels for two representative stops (regression guard).
+  eq('AC2-mag3 offset=0.5: header is exactly "1k+ → nearest 5k"',
+    fmtHdr(mag, 0.5), '1k+ → nearest 5k');
+  eq('AC2-mag3 offset=-1: header is exactly "1k+ → nearest 100"',
+    fmtHdr(mag, -1), '1k+ → nearest 100');
 })();
 
 // -------------------------------------------------------------------------
@@ -11843,6 +11688,80 @@ function fireMouseClick(buttonEl, fn) {
     nums.includes(2000), true);
 })();
 
+
+// -------------------------------------------------------------------------
+// Issue #4: era-marked years are dates, not offset-rounded numbers.
+// isEraYear locates a year token bound to an era marker; collectNumericCells /
+// extractPreviewSamples must exclude such tokens from magnitude detection and
+// the preview examples.
+// -------------------------------------------------------------------------
+(function eraYearDetection() {
+  // isEraYear: the digit token bound to a marker (either order) is an era year.
+  eq('era: "Kalki 2898 AD" → 2898 is an era year',
+    isEraYear('Kalki 2898 AD', 'Kalki '.length, '2898'), true);
+  eq('era: "500 BC" → 500 is an era year',
+    isEraYear('500 BC', 0, '500'), true);
+  eq('era: "AD 79" → 79 is an era year',
+    isEraYear('AD 79', 'AD '.length, '79'), true);
+  eq('era: "1200 CE" → 1200 is an era year',
+    isEraYear('1200 CE', 0, '1200'), true);
+  eq('era: "2,898 BCE" → comma year is an era year',
+    isEraYear('2,898 BCE', 0, '2,898'), true);
+
+  // Negatives: plain numbers, and marker letters embedded in a word.
+  eq('era: plain "Revenue 3,000,000" is NOT an era year',
+    isEraYear('Revenue 3,000,000', 'Revenue '.length, '3,000,000'), false);
+  eq('era: bare "2898" (no marker) is NOT an era year',
+    isEraYear('2898', 0, '2898'), false);
+  eq('era: "ADELAIDE 12" does NOT match (AD inside a word)',
+    isEraYear('ADELAIDE 12', 'ADELAIDE '.length, '12'), false);
+
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+
+  // collectNumericCells: the era year is dropped, real numbers are kept.
+  const cells = collectNumericCells({
+    rows: [{ cells: [tdCell('Kalki 2898 AD'), tdCell('1,050,000,000')] }],
+  });
+  const nums = cells.map(c => c.num);
+  eq('era-collect: 2898 (era year) excluded from numeric cells',
+    nums.includes(2898), false);
+  eq('era-collect: 1,050,000,000 (real number) still collected',
+    nums.includes(1050000000), true);
+
+  // extractPreviewSamples: maxMag comes from the real number, not the era year,
+  // and no sample row carries the era-year value.
+  const result = extractPreviewSamples({
+    rows: [{ cells: [tdCell('Kalki 2898 AD'), tdCell('1,050,000,000'), tdCell('500')] }],
+  });
+  eq('era-samples: maxMag is 9 (from 1.05B, not the 2898 AD year)',
+    result.maxMag, 9);
+  const sampleNums = result.samples.top.concat(result.samples.bottom).map(r => r.num);
+  eq('era-samples: no example row is the 2898 AD year',
+    sampleNums.includes(2898), false);
+})();
+
+// -------------------------------------------------------------------------
+// Issue #2: when a native table is already simplified, collectNumericCells
+// reads the stored original (dataset.originalValue) rather than the rounded
+// text now showing in the cell.
+// -------------------------------------------------------------------------
+(function originalValueOnSimplifiedTable() {
+  // A rounded native cell: innerText shows the rounded "3,000,000" but the true
+  // original "2,794,356" is stashed on dataset.originalValue.
+  const roundedCell = {
+    tagName: 'TD',
+    innerText: '3,000,000',
+    textContent: '3,000,000',
+    dataset: { originalValue: '2,794,356' },
+  };
+  const cells = collectNumericCells({ rows: [{ cells: [roundedCell] }] });
+  eq('orig-value: reads original text, not rounded',
+    cells[0].text, '2,794,356');
+  eq('orig-value: parses num from original, not rounded',
+    cells[0].num, 2794356);
+})();
 
 // --- Report ---
 console.log(`Passed: ${passed}`);


### PR DESCRIPTION
Reworks the Advanced preview band so the example rows read cleanly and dates are handled separately from numbers.

## Changes

1. **Labels / header / example.** The thumb labels now read just `largest numbers` / `all other numbers` (no trailing offset value). The strategy header drops the `(i.e. a half of 1M)` clause, leaving `1M+ → nearest 500k`. The top example becomes `e.g. <original> → <rounded>` with no trailing step.
2. **Original value on already-simplified tables.** When the sidebar opens on a bound table that is already simplified, the example's "original" now reads the stored pre-round value (`dataset.originalValue`) instead of the rounded text currently shown in the cell.
3. **Strip text from examples.** The "from" cell shows the bare number rather than the full cell content, and the per-row step annotation is removed. The bottom band keeps its magnitude tag (e.g. `(100k+)`); the top band shows none.
4. **Exclude dates from magnitude detection.** Era-marked calendar years (`2898 AD`, `500 BC`, `AD 79`, `1200 CE`) are detected and excluded from magnitude detection, the preview examples, and numeric (offset) rounding in the live table. So `Kalki 2898 AD` is no longer rounded to `3,000` by parameter, while real numbers in the same cell still round.

## Scope note

For #4, era-marked years are excluded from numeric rounding (left intact). This PR does not add decade/century date-rounding of years embedded in arbitrary prose — that is a larger feature (BC/AD reconstruction, prefix forms) and can be a follow-up if desired.

## Tests

Adds `isEraYear`/`eraYearDigitRanges` helpers and covers: era-year detection, era-year exclusion in `collectNumericCells`/`extractPreviewSamples`, an end-to-end `roundTable` era-year case, and the original-value-on-simplified-table case. The strategy-header and render-band tests were updated to the new no-clause / no-step format. Full suite: 1337 passing.