### PR TITLE
Two-line largest-numbers preview and per-OoM examples

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -408,21 +408,17 @@ function extractPreviewSamples(table) {
     }
   }
 
-  // Bottom band: remaining magnitudes, one per bucket, descending. If <3
-  // distinct buckets remain, fill from the largest remaining bucket.
+  // Bottom band: one representative per remaining (lower) order of magnitude,
+  // descending. Every distinct magnitude present gets its own example — there
+  // is no cap — so e.g. a dataset of 1234 / 123 / -12 yields a top-band 1k+
+  // line plus bottom-band 100+ and 10+ lines. Magnitude is floor(log10|num|),
+  // so negatives bucket by their absolute value.
   const bottomMags = Array.from(byMag.keys())
     .filter(m => (maxMag - m) >= numTop)
     .sort((a, b) => b - a);
   const bottom = [];
   for (const m of bottomMags) {
-    if (bottom.length >= 3) break;
     bottom.push(demoFirst(byMag.get(m), otherOffset)[0]);
-  }
-  if (bottom.length < 3 && bottomMags.length > 0) {
-    const bucket = demoFirst(byMag.get(bottomMags[0]), otherOffset);
-    for (let i = 1; i < bucket.length && bottom.length < 3; i++) {
-      bottom.push(bucket[i]);
-    }
   }
 
   const toRow = c => ({ original: c.text, num: c.num });

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -202,20 +202,15 @@
     .results-band .num { color: #202124; text-align: right; }
     .results-band .oom-label { color: #b3623d; }
     .results-band .step-label { color: #b3623d; }
-    .results-band .strategy { color: #1a73e8; grid-column: 1 / -1; font-style: italic; }
-    /* Top band: strategy header + worked example share one line and wrap
-       together (as whole units) when the sidebar is too narrow for both. */
-    #topBand {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      align-items: baseline;
-      column-gap: 8px;
-      row-gap: 2px;
-    }
-    #topBand .strategy,
-    #topBand .example { white-space: nowrap; }
-    #topBand .example .arrow { margin: 0 4px; }
+    /* Top band: strategy header on the first line, worked example on the
+       second. Both render as from|arrow|num pairs in the shared 3-column grid,
+       so the two "→" arrows line up vertically between the lines. */
+    #topBand .strategy { font-style: italic; }
+    #topBand .strategy .from,
+    #topBand .strategy .arrow,
+    #topBand .strategy .num { color: #1a73e8; }
+    #topBand .from,
+    #topBand .num { white-space: nowrap; }
     .results-band .empty {
       color: #80868b;
       font-style: italic;

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -208,31 +208,46 @@ function formatStrategyHeader(maxMag, offset) {
 }
 
 /**
- * Render the top preview band: the strategy header (blue) and a single worked
- * example ("e.g. <original> → <rounded>", black) share one line, wrapping to
- * two lines only when the sidebar is too narrow to fit both. The example
- * carries no step annotation and shows the bare original number (text stripped
- * per #3).
+ * Render the top preview band on two lines: the strategy header (blue) on the
+ * first line and a single worked example ("e.g. <original> → <rounded>", black)
+ * on the second. Both lines are laid out as from|arrow|num pairs in the shared
+ * 3-column grid so their "→" arrows line up vertically. The example carries no
+ * step annotation and shows the bare original number (text stripped per #3).
  */
 function renderTopBand(el, rows, offset) {
   if (!el) return;
   el.innerHTML = '';
   if (!rows || rows.length === 0) return;
 
-  // Strategy header, e.g. "1M+ → nearest 250k". Kept whole (nowrap) so it never
-  // breaks mid-phrase; the flex container wraps it as a unit beside the example.
+  // Strategy line, e.g. "1M+ → nearest 250k", split into the same
+  // from | arrow | num columns as the example so the arrows align.
   if (cachedMaxMag !== null && cachedMaxMag !== undefined) {
-    const headerEl = document.createElement('span');
-    headerEl.className = STRATEGY_CLASS;
-    headerEl.textContent = formatStrategyHeader(cachedMaxMag, offset);
-    el.appendChild(headerEl);
+    const step = stepForOffset(Math.pow(10, cachedMaxMag), offset);
+    const strat = document.createElement('div');
+    strat.className = 'pair ' + STRATEGY_CLASS;
+
+    const stratFrom = document.createElement('span');
+    stratFrom.className = 'from';
+    stratFrom.textContent = formatOomLabel(cachedMaxMag);
+    strat.appendChild(stratFrom);
+
+    const stratArrow = document.createElement('span');
+    stratArrow.className = 'arrow';
+    stratArrow.textContent = '→';
+    strat.appendChild(stratArrow);
+
+    const stratNum = document.createElement('span');
+    stratNum.className = 'num';
+    stratNum.textContent = 'nearest ' + formatStep(step);
+    strat.appendChild(stratNum);
+
+    el.appendChild(strat);
   }
 
-  // Single example (PREVIEW_NUM_TOP = 1), grouped in one nowrap span so the
-  // whole "e.g. … → …" wraps to the next line as a unit when space is tight.
+  // Single example (PREVIEW_NUM_TOP = 1) on its own line below the strategy.
   const row = rows[0];
-  const example = document.createElement('span');
-  example.className = 'example';
+  const example = document.createElement('div');
+  example.className = 'pair example';
 
   const from = document.createElement('span');
   from.className = 'from';

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -4044,6 +4044,41 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   eq('extractPreviewSamples: bottom[2] is 56', result.samples.bottom[2].num, 56);
 })();
 
+(function previewBand_extractPreviewSamples_onePerOrderOfMagnitude() {
+  // The bottom band shows one example per distinct lower order of magnitude,
+  // with no cap. Negatives bucket by absolute value. For 1234 / 123 / -12 the
+  // preview is three lines: top-band 1k+ (1234) plus bottom-band 100+ (123)
+  // and 10+ (|-12|).
+  function tdCell(text) {
+    return { tagName: 'TD', innerText: text, textContent: text };
+  }
+  const table = {
+    rows: [{ cells: [tdCell('1234'), tdCell('123'), tdCell('-12')] }],
+  };
+  const result = extractPreviewSamples(table);
+  eq('onePerOom: maxMag is 3 (1234)', result.maxMag, 3);
+  eq('onePerOom: top band is the 1k+ value (1234)', result.samples.top[0].num, 1234);
+  eq('onePerOom: bottom band has one row per lower magnitude (2)',
+    result.samples.bottom.length, 2);
+  eq('onePerOom: bottom[0] is the 100+ value (123)', result.samples.bottom[0].num, 123);
+  eq('onePerOom: bottom[1] is the 10+ value, abs of -12', result.samples.bottom[1].num, -12);
+
+  // No cap: five distinct lower magnitudes yield five bottom rows (old code
+  // capped the band at 3).
+  const deep = {
+    rows: [{ cells: [
+      tdCell('7,000,000'),                                  // mag 6 -> top
+      tdCell('500,000'), tdCell('40,000'), tdCell('3,000'), // mags 5,4,3
+      tdCell('200'), tdCell('10'),                          // mags 2,1
+    ] }],
+  };
+  const deepResult = extractPreviewSamples(deep);
+  eq('onePerOom: uncapped bottom band has 5 rows (one per lower OoM)',
+    deepResult.samples.bottom.length, 5);
+  eq('onePerOom: bottom rows are descending by magnitude',
+    deepResult.samples.bottom.map(r => r.num), [500000, 40000, 3000, 200, 10]);
+})();
+
 (function previewBand_extractPreviewSamples_prefersDemonstrative() {
   // Within a magnitude bucket, an already-round value (250,000,000) would make
   // a useless "X -> X" preview row. extractPreviewSamples should surface a cell
@@ -11138,10 +11173,11 @@ function fireMouseClick(buttonEl, fn) {
   eq('AC4-src: STEP_LABEL_CLASS constant is "step-label" in source',
     /const STEP_LABEL_CLASS\s*=\s*['"]step-label['"]/.test(sidebarSrc), true);
 
-  // AC4e: when cachedMaxMag is set, the top band renders the strategy header
-  // AND the example into the same band container (which the #topBand flex rule
-  // lays out on one line, wrapping each as a whole unit). Rebuild the render
-  // helpers with a non-null cachedMaxMag to exercise the header path.
+  // AC4e: when cachedMaxMag is set, the top band renders the strategy line AND
+  // the example as two from|arrow|num pairs in the same band container (the
+  // #topBand grid lays them on two lines with their "→" arrows aligned in the
+  // middle column). Rebuild the render helpers with a non-null cachedMaxMag to
+  // exercise the header path.
   let renderHelpersWithMag;
   try {
     renderHelpersWithMag = (new Function(
@@ -11155,25 +11191,39 @@ function fireMouseClick(buttonEl, fn) {
   if (renderHelpersWithMag) {
     const topWithHdr = makeBandEl();
     renderHelpersWithMag.renderTopBand(topWithHdr, [{ num: 8584629, original: '8,584,629' }], -0.5);
-    eq('AC4e: top band appends 2 elements (strategy header + example)',
+    eq('AC4e: top band appends 2 elements (strategy line + example)',
       topWithHdr._appended.length, 2);
-    eq('AC4e: first appended element is the strategy header (class "strategy")',
-      topWithHdr._appended[0].className, 'strategy');
-    eq('AC4e: strategy header text starts "1M+ → nearest" (maxMag=6)',
-      topWithHdr._appended[0].textContent.indexOf('1M+ → nearest') === 0, true);
-    eq('AC4e: second appended element groups the example (class "example")',
-      topWithHdr._appended[1].className, 'example');
-    eq('AC4e: example group has 3 cells (from/arrow/num)',
-      topWithHdr._appended[1]._children.length, 3);
+    const stratPair = topWithHdr._appended[0];
+    const examplePair = topWithHdr._appended[1];
+    eq('AC4e: first appended element is the strategy pair (class "pair strategy")',
+      stratPair.className, 'pair strategy');
+    eq('AC4e: strategy pair has 3 cells (from/arrow/num)',
+      stratPair._children.length, 3);
+    eq('AC4e: strategy "from" is the OoM label "1M+" (maxMag=6)',
+      stratPair._children[0].textContent, '1M+');
+    eq('AC4e: strategy "num" starts "nearest "',
+      stratPair._children[2].textContent.indexOf('nearest ') === 0, true);
+    eq('AC4e: second appended element is the example pair (class "pair example")',
+      examplePair.className, 'pair example');
+    eq('AC4e: example pair has 3 cells (from/arrow/num)',
+      examplePair._children.length, 3);
+    // The two "→" arrows sit in the same (middle) grid column so they align.
+    eq('AC4e: strategy arrow is in the middle cell ("→")',
+      stratPair._children[1].textContent, '→');
+    eq('AC4e: example arrow is in the middle cell ("→")',
+      examplePair._children[1].textContent, '→');
   }
 
-  // AC4f: sidebar.html lays the top band out as a wrapping flex row so the
-  // strategy + example share one line (and wrap together when too narrow).
+  // AC4f: sidebar.html lays the top band out on the shared results-band grid
+  // (no flex override), so the strategy line and the example line stack and
+  // their "→" arrows align in the middle column. The strategy cells are blue.
   const sidebarHtmlSrc = fs.readFileSync(path.join(__dirname, 'sidebar.html'), 'utf8');
-  eq('AC4f: #topBand rule sets display:flex in sidebar.html',
-    /#topBand\s*\{[^}]*display:\s*flex/.test(sidebarHtmlSrc), true);
-  eq('AC4f: #topBand rule sets flex-wrap:wrap in sidebar.html',
-    /#topBand\s*\{[^}]*flex-wrap:\s*wrap/.test(sidebarHtmlSrc), true);
+  eq('AC4f: #topBand element carries the results-band grid class',
+    /<div[^>]*id="topBand"[^>]*class="results-band"|<div[^>]*class="results-band"[^>]*id="topBand"/.test(sidebarHtmlSrc), true);
+  eq('AC4f: #topBand is NOT overridden to display:flex',
+    /#topBand\s*\{[^}]*display:\s*flex/.test(sidebarHtmlSrc), false);
+  eq('AC4f: #topBand strategy cells are blue (#1a73e8)',
+    /#topBand \.strategy \.num\s*\{\s*color:\s*#1a73e8/.test(sidebarHtmlSrc), true);
   eq('AC4f: .step-label colour rule present in sidebar.html',
     /\.step-label\s*\{\s*color:\s*#b3623d/.test(sidebarHtmlSrc), true);
 


### PR DESCRIPTION
## Summary

Two refinements to the sidebar rounding preview.

### "Largest numbers" band — line break + aligned arrows
- The strategy (`1M+ → nearest 500k`) and the worked example (`e.g. 1,234,567 → 1,000,000`) now render on two separate lines instead of sharing one wrapping line.
- Both lines render as `from | arrow | num` pairs on the shared `results-band` grid, so their `→` arrows line up vertically in the middle column.

### Lower orders of magnitude — one example per OoM
- The bottom band now shows one example per distinct lower order of magnitude, uncapped (previously capped at 3 with same-bucket backfill). Magnitude is `floor(log10|num|)`, so negatives bucket by their absolute value.
- Example: a dataset of `1234 / 123 / -12` yields `1k+` (top band) plus `100+` and `10+` (bottom band).

## Tests
- Updated the affected band-rendering assertions (AC4e/AC4f) and added coverage for the per-OoM/uncapped behavior and the `1234 / 123 / -12` case.
- `node chrome-extension/tests.js` → 1379 passed, 0 failed
- `node js/tests.js` → 158 passed, 0 failed