### PR TITLE
chore(extension): drop unreachable native-table cell writer

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -291,7 +291,7 @@ function resetTable(table) {
   const roundedCells = table.querySelectorAll('.dr-ext-rounded');
   for (const cell of roundedCells) {
     // Grid cells are reset via nodeValue patching (drOriginal is set by GridAdapter.setText).
-    // Native-table cells are reset via innerHTML (originalHtml is set by NativeTableAdapter.setText).
+    // Native-table cells are reset via innerHTML (originalHtml is stashed by roundTable's native path).
     if (cell.dataset.drOriginal !== undefined) {
       // Grid path: restore the original text node value in place (preserves node identity).
       const tn = findCellTextNode(cell);

--- a/chrome-extension/dom-adapters.js
+++ b/chrome-extension/dom-adapters.js
@@ -48,11 +48,12 @@ class NativeTableAdapter {
     return Array.from(this.el.rows).map(row => ({
       getCells() {
         return Array.from(row.cells).map(cell => ({
+          // No setText: the native path writes cells directly in roundTable so it
+          // can preserve markup in mixed cells and stash both originalHtml and
+          // originalValue. A textContent-based setText here would flatten mixed
+          // cells and skip originalValue, silently feeding the sidebar preview
+          // its own rounded output.
           getText() { return cell.innerText || cell.textContent || ''; },
-          setText(s) {
-            cell.dataset.originalHtml = cell.innerHTML;
-            cell.textContent = s;
-          },
           el: cell,
           tagName: cell.tagName,
         }));

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -6949,6 +6949,41 @@ function makeNativeTableEl(rowsSpec) {
     cells0[0].el, tableEl.rows[0].cells[0]);
 })();
 
+// TA1b: NativeTableAdapter cells expose NO setText — deliberate absence guard.
+// The native path writes cells directly in roundTable so it can preserve markup
+// in mixed cells and stash both originalHtml and originalValue. A setText here
+// would be reached by any future code that drives both adapters through one
+// loop; a textContent-based one would flatten mixed cells and skip
+// originalValue, silently feeding the sidebar preview its own rounded output.
+// Absent, that future code fails at the call site instead. This test keeps the
+// absence deliberate rather than incidental — if you are adding setText back,
+// it must preserve markup and stash BOTH dataset keys, and this guard must be
+// rewritten to assert that, not simply deleted.
+(function nativeTableAdapter_hasNoSetText() {
+  const tableEl = makeNativeTableEl([
+    [{ tag: 'td', text: '1,234' }],
+  ]);
+  const cell = makeAdapter(tableEl).getRows()[0].getCells()[0];
+
+  eq('TA1b: native adapter cell exposes no setText',
+    cell.setText, undefined);
+
+  // Source scan: nothing in the class may assign textContent/innerHTML on a
+  // cell. Catches a setText re-added under a different name.
+  const start = domAdaptersCode.indexOf('class NativeTableAdapter');
+  const rest = domAdaptersCode.slice(start);
+  const classBody = rest.slice(0, rest.indexOf('\n}\n'));
+
+  eq('TA1b (setup): NativeTableAdapter class body located',
+    start >= 0 && classBody.length > 0, true);
+
+  eq('TA1b: NativeTableAdapter class body has no textContent= assignment',
+    /textContent\s*=[^=]/.test(classBody), false);
+
+  eq('TA1b: NativeTableAdapter class body has no innerHTML= assignment',
+    /innerHTML\s*=[^=]/.test(classBody), false);
+})();
+
 // TA2: NativeTableAdapter — cell count matches table structure
 // A 3-row × 3-column table round-trips with correct row and cell counts.
 (function nativeTableAdapter_3x3() {


### PR DESCRIPTION
## What

Removed unused cell-writing method on the native-table adapter. Corrected a stale comment that credited it with stashing the restore buffer. Added a test guarding the absence.

## Why

Never called. The only adapter write call site sits behind the virtualized-grid branch; the native path writes cells directly. No test covered it.

Also wrong for the path it appeared to serve. Flattened the cell to plain text, destroying markup in mixed cells — the case the restore buffer exists to protect. Stashed the markup buffer without the plain-text copy, which would have left the sidebar preview sampling its own rounded output on an already-simplified table.

## Guard

Suite passed identically with and without the method, so nothing held the removal in place. New test asserts native cells expose no writer, plus a source scan of that class for text/markup assignment — catches a re-add under a different name. Verified the test goes red when the old method is restored.

Not a blanket ban. Comment states conditions for a legitimate re-add: preserve markup, stash both keys, rewrite the guard rather than delete it. Adapter unification stays open.

## Tests

Extension: 1432 pass / 0 fail (baseline 1428; +4 new assertions).
Sheets: 158 pass / 0 fail.

## Cost

No behavior change. Net line count up — the comment is longer than the removed code.

## Reviewer notes

No follow-up issues opened.
