### PR TITLE
fix(extension): stop mining digits out of identifiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,20 @@ Every review finding — from the `/code-review` skill, a sprint-stack reviewer 
 
 For sprint-stack specifically: the reviewer subagent still returns APPROVE/BLOCK and does not edit files (its verdict must stay honest). Routing happens in the orchestrator step after APPROVE — apply bucket-1 fixes as a small `chore(...)`/`refactor(...)` commit and open bucket-2 issues, then write the log + open the PR.
 
+## Explanations
+
+- **Start with a TL;DR.** The conclusion first, then the support.
+- **No code references unless I ask.** No file paths, line numbers, function or symbol names, no code blocks. Describe behavior in plain terms — what the thing does, not what it is called. When I ask for the code, give me the code.
+- **Be precise and concise.** Before sending, re-read and cut whatever can go without losing information. Prefer the shorter phrasing over the more impressive one.
+
 ## PR content
 
 Do not include messages about Claude Code / AI tooling in PRs — no "Generated with [Claude Code]" footer, no AI-attribution lines in the PR title or body. Write the PR as a normal human-authored description. This overrides the session-harness default that appends a Claude Code footer.
+
+PR titles and bodies follow the Explanations rules above, plus:
+
+- **Conclusions only.** Do not narrate the investigation. Hypotheses that proved wrong, paths abandoned, and things ruled out do not belong in the PR — state what is true and what changed. The exception: a rejected alternative worth recording so nobody retries it, in one line.
+- **No essayistic prose, no algorithmic platitudes.** Skip the throat-clearing, the restated problem statement, and lines like "this ensures correctness" or "this improves robustness". Say what changed, why, and what it costs.
 
 ## GitHub writes (push, PR, comments)
 

--- a/chrome-extension/parsing.js
+++ b/chrome-extension/parsing.js
@@ -14,8 +14,27 @@
  * the shared global scope consumed by content.js.
  */
 
-const NUMBER_IN_TEXT_REGEX = /-?\d[\d,]*(?:\.\d+)?/;
-const NUMBER_IN_TEXT_REGEX_GLOBAL = /-?\d[\d,]*(?:\.\d+)?/g;
+// A digit run only counts as a quantity when it starts at a clean boundary: the
+// preceding character must not be a letter, digit, dot, or comma.
+//
+// Letters: digits welded to letters belong to an identifier, not a measurement
+// ("XR47182913MKB07", "MKB07", "Q3"). Mining them produces a rounded value that
+// still looks like a valid identifier, so the corruption is undetectable.
+// Refusing the leading digit is enough to drop the whole run, because every
+// later position inside it is itself preceded by a digit.
+//
+// Dot/comma: stops the scan re-entering a number it just refused — without
+// them "abc1,200" would skip "1,200" and then match the bare "200".
+//
+// The guard also decides when a leading "-" is a minus sign rather than a
+// separator. In "2022-04", "555-1234" or "10-20" the hyphen follows a digit, so
+// it is rejected as a sign; the digits after it still match on their own and
+// stay positive. Genuine negatives ("down -1,200 units") are preceded by
+// whitespace or punctuation and are unaffected. Note that en-dash ranges
+// ("₹615.71–623.33 crore") never relied on this — "-?" only ever matched an
+// ASCII hyphen — so hyphen-typed ranges now behave like en-dash ones.
+const NUMBER_IN_TEXT_REGEX = /(?<![\w.,])-?\d[\d,]*(?:\.\d+)?/;
+const NUMBER_IN_TEXT_REGEX_GLOBAL = /(?<![\w.,])-?\d[\d,]*(?:\.\d+)?/g;
 
 function lettersToColIndex(letters) {
   const up = letters.toUpperCase();

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -201,6 +201,76 @@ eq('extractAll: no digits returns empty array',
   extractNumbersInText('N/A'),
   []);
 
+// --- Boundary guard: digits welded to letters are identifiers, not quantities ---
+// Rounding them yields a value that still looks like a valid identifier, so the
+// corruption cannot be spotted by eye. The whole run must be skipped.
+
+const numStrs = text => extractNumbersInText(text).map(m => m.numStr);
+
+eq('guard: application number is not mined for digits',
+  numStrs('XR47182913MKB07'),
+  []);
+
+eq('guard: trailing zero-padded segment is not mined',
+  numStrs('MKB07'),
+  []);
+
+eq('guard: short label+digit is not mined',
+  numStrs('Q3'),
+  []);
+
+eq('guard: refusal does not let the scan re-enter mid-number',
+  numStrs('abc1,200'),
+  []);
+
+// --- Boundary guard: a hyphen after a digit is a separator, not a minus sign ---
+
+eq('guard: phone number yields two positive numbers',
+  numStrs('555-1234'),
+  ['555', '1234']);
+
+eq('guard: ZIP+4 yields two positive numbers',
+  numStrs('12345-6789'),
+  ['12345', '6789']);
+
+eq('guard: hyphen range yields two positive numbers',
+  numStrs('10-20'),
+  ['10', '20']);
+
+eq('guard: hyphen-typed range now matches en-dash behaviour',
+  numStrs('₹1,968-2,054 crore'),
+  ['1,968', '2,054']);
+
+eq('guard: en-dash range is unchanged',
+  numStrs('₹1,968–2,054 crore'),
+  ['1,968', '2,054']);
+
+eq('guard: year-month is no longer read as a negative month',
+  numStrs('2022-04'),
+  ['2022', '04']);
+
+// --- Boundary guard: genuine negatives and ordinary quantities still match ---
+
+eq('guard: negative after whitespace still signed',
+  numStrs('down -1,200 units'),
+  ['-1,200']);
+
+eq('guard: leading negative still signed',
+  numStrs('-5.2% change'),
+  ['-5.2']);
+
+eq('guard: currency-prefixed amount unaffected',
+  numStrs('$48,090.00'),
+  ['48,090.00']);
+
+eq('guard: numbers after a letter-word boundary unaffected',
+  numStrs('between 1,200 and 3,400 units'),
+  ['1,200', '3,400']);
+
+eq('guard: caret exponent notation unaffected',
+  numStrs('10^12'),
+  ['10', '12']);
+
 // --- formatExtractedNumber ---
 
 eq('format: large number gets commas matching original',


### PR DESCRIPTION
**TL;DR** — Alphanumeric identifiers were being taken apart and rounded segment by segment, producing values that still look like valid identifiers. One boundary rule fixes that and a related hyphen bug.
On the downside, quantities written with no separator, such as `USD5000`, are now left alone rather than rounded; however, this is a conservative failure (it failed to make something better) and immediately visible, which is preferred to agressively silently rewriting cells, which would actively make things worse.


## Problem

1. Cells with mixed text were being rounded.  This worked for USD205 --> USD200 but not for ID205 --> ID200.
2. Moreover, numbers that included dashes (e.g. Zip code:  10001-1234) were being 'understood' to be a positive and a negative number.  Nothing about the result signals it was altered, potentially confusing the user.
3. Identifier digits were being interpreted as magnitudes.  So a serial number might 'trick' the table into thinking the largest magnitude was 10^7 when no actual number in the data set came close to that.


Behaviour before and after this change:

| Cell | Before | After |
| :--- | :--- | :--- |
| `XR47182913MKB07` | `XR45000000MKB7` | unchanged |
| `555-1234` | second half read as negative | two positive numbers | 


## Change
A run of digits counts as a quantity only when the character before it is not a letter, digit, dot or comma.

- Digits welded to letters belong to an identifier. Refusing the first digit drops the whole run, since every later position inside it follows a digit.
- The dot and comma stop the scan re-entering a number it just refused, so `abc1,200` no longer matches a bare `200`.
- A hyphen after a digit is a separator, not a sign. The digits following it still match, and stay positive.

Ranges written with an en dash never relied on the sign prefix, which only ever matched an ASCII hyphen, so they are unchanged — and hyphen-typed ranges now behave the same way. Genuine negatives are preceded by whitespace or punctuation and still match.

Identifier digits no longer enter the set-aware magnitude pool, so a serial number can no longer set the rounding scale for unrelated columns. In the table above that drops the pooled magnitude from 10^7 to 10^4.

## Cost
Quantities written with no separator, such as `USD5000`, are now left alone rather than rounded. Leaving a cell untouched is visible to the reader; silently rewriting one is not.

## Not addressed
- **Year-month** cells are still not read as dates. Only complete, zero-padded dates work (e.g. YYYY-MM-DD). Anything shorter or loosely padded falls through to being treated as numbers

## Tests

15 new cases: identifier, zero-padded segment, short label, scan re-entry, phone, ZIP+4, hyphen range, hyphen/en-dash equivalence, year-month, plus regressions for genuine negatives, currency amounts, word-boundary numbers and caret exponents.

1428 extension tests and 158 Sheets tests pass.
