### PR TITLE
fix: stop reading lowercase "ad"/"bp" as era years

### DIFF
--- a/chrome-extension/parsing.js
+++ b/chrome-extension/parsing.js
@@ -487,13 +487,25 @@ function extractNumbersInText(text) {
 // rounded by date logic (decade/century), never by the numeric offset. These
 // helpers locate such year tokens so they can be excluded from numeric magnitude
 // detection, numeric rounding, and the sidebar preview examples (issue #4).
-const ERA_MARKER = '(?:A\\.?D\\.?|B\\.?C\\.?E\\.?|B\\.?C\\.?|C\\.?E\\.?|A\\.?H\\.?|B\\.?P\\.?)';
+// Period-less markers must be UPPERCASE. Bare lowercase forms ("ad", "bp",
+// "ah", "ce", "bc") collide with ordinary English words and abbreviations
+// ("ad hoc", "120 bp" basis points, "ah") and must not be read as years.
+// Conventionally written eras are uppercase (AD, BC, CE, BCE, AH, BP), so this
+// keeps real years matching while dropping the word collisions. BCE precedes BC
+// so the longer marker wins the alternation.
+const ERA_MARKER_UPPER = '(?:AD|BCE|BC|CE|AH|BP)';
+// Period-punctuated forms are unambiguous, so they stay case-insensitive
+// ("A.D.", "a.d.", "B.C.E.", …). Each requires at least its first period, so a
+// bare uppercase form is matched only by ERA_MARKER_UPPER above.
+const ERA_MARKER_DOTTED = '(?:[Aa]\\.[Dd]\\.?|[Bb]\\.[Cc]\\.[Ee]\\.?|[Bb]\\.[Cc]\\.?|[Cc]\\.[Ee]\\.?|[Aa]\\.[Hh]\\.?|[Bb]\\.[Pp]\\.?)';
+const ERA_MARKER = '(?:' + ERA_MARKER_UPPER + '|' + ERA_MARKER_DOTTED + ')';
 // "<year> <era>": the digits are not part of a larger number (no leading digit
 // or decimal point) and the era marker is a standalone token (not followed by a
-// letter, so "ADELAIDE" / "ADD" never match).
-const ERA_YEAR_AFTER_RE = new RegExp('(?<![\\d.])(\\d[\\d,]*)\\s*' + ERA_MARKER + '(?![A-Za-z])', 'gi');
+// letter, so "ADELAIDE" / "ADD" never match). Case-sensitive ('g', not 'gi') so
+// the uppercase-only requirement on period-less markers holds.
+const ERA_YEAR_AFTER_RE = new RegExp('(?<![\\d.])(\\d[\\d,]*)\\s*' + ERA_MARKER + '(?![A-Za-z])', 'g');
 // "<era> <year>": e.g. "AD 79". Era marker preceded by a non-letter boundary.
-const ERA_YEAR_BEFORE_RE = new RegExp('(?<![A-Za-z])' + ERA_MARKER + '\\s+(\\d[\\d,]*)', 'gi');
+const ERA_YEAR_BEFORE_RE = new RegExp('(?<![A-Za-z])' + ERA_MARKER + '\\s+(\\d[\\d,]*)', 'g');
 
 /**
  * Return {start, end} ranges (offsets into `text`) of every digit run that
@@ -504,12 +516,12 @@ function eraYearDigitRanges(text) {
   if (typeof text !== 'string') return [];
   const ranges = [];
   let m;
-  const after = new RegExp(ERA_YEAR_AFTER_RE.source, 'gi');
+  const after = new RegExp(ERA_YEAR_AFTER_RE.source, 'g');
   while ((m = after.exec(text)) !== null) {
     const start = m.index + m[0].indexOf(m[1]);
     ranges.push({ start, end: start + m[1].length });
   }
-  const before = new RegExp(ERA_YEAR_BEFORE_RE.source, 'gi');
+  const before = new RegExp(ERA_YEAR_BEFORE_RE.source, 'g');
   while ((m = before.exec(text)) !== null) {
     const start = m.index + m[0].lastIndexOf(m[1]);
     ranges.push({ start, end: start + m[1].length });

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -11911,6 +11911,19 @@ function fireMouseClick(buttonEl, fn) {
   eq('era: "ADELAIDE 12" does NOT match (AD inside a word)',
     isEraYear('ADELAIDE 12', 'ADELAIDE '.length, '12'), false);
 
+  // Lowercase, period-less marker letters are ordinary words/abbreviations, not
+  // eras: "3,420 ad hoc", "120 bp" (basis points), "5 ah", "12 ce", "9 bc".
+  // These must NOT be read as years (they'd otherwise be excluded from rounding).
+  eq('era: "3,420 ad hoc" → "ad" is a word, NOT an era year',
+    isEraYear('3,420 ad hoc', 0, '3,420'), false);
+  eq('era: "120 bp" (basis points) is NOT an era year',
+    isEraYear('120 bp', 0, '120'), false);
+  eq('era: "5 ah" is NOT an era year',
+    isEraYear('5 ah', 0, '5'), false);
+  // Period-punctuated lowercase forms stay unambiguous and DO match.
+  eq('era: "79 a.d." (dotted, lowercase) is still an era year',
+    isEraYear('79 a.d.', 0, '79'), true);
+
   function tdCell(text) {
     return { tagName: 'TD', innerText: text, textContent: text };
   }
@@ -11924,6 +11937,17 @@ function fireMouseClick(buttonEl, fn) {
     nums.includes(2898), false);
   eq('era-collect: 1,050,000,000 (real number) still collected',
     nums.includes(1050000000), true);
+
+  // Regression: "~3,420 ad hoc" — "ad" was being read as the AD era marker, so
+  // the 3,420 was dropped and the cell never rounded. It must now be collected.
+  const adHocCells = collectNumericCells({
+    rows: [{ cells: [tdCell('~30,800 PAD (EFT)'), tdCell('~3,420 ad hoc')] }],
+  });
+  const adHocNums = adHocCells.map(c => c.num);
+  eq('era-collect: "~3,420 ad hoc" number is collected (not an era year)',
+    adHocNums.includes(3420), true);
+  eq('era-collect: "~30,800 PAD (EFT)" number is collected',
+    adHocNums.includes(30800), true);
 
   // extractPreviewSamples: maxMag comes from the real number, not the era year,
   // and no sample row carries the era-year value.


### PR DESCRIPTION
## Problem

In a mixed-text table cell, `~3,420 ad hoc` was left un-rounded while its sibling `~30,800 PAD (EFT)` rounded to `~30,000`.

The cause is misclassification, not rounding math. The era-year detector (`isEraYear` / `ERA_YEAR_AFTER_RE` in `parsing.js`) matched bare marker letters **case-insensitively**, so the `ad` in `ad hoc` matched the `AD` (Anno Domini) marker and `3,420` was treated as the calendar year "3420 AD". Era-marked years are deliberately excluded from numeric rounding (#4, so genuine years like `2898 AD` aren't mangled to `3000`), so the number was dropped from the match set, the cell was classified `skip`, and it was never rounded or tagged.

This affects every period-less marker whose letters spell a common word/abbreviation: `ad` (ad hoc), `bp` (basis points), `ah`, `ce`, `bc`.

## Fix

Require period-less era markers (`AD BC CE BCE AH BP`) to be **uppercase** — the conventional form — and keep period-punctuated forms (`A.D.`, `a.d.`) case-insensitive. The two regexes drop the `i` flag (and so do their reconstructions in `eraYearDigitRanges`).

Genuine years still match (`2898 AD`, `500 BC`, `1200 CE`, `2,898 BCE`, `79 a.d.`); lowercase word collisions no longer do.

### Trade-off

Lowercase period-less eras (e.g. `500 bc`) are no longer recognised as years. That lowercase form is exactly the ambiguity behind the bug, and uppercase is the standard convention, so this is an intentional choice.

## Tests

Added `isEraYear` cases for each collision (`ad hoc`, `120 bp`, `5 ah`) plus a dotted-lowercase positive (`79 a.d.`), and an end-to-end `collectNumericCells` regression on the exact `~3,420 ad hoc` / `~30,800 PAD (EFT)` row. Full suite: 1399 passed, 0 failed (`node chrome-extension/tests.js`).