### PR TITLE
fix: stop grid re-apply observer fighting the show-originals toggle

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -664,6 +664,22 @@ function reapplyGridRounding(wrapperEl) {
     return;
   }
 
+  // Showing-original guard: when the per-table toggle has flipped the grid to
+  // show pristine values (toggleOriginalValues sets drShowingOriginal='true'),
+  // re-applying rounding would fight the toggle. The restore writes original
+  // text nodes, which themselves fire characterData mutations on the scroll
+  // container; without this guard the observer re-rounds them ~100ms later,
+  // making the cell flash original then snap back to rounded and leaving the
+  // toggle/sidebar state disconnected from the DOM. Reconnect (so future
+  // re-rounds after toggling back on still work) and bail without writing.
+  if (wrapperEl.dataset && wrapperEl.dataset.drShowingOriginal === 'true') {
+    if (observer) {
+      const scrollContainer = new GridAdapter(wrapperEl)._getScrollContainer();
+      observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
+    }
+    return;
+  }
+
   // Delegate to the single shared classify+compute function.
   // targetValue is null for excluded/out-of-range/skip cells (leave untouched).
   const cellTargets = computeGridRoundedValues(wrapperEl, opts);
@@ -1016,6 +1032,12 @@ function toggleOriginalValues(table) {
     resetTable(table);
     roundTable(table, opts);
   } else {
+    // Set the showing-original flag BEFORE mutating cells. Restoring grid cells
+    // writes their text nodes, which fire characterData mutations the grid's
+    // re-apply observer is listening for; setting the flag first guarantees the
+    // debounced reapplyGridRounding (and its showing-original guard) sees the
+    // toggled state and leaves the originals in place instead of re-rounding.
+    table.dataset.drShowingOriginal = 'true';
     // Restore each cell to its pristine value; keep the class and dataset so
     // a subsequent toggle knows to re-round.
     for (const cell of roundedCells) {
@@ -1030,7 +1052,6 @@ function toggleOriginalValues(table) {
       }
       cell.removeAttribute('title');
     }
-    table.dataset.drShowingOriginal = 'true';
   }
   syncSwitchForTable(table);
 }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -6982,6 +6982,9 @@ function makeElementNode(className, childNodes) {
     childNodes: kids,
     children: kids.filter(n => n.nodeType === 1),
     dataset: {},
+    // Real DOM elements expose removeAttribute; toggleOriginalValues calls it on
+    // every restored cell (to drop the rounding tooltip). No-op in the stub.
+    removeAttribute() {},
     classList: (() => {
       const c = [];
       return {
@@ -8128,6 +8131,65 @@ function flushTimers(pendingTimers) {
     // Original value must be restored.
     eq('GV5: cell[0] text node value is restored to original after resetTable',
       grid.cellEls[0].childNodes[0].nodeValue, '8584629');
+
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// GV5b (Regression #cstif9): Per-table toggle → show originals on a virtualized
+// grid. toggleOriginalValues restores pristine values; the still-connected grid
+// re-apply observer must NOT re-round them. Before the fix, the observer saw the
+// restore writes' characterData mutations and re-rounded the cells ~100ms later,
+// making them flash original then snap back to rounded and leaving the toggle
+// state (drShowingOriginal='true') disconnected from the DOM.
+// ---------------------------------------------------------------------------
+(function gv5b_toggleOriginal_observerDoesNotReRound() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { grid, pendingTimers } = ctx;
+    const obs = ctx.capturedObserver;
+
+    // Pre-condition: cells are rounded after roundTable.
+    eq('GV5b (pre): cell[0] is rounded after roundTable',
+      grid.cellEls[0].classList.contains('dr-ext-rounded'), true);
+
+    // User clicks the per-table pillbox toggle to show original values.
+    toggleOriginalValues(grid.wrapperEl);
+
+    // Flag must be set and originals restored.
+    eq('GV5b: drShowingOriginal is "true" after toggleOriginalValues',
+      grid.wrapperEl.dataset.drShowingOriginal, 'true');
+    eq('GV5b: cell[0] text node restored to original',
+      grid.cellEls[0].childNodes[0].nodeValue, '8584629');
+
+    // The restore writes fire characterData mutations the observer listens for.
+    // Simulate that, then flush the debounce timer.
+    obs.trigger([{ type: 'characterData' }]);
+    flushTimers(pendingTimers);
+
+    // The cell must STILL show the original value — the re-apply guard bails
+    // because drShowingOriginal === 'true'.
+    eq('GV5b: cell[0] still original after observer fires (no re-round)',
+      grid.cellEls[0].childNodes[0].nodeValue, '8584629');
+    eq('GV5b: cell[1] still original after observer fires (no re-round)',
+      grid.cellEls[1].childNodes[0].nodeValue, '100');
+
+    // Toggling back on must re-round (resetTable + roundTable path).
+    toggleOriginalValues(grid.wrapperEl);
+    eq('GV5b: drShowingOriginal cleared after toggling back on',
+      grid.wrapperEl.dataset.drShowingOriginal, undefined);
+    eq('GV5b: cell[0] re-rounded after toggling back on',
+      grid.cellEls[0].childNodes[0].nodeValue !== '8584629', true);
 
   } finally {
     if (ctx) {


### PR DESCRIPTION
## Problem

On virtualized grids (e.g. Kaggle's Data Explorer), the per-table pillbox toggle was disconnected from the actual DOM: toggling rounding **off** made cells flash their original values and then snap back to rounded, leaving the toggle/sidebar reporting "off" while the table stayed rounded.

## Root cause

`roundTable` attaches a `MutationObserver` to the grid's scroll container that re-rounds cells whenever their text changes (debounced ~100ms) — this keeps virtualized rows rounded as you scroll.

The "show originals" path (`toggleOriginalValues`) restored pristine values by writing cell text nodes, but never told that observer to stand down. Those restore writes fired `characterData` mutations, so the observer re-rounded the cells ~100ms later. `resetTable` already disconnects the observer before restoring; `toggleOriginalValues` did not, and `reapplyGridRounding` never checked the `drShowingOriginal` flag.

## Fix

- `reapplyGridRounding` now bails (reconnect + return, no writes) when the table is in the showing-original state, so restored originals stay put and scrolled-in rows remain original too.
- `toggleOriginalValues` sets `drShowingOriginal='true'` **before** mutating cells, so any in-flight debounced re-apply already sees the toggled state.

## Tests

- Adds **GV5b** regression test: drives the grid observer after `toggleOriginalValues` and asserts cells stay original (no re-round), then asserts re-round on toggle-back. Verified it fails without the guard.
- Adds a no-op `removeAttribute` to the element test stub to mirror real DOM cells.
- Full suite green: 1406 passed, 0 failed.