### PR TITLE
fix: restore grid cell text when table pillbox toggles off rounding

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1016,10 +1016,16 @@ function toggleOriginalValues(table) {
     resetTable(table);
     roundTable(table, opts);
   } else {
-    // Restore each cell to its pristine HTML; keep the class and dataset so
+    // Restore each cell to its pristine value; keep the class and dataset so
     // a subsequent toggle knows to re-round.
     for (const cell of roundedCells) {
-      if (cell.dataset.originalHtml !== undefined) {
+      if (cell.dataset.drOriginal !== undefined) {
+        // Grid path: restore the text node in place (preserves node identity).
+        const tn = findCellTextNode(cell);
+        if (tn !== null) {
+          tn.nodeValue = cell.dataset.drOriginal;
+        }
+      } else if (cell.dataset.originalHtml !== undefined) {
         cell.innerHTML = cell.dataset.originalHtml;
       }
       cell.removeAttribute('title');


### PR DESCRIPTION
## What

When the per-table pillbox toggle was clicked to turn off rounding on a virtualized grid (e.g. Kaggle's Data Explorer), the data stayed rounded even though the sidebar checkbox correctly synced to the off state.

## Why

`toggleOriginalValues` had two storage formats to handle but only handled one:

- **Native `<table>` cells** store the original HTML in `dataset.originalHtml` → restored via `innerHTML`
- **Virtualized grid cells** store the original text in `dataset.drOriginal` → must be restored via text-node `nodeValue` patch

The "show original" branch only did the `innerHTML` path, so grid cells were left unchanged (silent no-op).

`resetTable` (called by the sidebar path) already handles both formats correctly, which is why toggling via the sidebar worked fine.

## Fix

Added the grid path to the else branch of `toggleOriginalValues` (`content.js`), mirroring the text-node restore in `resetTable` but intentionally keeping `dr-ext-rounded` and `drOriginal` intact so toggling back on still works.

## Reviewer notes

Only `content.js` is touched — one new branch inside the existing for-loop.