### PR TITLE
Treat <th> row headers as the first column; default date granularity to year

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -485,11 +485,12 @@ function computeGridRoundedValues(wrapperEl, opts) {
 
   for (let r = 0; r < adapterRows.length; r++) {
     const adapterCells = adapterRows[r].getCells();
-    let dataCol = 0;
     for (let c = 0; c < adapterCells.length; c++) {
       const cellObj = adapterCells[c];
+      // <th> cells are never rounded, but they still occupy their column — see
+      // the column-index note in roundTable's native path.
       if (cellObj.tagName !== 'TD') continue;
-      const col = dataCol++;
+      const col = c;
       const cell = cellObj.el;
       const text = cellObj.getText();
       const trimmed = typeof text === 'string' ? text.trim() : '';
@@ -789,13 +790,17 @@ function roundTable(table, options) {
     const rowData = [];
     const rowCells = [];
     const rowInfo = [];
-    let dataCol = 0;
     for (let c = 0; c < adapterCells.length; c++) {
       const cellObj = adapterCells[c];
       const cell = cellObj.el;
-      // Skip <th> row-header cells entirely — they are not data columns.
+      // Skip <th> cells entirely — they are never rounded.
       if (cellObj.tagName !== 'TD') continue;
-      const col = dataCol++;
+      // The column index is the cell's position in the row, counting <th> row
+      // headers rather than skipping them. A <th scope="row"> IS the table's
+      // first column as rendered, so in such a table the leading <td> is column
+      // B: "first column" (and range "A") target the header column, not the
+      // first data cell after it.
+      const col = c;
       const text = cellObj.getText();
       rowData.push(text);
       // For native adapters carry the raw element (unchanged).
@@ -901,6 +906,10 @@ function roundTable(table, options) {
   }
 
   // --- Column post-pass: resolve ambiguous numeric date cells per column ---
+  // Note: rowData / rowInfo are packed per row (one entry per <td>), so the `c`
+  // below is the nth-<td> index, not the `col` used for range/exclusion gating.
+  // For a table with a uniform <th> layout the two differ by a constant, so
+  // cells still group by their real column.
   // Determine the maximum number of data columns across all rows.
   const numCols = cellInfo.reduce((max, row) => Math.max(max, row.length), 0);
   for (let c = 0; c < numCols; c++) {

--- a/chrome-extension/defaults.js
+++ b/chrome-extension/defaults.js
@@ -14,7 +14,7 @@ const DR_DEFAULTS = {
   simplifyFirstColumn: false,
   simplifyDates: true,
   simplifyTimes: false,
-  dateGranularity: 'decade',
+  dateGranularity: 'year',
   timeGranularity: 'hour',
   // Concrete numeric defaults (Variant F UI always sends concrete numbers, never
   // null/blank). num_top is no longer surfaced in the UI but stays here as the

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1716,8 +1716,8 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     DR_DEFAULTS.simplifyMixedCurrency, true);
   eq('sidebar-defaults: simplifyMixedPercent default is true in DR_DEFAULTS',
     DR_DEFAULTS.simplifyMixedPercent, true);
-  eq('sidebar-defaults: dateGranularity default is "decade" in DR_DEFAULTS',
-    DR_DEFAULTS.dateGranularity, 'decade');
+  eq('sidebar-defaults: dateGranularity default is "year" in DR_DEFAULTS',
+    DR_DEFAULTS.dateGranularity, 'year');
   eq('sidebar-defaults: timeGranularity default is "hour" in DR_DEFAULTS',
     DR_DEFAULTS.timeGranularity, 'hour');
   eq('sidebar-defaults: sidebar.html does not hard-code "checked" attributes',
@@ -4331,8 +4331,8 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     DR_DEFAULTS.simplifyFirstRow, false);
   eq('sidebar-tidyup AC3: DR_DEFAULTS.simplifyFirstColumn is false',
     DR_DEFAULTS.simplifyFirstColumn, false);
-  eq('sidebar-tidyup AC3: DR_DEFAULTS.dateGranularity is "decade"',
-    DR_DEFAULTS.dateGranularity, 'decade');
+  eq('sidebar-tidyup AC3: DR_DEFAULTS.dateGranularity is "year"',
+    DR_DEFAULTS.dateGranularity, 'year');
   eq('sidebar-tidyup AC3: DR_DEFAULTS.timeGranularity is "hour"',
     DR_DEFAULTS.timeGranularity, 'hour');
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -889,12 +889,14 @@ eq('parseRangeExpr: "A5:A2" auto-swaps to A2:A5',
 })();
 
 // ---------------------------------------------------------------------------
-// Sprint first-col-is-a: pin behavior of <th>-skipping dataCol counter
+// Sprint first-col-is-a: pin column-index behavior for tables with <th> cells
 //
-// The dev's fix (reading II / data-perspective):
-//   - <th> cells are skipped entirely; only <td> cells are counted.
-//   - rangeExpr "A" maps to the first <td> (dataCol 0), not the leftmost DOM cell.
-//   - simplifyFirstColumn=false excludes the first <td>, not the leftmost DOM cell.
+// Column index is the cell's position in its row, counting <th> cells:
+//   - <th> cells are never rounded, but they still occupy their column.
+//   - rangeExpr "A" maps to the leftmost DOM cell — the <th> in a row-header
+//     table, so the leading <td> there is column "B".
+//   - simplifyFirstColumn gates the leftmost DOM cell, so in a row-header table
+//     it does not gate the leading <td>.
 //
 // Helper: build a minimal mock table that roundTable can traverse.
 // roundTable accesses: table.rows -> array of {cells: array of cell-like objects}
@@ -951,10 +953,10 @@ function withCreateTreeWalker(fn) {
   try { fn(); } finally { delete global.document.createTreeWalker; }
 }
 
-// --- Test 1: Table with row headers — range = "A" targets first <td>, not the <th> ---
+// --- Test 1: Table with row headers — nothing outside the range is rounded ---
 // Row: [<th>Name</th>, <td>100</td>, <td>200</td>]
-// With rangeExpr = "A" (col 0 in dataCol space) and simplifyFirstColumn=true (not excluded),
-// "A" should hit <td>100</td> (the first <td>), NOT the <th>Name</th>.
+// With rangeExpr = "A" the range covers the <th> column only; neither <td> is
+// in range, and the <th> itself is never rounded.
 (function firstColIsA_withRowHeader() {
   withCreateTreeWalker(function() {
     const table = makeMockTable([[
@@ -973,8 +975,10 @@ function withCreateTreeWalker(fn) {
     // <th> Name: must NOT be rounded (it's not a <td>, skipped by the loop entirely)
     eq('first-col-is-A (row-header table): <th> Name is never rounded',
       cells[0].classList.contains('dr-ext-rounded'), false);
-    // <td> 200: dataCol 1 = column B — out of range A, must NOT be rounded
-    eq('first-col-is-A (row-header table): <td>200 at dataCol 1 not rounded',
+    // <td>100 is column B and <td>200 column C — both out of range A
+    eq('first-col-is-A (row-header table): <td>100 at column B not rounded',
+      cells[1].classList.contains('dr-ext-rounded'), false);
+    eq('first-col-is-A (row-header table): <td>200 at column C not rounded',
       cells[2].classList.contains('dr-ext-rounded'), false);
   });
 })();
@@ -1006,33 +1010,61 @@ function withCreateTreeWalker(fn) {
   });
 })();
 
-// --- Test 3: simplifyFirstColumn=false + row headers ---
-// Row: [<th>Name</th>, <td>100</td>, <td>200</td>]
-// rangeExpr = '' (whole table), simplifyFirstColumn = false.
-// Dev behavior: simplifyFirstColumn=false checks dataCol === 0, so <td>100</td> is
-// excluded (not the <th>, which is skipped from the data loop entirely).
-(function simplifyFirstColumn_withRowHeader() {
+// --- Test 3 / 4 helper: row-header table shaped like Wikipedia's
+// "List of James Bond films" — every data row opens with <th scope="row">.
+//   [<th>Dr. No</th>,     <td>59.5</td>,  <td>1234</td>]
+//   [<th>Goldfinger</th>, <td>124.9</td>, <td>5678</td>]
+// Columns: A = the <th>, B = the first <td>, C = the second <td>.
+function runRowHeaderTable(optsOverrides) {
+  let rows;
   withCreateTreeWalker(function() {
-    const table = makeMockTable([[
-      { tag: 'th', text: 'Name' },
-      { tag: 'td', text: '100'  },
-      { tag: 'td', text: '200'  },
-    ]]);
-    const opts = {
+    const table = makeMockTable([
+      [{ tag: 'th', text: 'Dr. No'     }, { tag: 'td', text: '59.5'  }, { tag: 'td', text: '1234' }],
+      [{ tag: 'th', text: 'Goldfinger' }, { tag: 'td', text: '124.9' }, { tag: 'td', text: '5678' }],
+    ]);
+    roundTable(table, Object.assign({
       enabled: true, simplifyMixedCells: false, simplifyDates: true, simplifyTimes: true,
-      simplifyFirstColumn: false, simplifyMixedPercent: false, simplifyMixedCurrency: false,
+      simplifyFirstRow: true, simplifyFirstColumn: false,
+      simplifyMixedPercent: false, simplifyMixedCurrency: false,
       offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
       rangeExpr: ''
-    };
-    roundTable(table, opts);
-    const cells = table.rows[0].cells;
-    // <th> Name: skipped (not a TD)
-    eq('simplifyFirstColumn=false (row-header table): <th> Name never rounded',
-      cells[0].classList.contains('dr-ext-rounded'), false);
-    // <td>100 is dataCol 0 — excluded by simplifyFirstColumn=false (dev reading II)
-    eq('simplifyFirstColumn=false (row-header table): <td>100 at dataCol 0 is excluded',
-      cells[1].classList.contains('dr-ext-rounded'), false);
+    }, optsOverrides));
+    rows = table.rows.map(row => row.cells);
   });
+  return rows;
+}
+
+function isRounded(cell) { return cell.classList.contains('dr-ext-rounded'); }
+
+// --- Test 3: simplifyFirstColumn gates the <th>, not the leading <td> ---
+// Regression: selecting "first column" used to enable the *second* rendered
+// column, because only <td> cells were counted and the <th> was invisible to
+// the column index. The <th> is the first column, so the leading <td> (column
+// B) is rounded regardless of the toggle, and the <th> is never rounded.
+(function simplifyFirstColumn_withRowHeader() {
+  for (const flag of [false, true]) {
+    const rows = runRowHeaderTable({ simplifyFirstColumn: flag });
+    eq(`simplifyFirstColumn=${flag} (row-header table): <th> is never rounded`,
+      isRounded(rows[0][0]), false);
+    eq(`simplifyFirstColumn=${flag} (row-header table): leading <td> is column B, not gated`,
+      isRounded(rows[0][1]), true);
+  }
+})();
+
+// --- Test 4: range letters count the <th> column ---
+// "A" is the <th> column (nothing to round there); "B" is the leading <td>.
+(function rangeLetters_withRowHeader() {
+  const rangeA = runRowHeaderTable({ rangeExpr: 'A' });
+  eq('range "A" (row-header table): <th> column matched, leading <td> untouched',
+    isRounded(rangeA[0][1]), false);
+  eq('range "A" (row-header table): column C untouched',
+    isRounded(rangeA[0][2]), false);
+
+  const rangeB = runRowHeaderTable({ rangeExpr: 'B' });
+  eq('range "B" (row-header table): leading <td> is rounded',
+    isRounded(rangeB[0][1]), true);
+  eq('range "B" (row-header table): column C untouched',
+    isRounded(rangeB[0][2]), false);
 })();
 
 // --- Sprint icon-no-sidebar: manifest + background invariants ---


### PR DESCRIPTION
Two changes.

## 1. `<th>` row headers now occupy their column (`fix`)

In a table whose rows open with `<th scope="row">` — e.g. Wikipedia's [List of James Bond films](https://en.wikipedia.org/wiki/List_of_James_Bond_films) — selecting the **first column** toggle enabled the *second* column as rendered.

The column index was built by counting only `<td>` cells:

```js
if (cellObj.tagName !== 'TD') continue;
const col = dataCol++;          // <th> invisible to the index
```

So `<th>Dr. No</th>` occupied no column at all and `<td>1962</td>` became column 0. `getExclusionReason` gates on `columnIndex === 0`, so "first column" landed on Year. Range letters had the same off-by-one: `A` meant the first `<td>`, not the leftmost cell.

Columns are now indexed by cell position within the row, counting `<th>` cells. `<th>` cells are still never rounded — they just own their column, so in a row-header table the header is column A and the leading `<td>` is column B.

Scope:
- Tables without row headers: column index unchanged.
- Virtual grids: unchanged (`GridAdapter` reports every cell as `TD`).
- **Behavior change worth noting:** range letters follow the same index, so in a row-header table `A` now selects the header column rather than the first data column after it. Unifying the two was deliberate — two different meanings of "column" in one engine is how this bug happened.

## 2. Default date granularity is now `year` (`chore`)

`DR_DEFAULTS.dateGranularity` moves `'decade'` → `'year'`, so a fresh install and the right-click toggle both simplify dates to the year. `sidebar.html` hard-codes no `selected` option, so the dropdown picks the new value up from `defaults.js` on load.

## Testing

`node chrome-extension/tests.js` → **1413 passed, 0 failed.**

The block that pinned the old `<td>`-only counting was rewritten around a Bond-shaped fixture (`<th>` + two data columns, two rows). Its assertions were all negative before, so they passed under either indexing; three of the new ones fail against the old code and pass against the new:

- `simplifyFirstColumn=false (row-header table): leading <td> is column B, not gated`
- `range "B" (row-header table): leading <td> is rounded`
- `range "B" (row-header table): column C untouched`

The two `DR_DEFAULTS.dateGranularity` assertions were updated to `'year'`.
