### PR TITLE
Slider stops: strategy-monotonic 9-stop set (follow-up to #180)

### DIFF
--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -145,7 +145,7 @@
     }
     .dual-ticks {
       position: absolute; left: 0; right: 0; top: 20px;
-      display: grid; grid-template-columns: repeat(11, 1fr);
+      display: grid; grid-template-columns: repeat(9, 1fr);
       pointer-events: none;
       /* top: 20px centres each 12px tick (top + 6px) on the thumb centre at 26px */
     }
@@ -153,8 +153,8 @@
       height: 12px; width: 2px; background: #b5b9c0;
       justify-self: center; border-radius: 1px;
     }
-    /* Distinguish the zero tick (offset = 0), the 7th of 11 stops. */
-    .dual-ticks .t:nth-child(7) {
+    /* Distinguish the zero tick (offset = 0), the 6th of 9 stops. */
+    .dual-ticks .t:nth-child(6) {
       background: #7a8089;
       height: 14px;
     }
@@ -367,7 +367,6 @@
           <span class="t"></span><span class="t"></span><span class="t"></span>
           <span class="t"></span><span class="t"></span><span class="t"></span>
           <span class="t"></span><span class="t"></span><span class="t"></span>
-          <span class="t"></span><span class="t"></span>
         </div>
         <div class="dual-thumb bot linked" id="botThumb" tabindex="0" role="slider"
              aria-label="all other numbers offset" aria-valuemin="-2" aria-valuemax="1" aria-valuenow="-0.5"></div>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -45,7 +45,14 @@ const timeGranularityEl = document.getElementById('timeGranularity');
 const rangeExprEl = document.getElementById('rangeExpr');
 
 // ----- Variant F: linked dual-thumb sliders -----
-const STOPS = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+// Stops are ordered so the *rounding strategy* changes monotonically across the
+// track (finest step on the left, coarsest on the right), NOT by offset value.
+// stepForOffset is non-monotonic in the offset because half-step offsets
+// interleave with the integer ones: e.g. at mag 6 the steps run
+//   -2:10k  -1.5:50k  -1:100k  -0.25:250k  -0.5:500k  -0.75:750k
+//    0:1M   0.25:2.5M  0.5:5M   0.75:7.5M    1:10M
+// Hence -0.25 precedes -0.5 precedes -0.75, and -1 sits right after -1.5.
+const STOPS = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
 const DEFAULT_OFFSET = -0.5;
 
 const sliderBlockEl = document.getElementById('sliderBlock');

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -49,10 +49,10 @@ const rangeExprEl = document.getElementById('rangeExpr');
 // track (finest step on the left, coarsest on the right), NOT by offset value.
 // stepForOffset is non-monotonic in the offset because half-step offsets
 // interleave with the integer ones: e.g. at mag 6 the steps run
-//   -2:10k  -1.5:50k  -1:100k  -0.25:250k  -0.5:500k  -0.75:750k
-//    0:1M   0.25:2.5M  0.5:5M   0.75:7.5M    1:10M
-// Hence -0.25 precedes -0.5 precedes -0.75, and -1 sits right after -1.5.
-const STOPS = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
+//   -2:10k  -1.5:50k  -1:100k  -0.25:250k  -0.5:500k
+//    0:1M   0.25:2.5M  0.5:5M    1:10M
+// Hence -0.25 precedes -0.5, and -1 sits right after -1.5.
+const STOPS = [-2, -1.5, -1, -0.25, -0.5, 0, 0.25, 0.5, 1];
 const DEFAULT_OFFSET = -0.5;
 
 const sliderBlockEl = document.getElementById('sliderBlock');

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -10848,7 +10848,7 @@ function fireMouseClick(buttonEl, fn) {
   // "×" multiplier.
   // -------------------------------------------------------------------------
   (function hdrAllStops() {
-    const stops = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+    const stops = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
     const testMags = [6, 5]; // 1M and 100k
 
     for (const mag of testMags) {
@@ -10864,6 +10864,50 @@ function fireMouseClick(buttonEl, fn) {
         eq(tag + ': no "×" multiplier', header.includes('×'), false);
       }
     }
+  })();
+
+  // -------------------------------------------------------------------------
+  // AC2-STRATEGY-MONOTONIC: the slider stops must be ordered so the resulting
+  // rounding STEP changes in a single direction across the track. This is the
+  // whole point of the stop ordering: stepForOffset is non-monotonic in the
+  // offset value (half-steps interleave with integer steps), so the array order
+  // — not numeric sort — is what guarantees a one-directional strategy sweep.
+  // Read STOPS straight from sidebar.js and assert step() is strictly
+  // increasing across it for several magnitudes.
+  // -------------------------------------------------------------------------
+  (function strategyMonotonic() {
+    const src = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
+    const m = src.match(/const STOPS\s*=\s*\[([^\]]*)\]/);
+    if (!m) {
+      eq('AC2-mono: STOPS array found in sidebar.js', false, true);
+      return;
+    }
+    const STOPS = m[1].split(',').map((s) => parseFloat(s.trim()));
+    eq('AC2-mono: STOPS has 11 stops', STOPS.length, 11);
+
+    for (const mag of [6, 5, 3, 9]) {
+      const oomVal = Math.pow(10, mag);
+      let monotonic = true;
+      let firstBreak = null;
+      for (let i = 1; i < STOPS.length; i++) {
+        const prev = stepForOffset(oomVal, STOPS[i - 1]);
+        const cur = stepForOffset(oomVal, STOPS[i]);
+        if (!(cur > prev)) {
+          monotonic = false;
+          firstBreak = STOPS[i - 1] + '→' + STOPS[i] + ' (' + prev + '≮' + cur + ')';
+          break;
+        }
+      }
+      eq('AC2-mono mag=' + mag + ': step() strictly increases across STOPS' +
+        (firstBreak ? ' [break at ' + firstBreak + ']' : ''), monotonic, true);
+    }
+
+    // Spot-check the exact step sweep at mag 6 against the worked example.
+    const expectAtMag6 = [10e3, 50e3, 100e3, 250e3, 500e3, 750e3, 1e6, 2.5e6, 5e6, 7.5e6, 10e6];
+    STOPS.forEach((offset, i) => {
+      eq('AC2-mono mag=6: offset ' + offset + ' → step ' + expectAtMag6[i],
+        stepForOffset(1e6, offset), expectAtMag6[i]);
+    });
   })();
 
   // -------------------------------------------------------------------------
@@ -11437,8 +11481,8 @@ function fireMouseClick(buttonEl, fn) {
     failures.push({ name: 'dots-tick: pct() function found in sidebar.js', actual: false, expected: true });
   } else {
     passed++;
-    // The 11 stops in order (k=0..10):
-    const stops = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+    // The 11 stops in strategy-monotonic order (k=0..10), mirroring STOPS:
+    const stops = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
     const N = stops.length;
     // pct() now closes over STOPS and snap(); supply both so the extracted body
     // runs standalone. snap() is the nearest-stop fallback for non-stop inputs.
@@ -11679,7 +11723,7 @@ function fireMouseClick(buttonEl, fn) {
 
   eq('AC2-mag3: oomLabel is "1k+"', oomLabel, '1k+');
 
-  const offsets = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
+  const offsets = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
   for (const offset of offsets) {
     const tag     = 'AC2-mag3 offset=' + offset;
     const stepLbl = formatStep(stepForOffset(oomVal, offset));

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -10848,7 +10848,7 @@ function fireMouseClick(buttonEl, fn) {
   // "×" multiplier.
   // -------------------------------------------------------------------------
   (function hdrAllStops() {
-    const stops = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
+    const stops = [-2, -1.5, -1, -0.25, -0.5, 0, 0.25, 0.5, 1];
     const testMags = [6, 5]; // 1M and 100k
 
     for (const mag of testMags) {
@@ -10883,7 +10883,7 @@ function fireMouseClick(buttonEl, fn) {
       return;
     }
     const STOPS = m[1].split(',').map((s) => parseFloat(s.trim()));
-    eq('AC2-mono: STOPS has 11 stops', STOPS.length, 11);
+    eq('AC2-mono: STOPS has 9 stops', STOPS.length, 9);
 
     for (const mag of [6, 5, 3, 9]) {
       const oomVal = Math.pow(10, mag);
@@ -10903,7 +10903,7 @@ function fireMouseClick(buttonEl, fn) {
     }
 
     // Spot-check the exact step sweep at mag 6 against the worked example.
-    const expectAtMag6 = [10e3, 50e3, 100e3, 250e3, 500e3, 750e3, 1e6, 2.5e6, 5e6, 7.5e6, 10e6];
+    const expectAtMag6 = [10e3, 50e3, 100e3, 250e3, 500e3, 1e6, 2.5e6, 5e6, 10e6];
     STOPS.forEach((offset, i) => {
       eq('AC2-mono mag=6: offset ' + offset + ' → step ' + expectAtMag6[i],
         stepForOffset(1e6, offset), expectAtMag6[i]);
@@ -11481,8 +11481,8 @@ function fireMouseClick(buttonEl, fn) {
     failures.push({ name: 'dots-tick: pct() function found in sidebar.js', actual: false, expected: true });
   } else {
     passed++;
-    // The 11 stops in strategy-monotonic order (k=0..10), mirroring STOPS:
-    const stops = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
+    // The 9 stops in strategy-monotonic order (k=0..8), mirroring STOPS:
+    const stops = [-2, -1.5, -1, -0.25, -0.5, 0, 0.25, 0.5, 1];
     const N = stops.length;
     // pct() now closes over STOPS and snap(); supply both so the extracted body
     // runs standalone. snap() is the nearest-stop fallback for non-stop inputs.
@@ -11509,17 +11509,17 @@ function fireMouseClick(buttonEl, fn) {
       }
     });
 
-    // AC1b: Key exact values — extremes and the zero stop (index 6 of 11).
+    // AC1b: Key exact values — extremes and the zero stop (index 5 of 9).
     const pctNeg2 = pct(-2);
     const pctZero = pct(0);
     const pctPos1 = pct(1);
 
-    eq('dots-tick: pct(-2) ≈ 4.5455% (1st cell centre)',
+    eq('dots-tick: pct(-2) ≈ 5.5556% (1st cell centre)',
       Math.abs(pctNeg2 - 0.5 / N * 100) < TOL, true);
-    eq('dots-tick: pct(0) ≈ 59.0909% (7th cell centre, asymmetric range)',
-      Math.abs(pctZero - 6.5 / N * 100) < TOL, true);
-    eq('dots-tick: pct(1) ≈ 95.4545% (11th cell centre)',
-      Math.abs(pctPos1 - 10.5 / N * 100) < TOL, true);
+    eq('dots-tick: pct(0) ≈ 61.1111% (6th cell centre, asymmetric range)',
+      Math.abs(pctZero - 5.5 / N * 100) < TOL, true);
+    eq('dots-tick: pct(1) ≈ 94.4444% (9th cell centre)',
+      Math.abs(pctPos1 - 8.5 / N * 100) < TOL, true);
 
     // AC1c: the extremes are inset by half a cell, never flush at 0/100.
     // A value-proportional formula would push an end stop to 0 or 100; the
@@ -11529,12 +11529,12 @@ function fireMouseClick(buttonEl, fn) {
     eq('dots-tick: pct(1) is NOT 100 (end stop is inset by half a cell)',
       pct(1) !== 100, true);
 
-    // AC2: Monotonic — pct is strictly increasing across all 11 stops.
+    // AC2: Monotonic — pct is strictly increasing across all 9 stops.
     let monotonic = true;
     for (let i = 1; i < stops.length; i++) {
       if (pct(stops[i]) <= pct(stops[i - 1])) { monotonic = false; break; }
     }
-    eq('dots-tick: pct() is strictly increasing across all 11 stops', monotonic, true);
+    eq('dots-tick: pct() is strictly increasing across all 9 stops', monotonic, true);
 
     // AC3: Equal columns — adjacent stops are exactly one cell (100/N %) apart,
     // regardless of the uneven numeric spacing of the stop values.
@@ -11546,15 +11546,15 @@ function fireMouseClick(buttonEl, fn) {
     eq('dots-tick: adjacent stops are one equal column (100/N %) apart', equalCols, true);
   }
 
-  // --- AC4: 11-column grid assumption — verify tick markup matches formula ---
+  // --- AC4: 9-column grid assumption — verify tick markup matches formula ---
   // The pct formula assumes N equal columns. Adversarial check: count the actual
-  // tick spans and verify the CSS declares exactly repeat(11, 1fr).
+  // tick spans and verify the CSS declares exactly repeat(9, 1fr).
   const tickSpans = (sidebarHtmlSrc.match(/class="t"/g) || []).length;
-  eq('dots-tick: .dual-ticks contains exactly 11 tick spans (matches pct() formula)',
-    tickSpans, 11);
+  eq('dots-tick: .dual-ticks contains exactly 9 tick spans (matches pct() formula)',
+    tickSpans, 9);
 
-  eq('dots-tick: .dual-ticks CSS uses repeat(11, 1fr) grid',
-    /\.dual-ticks\s*\{[^}]*grid-template-columns\s*:\s*repeat\(11,\s*1fr\)/.test(sidebarHtmlSrc), true);
+  eq('dots-tick: .dual-ticks CSS uses repeat(9, 1fr) grid',
+    /\.dual-ticks\s*\{[^}]*grid-template-columns\s*:\s*repeat\(9,\s*1fr\)/.test(sidebarHtmlSrc), true);
 
   // --- AC5: Vertical CSS — .dual-ticks uses top: 20px (not 22px) ---
   eq('dots-tick: .dual-ticks CSS top is 20px',
@@ -11723,7 +11723,7 @@ function fireMouseClick(buttonEl, fn) {
 
   eq('AC2-mag3: oomLabel is "1k+"', oomLabel, '1k+');
 
-  const offsets = [-2, -1.5, -1, -0.25, -0.5, -0.75, 0, 0.25, 0.5, 0.75, 1];
+  const offsets = [-2, -1.5, -1, -0.25, -0.5, 0, 0.25, 0.5, 1];
   for (const offset of offsets) {
     const tag     = 'AC2-mag3 offset=' + offset;
     const stepLbl = formatStep(stepForOffset(oomVal, offset));


### PR DESCRIPTION
Follow-up to #180. That PR merged only its first commit, which left an 11-stop, **numerically ascending** stop array on `main`:

```
const STOPS = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1];
```

That ordering makes the rounding strategy bounce (e.g. at mag 6: `…100K, 750K, 500K, 250K, 1M…`) because `stepForOffset` is non-monotonic in the offset value. This PR brings the two follow-up commits that were never merged.

### Result
```
const STOPS = [-2, -1.5, -1, -0.25, -0.5, 0, 0.25, 0.5, 1];   // 9 stops
```
Stops are ordered by resulting **step**, so the strategy sweeps in one direction. At mag 6: `10K, 50K, 100K, 250K, 500K, 1M, 2.5M, 5M, 10M`. The 750K / 7.5M stops were dropped per design decision.

### Commits
- `623070a` — order stops by strategy, not offset value (fixes the bounce; `-0.25` precedes `-0.5`, `-1` follows `-1.5`).
- `53cab2e` — drop 750K / 7.5M, leaving the 9-stop set; tick grid back to `repeat(9, 1fr)`, zero tick is the 6th.

The index-based `pct()` / drag geometry positions thumbs by array index, so reordering the array is sufficient. Adds a strategy-monotonicity test that reads `STOPS` from source and asserts `stepForOffset` strictly increases across it (mags 6/5/3/9) plus the exact mag-6 sweep.

### Tests
`node tests.js` -> 1367 passed, 0 failed.