### PR TITLE
fix(extension): deliver CLOSE_SIDEBAR to the content script

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -40,7 +40,13 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 });
 
 function closeSidebarIfOpen() {
+  // The side panel is an extension page and hears the broadcast. A content
+  // script does not: it is reachable only through its tab. Both need telling,
+  // or content.js keeps sidebarOpen set for the rest of the tab's life.
   chrome.runtime.sendMessage({ action: "CLOSE_SIDEBAR" }).catch(() => {});
+  if (sidebarTabId !== null) {
+    chrome.tabs.sendMessage(sidebarTabId, { action: "CLOSE_SIDEBAR" }).catch(() => {});
+  }
   sidebarTabId = null;
 }
 
@@ -87,10 +93,8 @@ chrome.runtime.onMessage.addListener((request, sender) => {
     return;
   }
 
-  if (request.action === "TABLE_ACTIVATED") {
-    if (sidebarTabId !== null) {
-      chrome.tabs.sendMessage(sidebarTabId, { action: "TABLE_ACTIVATED" });
-    }
-    return;
-  }
+  // TABLE_ACTIVATED needs no relay. content.js sends it with
+  // runtime.sendMessage, which the side panel already receives directly.
+  // Forwarding it to sidebarTabId aimed it at the content script, which has no
+  // handler for that action.
 });

--- a/chrome-extension/parsing.js
+++ b/chrome-extension/parsing.js
@@ -578,17 +578,14 @@ function decimalCount(n) {
 /**
  * Format a rounded number extracted from inline text for display.
  *
- * Band rule for minimumFractionDigits:
- *   |rounded| < 10  → use Math.max(decimals, floorDecimals)
- *     The <10 band covers small values such as percentages/fractions where
- *     the offset's own decimal precision is meaningful to the reader.
- *   |rounded| >= 10 → zero decimals (existing short-circuit unchanged).
- *     Large magnitudes are already rounded to integer multiples of a coarse
- *     base, so decimal places would be spurious.
+ * Trailing zeros are always stripped, at every magnitude: minimumFractionDigits
+ * stays 0. Sprint trim-trailing-zeros replaced the earlier band rule that raised
+ * the floor to the offset's own decimal count for |rounded| < 10.
  *
  * @param {number} rounded       - The rounded numeric value.
  * @param {string} originalNumStr - The original number string (for comma/decimal detection).
- * @param {number} [floorDecimals=0] - Minimum decimal places from the offset's own precision.
+ * @param {number} [floorDecimals=0] - Ignored. Kept so existing call sites and the
+ *   tests that assert output does not depend on it keep their signature.
  */
 function formatExtractedNumber(rounded, originalNumStr, floorDecimals = 0) {
   const hasCommas = originalNumStr.includes(',');
@@ -602,13 +599,11 @@ function formatExtractedNumber(rounded, originalNumStr, floorDecimals = 0) {
 /**
  * Restore the formatting of a pure-numeric cell after rounding.
  *
- * Band rule for minimumFractionDigits (mirrors formatExtractedNumber):
- *   |roundedValue| < 10  → use Math.max(decimals, floorDecimals)
- *   |roundedValue| >= 10 → zero decimals (short-circuit, unchanged)
+ * Trailing zeros are always stripped, mirroring formatExtractedNumber.
  *
  * @param {number} roundedValue   - The rounded numeric value.
  * @param {string} originalString - Original cell text (for symbol/format detection).
- * @param {number} [floorDecimals=0] - Minimum decimal places from the offset's precision.
+ * @param {number} [floorDecimals=0] - Ignored. See formatExtractedNumber.
  */
 function restoreFormatting(roundedValue, originalString, floorDecimals = 0) {
   let result;

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -133,7 +133,6 @@
     .label-row .lbl.top { color: #1a73e8; }
     .label-row .lbl.bot { color: #b3623d; }
     #sliderBlock.linked .label-row .lbl.bot { color: #c48a6a; }
-    .label-row .val { color: #202124; font-variant-numeric: tabular-nums; }
     .dual-wrap {
       position: relative;
       height: 56px;
@@ -176,7 +175,6 @@
     }
     .dual-thumb.bot.linked { background: #c48a6a; }
     .dual-thumb:focus-visible { outline: 2px solid #1a73e8; outline-offset: 2px; }
-    .section.disabled .dual-thumb { cursor: not-allowed; }
     /* Preview band: 2 samples above slider, 3 below (variant F).
        Grid + display:contents pairs so the "→" column aligns vertically
        and the whole band is centered horizontally under the slider. */
@@ -211,11 +209,6 @@
     #topBand .strategy .num { color: #1a73e8; }
     #topBand .from,
     #topBand .num { white-space: nowrap; }
-    .results-band .empty {
-      color: #80868b;
-      font-style: italic;
-      text-align: center;
-    }
     #rangeExpr {
       width: 100%;
       box-sizing: border-box;

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -102,7 +102,6 @@ function renderSliders() {
 // ----- Preview band -----
 const topBandEl = document.getElementById('topBand');
 const botBandEl = document.getElementById('botBand');
-const PREVIEW_NUM_TOP = 1;
 let cachedSamples = null;
 let cachedMaxMag = null;
 
@@ -188,10 +187,8 @@ function formatOomLabel(mag) {
     str = trimNum(val / 1e6) + 'M';
   } else if (val >= 1e3) {
     str = trimNum(val / 1e3) + 'k';
-  } else if (val >= 1) {
-    str = trimNum(val);
   } else {
-    // Sub-integer magnitudes: e.g. mag=-1 → 0.1, mag=-2 → 0.01
+    // Includes sub-integer magnitudes: mag=-1 → 0.1, mag=-2 → 0.01
     str = trimNum(val);
   }
   return str + '+';
@@ -244,7 +241,7 @@ function renderTopBand(el, rows, offset) {
     el.appendChild(strat);
   }
 
-  // Single example (PREVIEW_NUM_TOP = 1) on its own line below the strategy.
+  // Single example on its own line below the strategy.
   const row = rows[0];
   const example = document.createElement('div');
   example.className = 'pair example';

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -10366,21 +10366,16 @@ function fireMouseClick(buttonEl, fn) {
     /flashSidebarContainer[\s\S]{0,300}classList\.add\s*\(\s*SIDEBAR_FLASH_CLASS\s*\)/.test(sidebarSrc),
     true);
 
-  // AC4 (source): background.js wraps the sendMessage relay in `if (sidebarTabId !== null)`.
-  eq('table-activation AC4 source: background.js guards TABLE_ACTIVATED relay with sidebarTabId !== null',
-    /TABLE_ACTIVATED[\s\S]{0,200}sidebarTabId\s*!==\s*null[\s\S]{0,200}sendMessage/.test(bgSrc),
-    true);
+  // AC4 (source): background.js does not relay TABLE_ACTIVATED at all. The
+  // panel receives it straight from content.js via runtime.sendMessage, so the
+  // old relay only ever delivered it to a content script with no handler.
+  // Runtime coverage lives in backgroundMessageRouting.
+  eq('table-activation AC4 source: background.js does not send TABLE_ACTIVATED',
+    /sendMessage\s*\([^)]*TABLE_ACTIVATED/.test(bgSrc), false);
 
-  // AC4 (source): the relay block must not call sendMessage outside the null-guard.
-  // We isolate the TABLE_ACTIVATED handler block (from 'TABLE_ACTIVATED' to the next 'return;')
-  // and confirm the sendMessage call is inside an `if (sidebarTabId` conditional.
-  const activatedBlock = bgSrc.match(/TABLE_ACTIVATED[\s\S]*?return;/);
-  const blockText = activatedBlock ? activatedBlock[0] : '';
-  // Any chrome.tabs.sendMessage in the block must be preceded by a sidebarTabId guard.
-  const sendMsgPos  = blockText.indexOf('sendMessage');
-  const guardPos    = blockText.indexOf('sidebarTabId');
-  eq('table-activation AC4 source: relay sendMessage is guarded (appears after sidebarTabId check in block)',
-    sendMsgPos !== -1 && guardPos !== -1 && guardPos < sendMsgPos,
+  // AC4 (source): content.js reaches the panel directly, without the background.
+  eq('table-activation AC4 source: content.js sends TABLE_ACTIVATED via runtime.sendMessage',
+    /chrome\.runtime\.sendMessage\s*\(\s*\{\s*action:\s*ACTION_TABLE_ACTIVATED/.test(contentSrc),
     true);
 })();
 
@@ -12179,6 +12174,129 @@ function fireMouseClick(buttonEl, fn) {
     cells[0].text, '2,794,356');
   eq('orig-value: parses num from original, not rounded',
     cells[0].num, 2794356);
+})();
+
+// ---------------------------------------------------------------------------
+// Background message routing.
+//
+// chrome.runtime.sendMessage from the service worker reaches extension pages
+// such as the side panel, and never reaches content scripts. A content script
+// is reachable only through chrome.tabs.sendMessage(tabId, ...). Two rules
+// follow, and both are asserted at runtime rather than by source regex:
+//
+//   1. Closing the panel must notify the panel AND the content script. Without
+//      the tab-directed send, content.js never clears sidebarOpen, so the flag
+//      stays true for the rest of the tab's life and every branch that reads it
+//      sees stale state.
+//   2. TABLE_ACTIVATED must not be relayed into the tab. content.js already
+//      sends it with runtime.sendMessage, which the panel receives directly.
+//      Relaying it to sidebarTabId delivers it to a content script that has no
+//      handler for that action.
+// ---------------------------------------------------------------------------
+
+(function backgroundMessageRouting() {
+  const bgSrc = fs.readFileSync(path.join(__dirname, 'background.js'), 'utf8');
+
+  // Evaluate background.js against a capturing stub. sidePanel is deliberately
+  // omitted: background.js guards on `chrome.sidePanel && chrome.sidePanel.open`,
+  // so with it absent the menu handler never awaits and runs to completion
+  // synchronously, letting us assert without async plumbing.
+  // rejectClosePath simulates a tab that is already gone by the time the close
+  // message goes out, which is exactly the onRemoved case.
+  function loadBackground({ rejectClosePath = false } = {}) {
+    const runtimeSends = [];
+    const tabSends = [];
+    const listeners = {};
+    const chromeStub = {
+      runtime: {
+        onInstalled: { addListener: () => {} },
+        onMessage: { addListener: (fn) => { listeners.message = fn; } },
+        sendMessage: (msg) => { runtimeSends.push(msg); return Promise.resolve(); },
+      },
+      contextMenus: {
+        create: () => {},
+        update: () => {},
+        onClicked: { addListener: (fn) => { listeners.menuClicked = fn; } },
+      },
+      tabs: {
+        sendMessage: (tabId, msg) => {
+          tabSends.push({ tabId, msg });
+          return rejectClosePath && msg.action === 'CLOSE_SIDEBAR'
+            ? Promise.reject(new Error('no receiving end'))
+            : Promise.resolve();
+        },
+        onUpdated:   { addListener: (fn) => { listeners.updated = fn; } },
+        onRemoved:   { addListener: (fn) => { listeners.removed = fn; } },
+        onActivated: { addListener: (fn) => { listeners.activated = fn; } },
+      },
+    };
+    new Function('chrome', 'console', bgSrc)(
+      chromeStub,
+      { warn: () => {}, debug: () => {}, log: () => {} }
+    );
+    return { runtimeSends, tabSends, listeners };
+  }
+
+  const PANEL_TAB = 7;
+
+  function openPanel(ctx) {
+    ctx.listeners.menuClicked({ menuItemId: 'dr-action-sidebar' }, { id: PANEL_TAB });
+  }
+
+  // --- Rule 1: closing notifies both the panel and the content script ---
+  (function closeNotifiesBoth() {
+    const ctx = loadBackground();
+    openPanel(ctx);
+    eq('bg routing: opening the panel sends SIDEBAR_OPENED to that tab',
+      ctx.tabSends.some(s => s.tabId === PANEL_TAB && s.msg.action === 'SIDEBAR_OPENED'),
+      true);
+
+    ctx.runtimeSends.length = 0;
+    ctx.tabSends.length = 0;
+
+    // Activating a different tab closes the panel.
+    ctx.listeners.activated({ tabId: 99 });
+
+    eq('bg routing: CLOSE_SIDEBAR broadcast reaches the panel',
+      ctx.runtimeSends.some(m => m.action === 'CLOSE_SIDEBAR'), true);
+    eq('bg routing: CLOSE_SIDEBAR is also sent to the content script tab',
+      ctx.tabSends.some(s => s.tabId === PANEL_TAB && s.msg.action === 'CLOSE_SIDEBAR'),
+      true);
+  })();
+
+  // The same must hold for the other two close triggers.
+  (function closeOnNavigationAndRemoval() {
+    const navCtx = loadBackground();
+    openPanel(navCtx);
+    navCtx.tabSends.length = 0;
+    navCtx.listeners.updated(PANEL_TAB, { status: 'loading' });
+    eq('bg routing: navigation away sends CLOSE_SIDEBAR to the content script',
+      navCtx.tabSends.some(s => s.tabId === PANEL_TAB && s.msg.action === 'CLOSE_SIDEBAR'),
+      true);
+
+    // A removed tab has no receiving end; the send must not surface an error.
+    const goneCtx = loadBackground({ rejectClosePath: true });
+    openPanel(goneCtx);
+    let threw = false;
+    try {
+      goneCtx.listeners.removed(PANEL_TAB);
+    } catch (e) {
+      threw = true;
+    }
+    eq('bg routing: closing a removed tab does not throw', threw, false);
+  })();
+
+  // --- Rule 2: TABLE_ACTIVATED is not relayed into the tab ---
+  (function activatedNotRelayedToTab() {
+    const ctx = loadBackground();
+    openPanel(ctx);
+    ctx.tabSends.length = 0;
+
+    ctx.listeners.message({ action: 'TABLE_ACTIVATED' }, {});
+
+    eq('bg routing: TABLE_ACTIVATED is not relayed to the content script',
+      ctx.tabSends.filter(s => s.msg.action === 'TABLE_ACTIVATED').length, 0);
+  })();
 })();
 
 // --- Report ---

--- a/python/dynamic_rounding/pandas.py
+++ b/python/dynamic_rounding/pandas.py
@@ -10,7 +10,7 @@ Usage:
 
 import math
 import re
-from typing import Optional, Union
+from typing import Optional
 
 try:
     import pandas as pd


### PR DESCRIPTION
Two message-routing bugs in `background.js`, plus a dead-code sweep. Split into `880371b` (cleanup) and `7a857a7` (fix) so the behavior change is reviewable on its own.

## The bug

`closeSidebarIfOpen` announced the close with `chrome.runtime.sendMessage` only. From a service worker that reaches extension pages, so the side panel heard it, but it never reaches a content script — those are reachable only through `chrome.tabs.sendMessage(tabId, …)`. `content.js` has a `CLOSE_SIDEBAR` handler that clears `sidebarOpen`, and that handler could not fire. `sidebarOpen` therefore latched `true` from the first open until the tab went away, and the four `ui-toggle.js` branches that read it saw stale state.

The broadcast stays for the panel. A tab-directed send now runs alongside it, before `sidebarTabId` is cleared. It carries `.catch` because `onRemoved` fires when the tab is already gone and the send has no receiving end.

## The misrouted relay

The `TABLE_ACTIVATED` handler forwarded to `sidebarTabId`, which is a tab id, so the message went to the content script — which has no handler for that action. `content.js` already sends `TABLE_ACTIVATED` with `runtime.sendMessage` and the panel receives it directly, so the relay was redundant as well as misaimed. Removed rather than re-aimed.

## Dead code

- `Union` import in `dynamic_rounding/pandas.py`.
- `PREVIEW_NUM_TOP` in `sidebar.js`, referenced by nothing but a comment.
- Three CSS rules in `sidebar.html` that cannot match: `.label-row .val` and `.results-band .empty` are never applied, and `.section.disabled .dual-thumb` spans two siblings — only `#optionsSection` takes `disabled`, and the thumbs live in `#advancedSection`.
- The `val >= 1` branch in `formatOomLabel`, whose body was identical to its `else`.

No dead functions, classes, constants, or dependencies exist in `round_dynamic.js` or the Python package. The three rounding implementations stay separate by design.

## Docs corrected

JSDoc on `formatExtractedNumber` and `restoreFormatting` documented a band rule raising `minimumFractionDigits` to the offset's decimal count for `|value| < 10`. Sprint `trim-trailing-zeros` (`fef97af`, `70d367b`) removed that behavior and left the docs describing the opposite of what the code does.

The `floorDecimals` parameter stays. Rejected removing it: the tests pass it deliberately to assert output does not depend on it, so removing the parameter would delete the regression guard for the trailing-zeros reversal.

## Why the suite missed both bugs

Two source-regex assertions checked the `TABLE_ACTIVATED` relay was wrapped in a null guard, which presumed the relay belonged there — they pinned the defect. They are replaced with assertions that `background.js` sends no `TABLE_ACTIVATED` and that `content.js` reaches the panel directly.

The existing close-flag test sets `sidebarOpen` directly and calls that equivalent to the message path. It was not equivalent: the assignment worked and the delivery never happened. The new `backgroundMessageRouting` block evaluates `background.js` against a capturing `chrome` stub and drives the real listeners, which puts the routing itself under test. It follows the harness's existing pattern of reading and evaluating its own sources.

## Cost

One extra `chrome.tabs.sendMessage` per panel close, across three triggers. The `TABLE_ACTIVATED` removal drops one `chrome.tabs.sendMessage` per table activation.

## Tested

- `node chrome-extension/tests.js` — 1438 passed, 0 failed (1432 before, +6 assertions)
- `node js/tests.js` — 158 passed, 0 failed
- `pytest python/ -q` — 116 passed
- Confirmed the three new routing assertions fail against the old code and pass after the fix.
- Confirmed the removal case has teeth: rejecting the close send without `.catch` crashes the run on an unhandled rejection.

## Manual tests

- Open the panel on a table, switch tabs, come back, then click a **different** table. It must not reset the sidebar to defaults — that branch is the one that read the stale flag.
- With the panel open, navigate its tab to a new URL. No error from the close send.
- Close the panel's tab outright. No unhandled rejection in the service-worker log.
- Right-click a table with the panel open. The panel must still flash, confirming the removed relay was not the delivery path.

## Reviewer notes

- Four dead-code items were left in place and documented in #202 (`follow-up`, `tech-debt`): the no-op `UPDATE_MENU_LABEL` round trip, test-only `extractNumberInText` and `NUMBER_IN_TEXT_REGEX`, test-only `formatStrategyHeader`, and `getElement` on both adapters. Each needs a judgement call or coordinated `tests.js` edits.
- #157 (`truncateDecimals`) re-verified as still dead. Commented there rather than refiling; it is the same decision as item 3 of #202.
- The Python suite is not in CI — `.github/workflows/tests.yml` runs only the two Node suites — so the `pandas.py` change is covered locally only.
