### PR TITLE
refactor(extension): move table detection into lib/dr-table behind ports

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -20,8 +20,9 @@
 
 let lastRightClickedElement = null;
 // Widened contract: may hold a <table> element OR a div-based grid root (any
-// element carrying class dr-ext-grid or returned by findTargetTable). All
-// callers that previously assumed HTMLTableElement must tolerate any Element.
+// element carrying class dr-ext-grid or returned by findTargetTable's
+// .handle). All callers that previously assumed HTMLTableElement must
+// tolerate any Element.
 let lastRightClickedTable = null;
 let sidebarOpen = false;
 
@@ -38,10 +39,24 @@ const gridReapplyTimers = new WeakMap();
 
 const ACTION_TABLE_ACTIVATED = 'TABLE_ACTIVATED';
 
+// findTargetTable() only reports what it found; it never writes the
+// dr-ext-grid marker or builds the toggle widget. When it discovers a grid
+// root for the first time (found.isNew), this caller does both, exactly as
+// findTargetTable used to do internally before the sprint that split
+// detection into lib/dr-table.
+function markAndToggleIfNewGrid(found) {
+  if (found.isNew) {
+    found.handle.classList.add('dr-ext-grid');
+    createToggleForTable(found.handle);
+  }
+  return found.handle;
+}
+
 document.addEventListener('contextmenu', (event) => {
   lastRightClickedElement = event.target;
-  const table = findTargetTable(event.target);
-  if (table) {
+  const found = findTargetTable(event.target);
+  if (found) {
+    const table = markAndToggleIfNewGrid(found);
     lastRightClickedTable = table;
     flashTargetedTable(table);
     try {
@@ -68,9 +83,9 @@ function runToggleAction(table) {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'MENU_CLICKED') {
     if (lastRightClickedElement) {
-      const table = findTargetTable(lastRightClickedElement);
-      if (table) {
-        runToggleAction(table);
+      const found = findTargetTable(lastRightClickedElement);
+      if (found) {
+        runToggleAction(markAndToggleIfNewGrid(found));
       } else {
         console.debug("Dynamic Rounding: No table found at right-click location.");
       }

--- a/chrome-extension/lib/dr-number/index.js
+++ b/chrome-extension/lib/dr-number/index.js
@@ -3,9 +3,9 @@
  *
  * Loaded LAST within lib/dr-number, after rounding.js, core.js, and
  * parsing.js. Those three files still declare their functions as bare
- * top-level names on the shared global scope (content.js, dom-adapters.js,
- * ui-toggle.js, and sidebar.js keep consuming those bare names unchanged —
- * this sprint does not migrate any consumer). This file adds one more thing:
+ * top-level names on the shared global scope (content.js and sidebar.js
+ * keep consuming those bare names unchanged — this sprint does not migrate
+ * any consumer). This file adds one more thing:
  * a single DR_NUMBER object that groups every public function the package
  * exposes, so future consumers can start depending on DR_NUMBER.x instead of
  * the bare name without another move.

--- a/chrome-extension/lib/dr-table/detect.js
+++ b/chrome-extension/lib/dr-table/detect.js
@@ -14,6 +14,18 @@
  * constants and the structure-preserving cell-write helpers
  * (replaceTextPreservingHTML, applyExtractedPatches, getSuperscriptRanges,
  * link filtering). Loaded by manifest content_scripts before content.js.
+ *
+ * This file is the lib/dr-table package's detection layer. Detection
+ * (isDataTable, looksLikeGrid, findTargetTable, isPhantomA11yTable) reports
+ * findings only — it never writes a marker class or builds a toggle widget.
+ * Callers (ui-toggle.js, content.js) own both: they check their own "seen"
+ * registry (a WeakMap or the dr-ext-grid class) and, for a first-time match,
+ * write the marker and construct the widget.
+ *
+ * Every environment-sensitive read (computed style, offsetWidth, number
+ * parsing, the vendor grid selectors, `document` itself) goes through a
+ * small port with a working default, so the functions below run under a
+ * plain Node/jsdom-less context with no Chrome globals and no `window`.
  */
 
 // Grid detection constants
@@ -25,12 +37,82 @@ const GRID_WALK_DEPTH_CAP = 15;
 const GRID_COL_WIDTH_SAMPLE = 10;
 /** CSS display values that indicate a grid/flex layout. */
 const GRID_DISPLAY_VALUES = new Set(['grid', 'flex', 'inline-grid', 'inline-flex']);
-/** Library class substrings that short-circuit the geometry probe. */
-const GRID_LIBRARY_CLASS_TOKENS = ['dg--', 'ag-'];
 /** CSS selector for the cheap proactive ARIA pass. */
 const GRID_ARIA_SELECTOR = '[role="grid"], [role="table"]';
 /** Debounce delay (ms) for the grid virtualization re-apply observer. */
 const GRID_REAPPLY_DEBOUNCE_MS = 100;
+/** Node.ELEMENT_NODE, with a fallback for contexts with no `Node` global (its value, 1, is part of the DOM spec and never changes). */
+const DR_TABLE_ELEMENT_NODE = (typeof Node !== 'undefined' && Node.ELEMENT_NODE) || 1;
+
+// --- Ports: pluggable defaults for environment-sensitive reads ---
+// Each accepts an optional `opts` bag on the calling function; every default
+// below mirrors this file's pre-port behavior exactly when the real browser
+// globals are present, and degrades to a safe, working default when they are
+// not — that degradation, not a thrown error, is what lets detection run
+// standalone (a Node script, a unit test, a future non-extension host).
+
+/**
+ * StyleProbe: the shared source for every guarded getComputedStyle/offsetWidth
+ * read in this file (looksLikeGrid's display and column-width checks,
+ * isPhantomA11yTable's positioned-ancestor check, getSuperscriptRanges'
+ * vertical-align check). With no real getComputedStyle, assumes a normal,
+ * visible, statically-positioned block element — the jsdom-less default that
+ * lets detection keep running instead of reasoning from an absent style.
+ */
+const DEFAULT_STYLE_PROBE = {
+  getComputedStyle(el) {
+    if (typeof getComputedStyle === 'function') {
+      try { return getComputedStyle(el) || null; } catch (e) { return null; }
+    }
+    return { display: 'block', visibility: 'visible', position: 'static', left: '', verticalAlign: '' };
+  },
+  getOffsetWidth(el) {
+    return (el && typeof el.offsetWidth === 'number') ? el.offsetWidth : -1;
+  },
+};
+
+/**
+ * NumericProbe: parses a cell's text to a number for the "does this look
+ * numeric" checks in looksLikeGrid/isDataTable. Prefers DR_NUMBER.toNumber
+ * (the same parsing the round pass uses, handling currency/comma/percent
+ * strip and parenthesized negatives) when the lib/dr-number package is
+ * loaded; falls back to a plain digit-regex parse when it is not.
+ */
+const DEFAULT_NUMERIC_PROBE = {
+  parse(text) {
+    if (typeof DR_NUMBER !== 'undefined' && DR_NUMBER && typeof DR_NUMBER.toNumber === 'function') {
+      return DR_NUMBER.toNumber(text);
+    }
+    if (typeof toNumber === 'function') {
+      return toNumber(text);
+    }
+    const match = String(text).match(/-?\d+(\.\d+)?/);
+    if (!match) return null;
+    const parsed = Number(match[0]);
+    return isFinite(parsed) ? parsed : null;
+  },
+};
+
+/**
+ * VendorProfiles: known third-party grid libraries. `classToken` short-
+ * circuits looksLikeGrid's geometry probe; `scrollContainerSelectors` /
+ * `pinnedPaneSelectors` resolve GridAdapter's scroll and pinned panes.
+ * A consumer may pass a custom list via opts.vendorProfiles.
+ */
+const DEFAULT_VENDOR_PROFILES = [
+  {
+    name: 'databricks',
+    classToken: 'dg--',
+    scrollContainerSelectors: ['.dg--grid-scroll-container', '.dg--grid-container'],
+    pinnedPaneSelectors: ['.dg--pinned-grid'],
+  },
+  {
+    name: 'ag-grid',
+    classToken: 'ag-',
+    scrollContainerSelectors: ['.ag-center-cols-viewport'],
+    pinnedPaneSelectors: ['.ag-pinned-left-cols-container'],
+  },
+];
 
 // --- TableAdapter abstraction ---
 // Two adapter classes provide a uniform row/cell interface over both native
@@ -95,8 +177,9 @@ function findCellTextNode(cellEl) {
 const GRID_ROUNDED_CLASS = 'dr-ext-rounded';
 
 class GridAdapter {
-  constructor(el) {
+  constructor(el, opts = {}) {
     this.el = el;
+    this.vendorProfiles = opts.vendorProfiles || DEFAULT_VENDOR_PROFILES;
   }
   getElement() { return this.el; }
   isVirtualized() { return true; }
@@ -107,11 +190,10 @@ class GridAdapter {
    */
   _getScrollContainer() {
     const el = this.el;
-    // Known library selectors (single-pane Databricks, AG Grid, etc.)
+    // Known library selectors (single-pane Databricks, AG Grid, etc.), plus
+    // the generic ARIA grid role as a final, vendor-agnostic fallback.
     const knownSelectors = [
-      '.dg--grid-scroll-container',
-      '.dg--grid-container',
-      '.ag-center-cols-viewport',
+      ...this.vendorProfiles.flatMap((p) => p.scrollContainerSelectors || []),
       '[role="grid"]',
     ];
     for (const sel of knownSelectors) {
@@ -134,10 +216,7 @@ class GridAdapter {
    * Returns null for single-pane grids (Databricks).
    */
   _getPinnedPane(scrollContainer) {
-    const pinnedSelectors = [
-      '.dg--pinned-grid',
-      '.ag-pinned-left-cols-container',
-    ];
+    const pinnedSelectors = this.vendorProfiles.flatMap((p) => p.pinnedPaneSelectors || []);
     const el = this.el;
     for (const sel of pinnedSelectors) {
       const found = el.querySelector && el.querySelector(sel);
@@ -310,11 +389,11 @@ class GridAdapter {
  * Duck-typing fallback: plain objects with a `rows` property (e.g. test stubs)
  * are treated as native tables since they expose the same row/cell interface.
  */
-function makeAdapter(el) {
+function makeAdapter(el, opts = {}) {
   if (el.tagName === 'TABLE' || (el.tagName === undefined && el.rows)) {
     return new NativeTableAdapter(el);
   }
-  return new GridAdapter(el);
+  return new GridAdapter(el, opts);
 }
 
 /**
@@ -329,18 +408,22 @@ function makeAdapter(el) {
  * <sup> element (or has verticalAlign 'super'), record {start: cursor, end: cursor + len}.
  *
  * Guards:
- * - If document.createTreeWalker is unavailable, returns [].
- * - getComputedStyle is only called when typeof getComputedStyle === 'function', so the
- *   helper never throws in the Node test harness.
+ * - If doc.createTreeWalker is unavailable, returns [].
+ * - The vertical-align check goes through opts.styleProbe (default:
+ *   DEFAULT_STYLE_PROBE), so the helper never throws when getComputedStyle
+ *   is absent.
  * @param {Element} cell
+ * @param {{doc?: Document, styleProbe?: object}} [opts]
  * @returns {{start: number, end: number}[]}
  */
-function getSuperscriptRanges(cell) {
-  if (!cell || typeof document === 'undefined' || typeof document.createTreeWalker !== 'function') {
+function getSuperscriptRanges(cell, opts = {}) {
+  const doc = opts.doc || (typeof document !== 'undefined' ? document : null);
+  const styleProbe = opts.styleProbe || DEFAULT_STYLE_PROBE;
+  if (!cell || !doc || typeof doc.createTreeWalker !== 'function') {
     return [];
   }
   const ranges = [];
-  const treeWalker = document.createTreeWalker(cell, NodeFilter.SHOW_TEXT, null, false);
+  const treeWalker = doc.createTreeWalker(cell, NodeFilter.SHOW_TEXT, null, false);
   let cursor = 0;
   let node;
   while ((node = treeWalker.nextNode())) {
@@ -354,16 +437,12 @@ function getSuperscriptRanges(cell) {
           isSup = true;
           break;
         }
-        // Also check computed verticalAlign, but only when getComputedStyle is available
-        // (it may be absent in the Node test harness).
-        if (!isSup && typeof getComputedStyle === 'function') {
-          try {
-            const style = getComputedStyle(ancestor);
-            if (style && style.verticalAlign === 'super') {
-              isSup = true;
-              break;
-            }
-          } catch (e) { /* ignore */ }
+        if (!isSup) {
+          const style = styleProbe.getComputedStyle(ancestor);
+          if (style && style.verticalAlign === 'super') {
+            isSup = true;
+            break;
+          }
         }
         ancestor = ancestor.parentNode || ancestor.parentElement;
       }
@@ -566,13 +645,18 @@ function applyExtractedPatches(cell, patches) {
  *
  * Short-circuit ACCEPT (skip step 6) when el carries:
  *   - role="grid" or role="table"  (ARIA)
- *   - a class containing "dg--" or "ag-"  (known library prefixes)
+ *   - a class matching one of opts.vendorProfiles' classToken (default:
+ *     DEFAULT_VENDOR_PROFILES — "dg--" or "ag-")
  *
  * @param {Element} el
+ * @param {{styleProbe?: object, numericProbe?: object, vendorProfiles?: object[]}} [opts]
  * @returns {boolean}
  */
-function looksLikeGrid(el) {
+function looksLikeGrid(el, opts = {}) {
   if (!el || typeof el.children === 'undefined') return false;
+  const styleProbe = opts.styleProbe || DEFAULT_STYLE_PROBE;
+  const numericProbe = opts.numericProbe || DEFAULT_NUMERIC_PROBE;
+  const vendorProfiles = opts.vendorProfiles || DEFAULT_VENDOR_PROFILES;
 
   // --- Step 1: Child count ≥ GRID_MIN_CHILDREN ---
   const children = Array.from(el.children);
@@ -610,10 +694,8 @@ function looksLikeGrid(el) {
   const candidateRows = children.filter(c => c.children.length === modalChildCount);
 
   // --- Step 4: Layout — display is grid or flex ---
-  let display = '';
-  if (typeof getComputedStyle === 'function') {
-    try { display = getComputedStyle(el).display || ''; } catch (e) { /* ignore */ }
-  }
+  const computedForDisplay = styleProbe.getComputedStyle(el);
+  const display = (computedForDisplay && computedForDisplay.display) || '';
   if (!GRID_DISPLAY_VALUES.has(display)) return false;
 
   // --- Step 5: Numeric content — ≥ 1 cell parses as a finite number (mandatory) ---
@@ -621,8 +703,9 @@ function looksLikeGrid(el) {
   outer:
   for (const row of candidateRows) {
     for (const cell of Array.from(row.children)) {
-      const text = (cell.textContent || '').trim().replace(CLEAN_REGEX, '');
-      if (text !== '' && isFinite(parseFloat(text))) { hasNumeric = true; break outer; }
+      const text = (cell.textContent || '').trim();
+      const parsed = text === '' ? null : numericProbe.parse(text);
+      if (parsed !== null && isFinite(parsed)) { hasNumeric = true; break outer; }
     }
   }
   if (!hasNumeric) return false;
@@ -631,12 +714,12 @@ function looksLikeGrid(el) {
   const role = el.getAttribute && el.getAttribute('role');
   if (role === 'grid' || role === 'table') return true;
   const elClass = (el.className && typeof el.className === 'string') ? el.className : '';
-  if (GRID_LIBRARY_CLASS_TOKENS.some(token => elClass.includes(token))) return true;
+  if (vendorProfiles.some(profile => elClass.includes(profile.classToken))) return true;
 
   // --- Step 6: Column-width alignment — sample offsetWidth of column-0 cells ---
   // Bounded to GRID_COL_WIDTH_SAMPLE rows; only runs when all prior steps passed.
   const sample = candidateRows.slice(0, GRID_COL_WIDTH_SAMPLE);
-  const widths = sample.map(row => row.children[0] ? row.children[0].offsetWidth : -1)
+  const widths = sample.map(row => row.children[0] ? styleProbe.getOffsetWidth(row.children[0]) : -1)
                        .filter(w => w > 0);
   if (widths.length < 2) return true; // too few rows to measure — benefit of the doubt
   const firstWidth = widths[0];
@@ -654,40 +737,51 @@ function looksLikeGrid(el) {
  *   3. Walk UP from el calling looksLikeGrid at each ancestor; return the
  *      OUTERMOST match — keep walking while the parent also passes; stop when
  *      the parent fails, is <body>, or depth exceeds GRID_WALK_DEPTH_CAP.
- *      On a new match: add dr-ext-grid, call createToggleForTable, return it.
+ *
+ * REPORTS only — this function never writes the dr-ext-grid marker class and
+ * never builds a toggle widget. It returns { handle, isNew }, where `handle`
+ * is the resolved element and `isNew` tells the caller whether this is the
+ * first time the walk-up path (case 3) has resolved to this element — i.e.
+ * whether the caller still needs to mark it and construct its widget. Cases
+ * 1 and 2 resolve to an element the caller already knows how to handle
+ * (a bare <table>, or an already-marked grid root), so isNew is always false
+ * for them; only case 3 can discover a not-yet-seen grid root.
  *
  * Returns null if nothing found.
  *
  * @param {Element} el
- * @returns {Element|null}
+ * @param {{styleProbe?: object, numericProbe?: object, vendorProfiles?: object[], doc?: Document}} [opts]
+ * @returns {{handle: Element, isNew: boolean}|null}
  */
-function findTargetTable(el) {
+function findTargetTable(el, opts = {}) {
   if (!el) return null;
+  const doc = opts.doc || (typeof document !== 'undefined' ? document : null);
 
   // 1. Nearest <table> ancestor.
   if (typeof el.closest === 'function') {
     const tableAncestor = el.closest('table');
-    if (tableAncestor) return tableAncestor;
+    if (tableAncestor) return { handle: tableAncestor, isNew: false };
   }
 
   // 2. Nearest ancestor already tagged as a grid root.
   if (typeof el.closest === 'function') {
     const existingGrid = el.closest('.dr-ext-grid');
-    if (existingGrid) return existingGrid;
+    if (existingGrid) return { handle: existingGrid, isNew: false };
   }
 
   // 3. Walk up, calling looksLikeGrid; return the outermost consecutive match.
   let current = el.parentElement || el.parentNode;
   let depth = 0;
   let outermost = null;
+  const docBody = doc && doc.body;
 
-  while (current && current !== document.body && depth < GRID_WALK_DEPTH_CAP) {
-    if (current.nodeType !== Node.ELEMENT_NODE) {
+  while (current && current !== docBody && depth < GRID_WALK_DEPTH_CAP) {
+    if (current.nodeType !== DR_TABLE_ELEMENT_NODE) {
       current = current.parentElement || current.parentNode;
       depth++;
       continue;
     }
-    if (looksLikeGrid(current)) {
+    if (looksLikeGrid(current, opts)) {
       outermost = current;
       // Keep walking to find the outermost matching container.
     } else if (outermost !== null) {
@@ -699,11 +793,7 @@ function findTargetTable(el) {
   }
 
   if (outermost !== null) {
-    if (!outermost.classList.contains('dr-ext-grid')) {
-      outermost.classList.add('dr-ext-grid');
-      createToggleForTable(outermost);
-    }
-    return outermost;
+    return { handle: outermost, isNew: !outermost.classList.contains('dr-ext-grid') };
   }
 
   return null;
@@ -722,9 +812,11 @@ const OFFSCREEN_LEFT_PX_THRESHOLD = -9999;
  * when available.  Returns null when no positioned ancestor is found.
  *
  * @param {Element} el
+ * @param {{styleProbe?: object}} [opts]
  * @returns {Element|null}
  */
-function _nearestPositionedAncestor(el) {
+function _nearestPositionedAncestor(el, opts = {}) {
+  const styleProbe = opts.styleProbe || DEFAULT_STYLE_PROBE;
   const POSITIONED = new Set(['relative', 'absolute', 'fixed', 'sticky']);
   let current = el;
   while (current) {
@@ -738,9 +830,10 @@ function _nearestPositionedAncestor(el) {
     if (current.style && typeof current.style.position === 'string') {
       pos = current.style.position;
     }
-    // Computed style when inline is absent and getComputedStyle is available
-    if (!pos && typeof getComputedStyle === 'function') {
-      try { pos = getComputedStyle(current).position || ''; } catch (e) { /* ignore */ }
+    // Computed style when inline is absent
+    if (!pos) {
+      const style = styleProbe.getComputedStyle(current);
+      if (style && style.position) pos = style.position;
     }
     if (POSITIONED.has(pos)) return current;
     current = current.parentElement || current.parentNode || null;
@@ -775,9 +868,11 @@ function _parsePx(value) {
  *      table is an a11y fallback for a chart rendered by that SVG.
  *
  * @param {Element} table
+ * @param {{styleProbe?: object}} [opts]
  * @returns {boolean}
  */
-function isPhantomA11yTable(table) {
+function isPhantomA11yTable(table, opts = {}) {
+  const styleProbe = opts.styleProbe || DEFAULT_STYLE_PROBE;
   if (!table || typeof table.getAttribute !== 'function') return false;
 
   // --- Signal 1: aria-hidden on self or any ancestor ---
@@ -792,7 +887,7 @@ function isPhantomA11yTable(table) {
   }
 
   // --- Signal 2: nearest positioned ancestor has left ≤ threshold ---
-  const posAncestor = _nearestPositionedAncestor(table);
+  const posAncestor = _nearestPositionedAncestor(table, opts);
   const checkEl = posAncestor || table;
 
   let leftVal = NaN;
@@ -801,11 +896,9 @@ function isPhantomA11yTable(table) {
     leftVal = _parsePx(checkEl.style.left);
   }
   // Fall back to computed style when inline is absent
-  if (isNaN(leftVal) && typeof getComputedStyle === 'function') {
-    try {
-      const computed = getComputedStyle(checkEl);
-      if (computed && computed.left) leftVal = _parsePx(computed.left);
-    } catch (e) { /* ignore */ }
+  if (isNaN(leftVal)) {
+    const computed = styleProbe.getComputedStyle(checkEl);
+    if (computed && computed.left) leftVal = _parsePx(computed.left);
   }
   if (!isNaN(leftVal) && leftVal <= OFFSCREEN_LEFT_PX_THRESHOLD) return true;
 
@@ -829,8 +922,14 @@ function isPhantomA11yTable(table) {
   return false;
 }
 
-function isDataTable(table) {
-  const adapter = makeAdapter(table);
+/**
+ * @param {Element} table
+ * @param {{numericProbe?: object, vendorProfiles?: object[]}} [opts]
+ * @returns {boolean}
+ */
+function isDataTable(table, opts = {}) {
+  const numericProbe = opts.numericProbe || DEFAULT_NUMERIC_PROBE;
+  const adapter = makeAdapter(table, opts);
   const rows = adapter.getRows();
   if (rows.length < 2) return false;
   let hasMultipleColumns = false;
@@ -850,9 +949,64 @@ function isDataTable(table) {
     for (let j = 0; j < cells.length; j++) {
       if (cellCount >= maxCells) return false;
       cellCount++;
-      const text = cells[j].getText().trim().replace(CLEAN_REGEX, '');
-      if (text !== '' && isFinite(parseFloat(text))) return true;
+      const text = cells[j].getText().trim();
+      if (text === '') continue;
+      const parsed = numericProbe.parse(text);
+      if (parsed !== null && isFinite(parsed)) return true;
     }
   }
   return false;
+}
+
+/**
+ * Scan `root` for native <table> elements and ARIA grid roots ([role="grid"]
+ * or [role="table"]), mirroring the two-pass order the toggle scanners use
+ * (native tables first, then a cheap ARIA pass for div-based grids whose
+ * table descendants — if any — are all accessibility artifacts already
+ * dropped by tableFilter).
+ *
+ * REPORTS only — like findTargetTable, this never writes the dr-ext-grid
+ * marker class and never builds a toggle widget. Each result is
+ * { handle, isNew }; isNew is computed from opts.isSeen (a caller-supplied
+ * "have I already handled this element" check — e.g. `tableToggles.has` for
+ * native tables, or a dr-ext-grid classList check for grid roots). Without
+ * opts.isSeen every result reports isNew: true, since detection keeps no
+ * registry of its own.
+ *
+ * @param {Element|Document} root
+ * @param {{
+ *   tableFilter?: (table: Element) => boolean,
+ *   isSeen?: (handle: Element) => boolean,
+ *   styleProbe?: object, numericProbe?: object, vendorProfiles?: object[],
+ * }} [opts]
+ * @returns {{handle: Element, isNew: boolean}[]}
+ */
+function findTables(root, opts = {}) {
+  if (!root || typeof root.querySelectorAll !== 'function') return [];
+  const tableFilter = opts.tableFilter || isPhantomA11yTable;
+  const isSeen = opts.isSeen || (() => false);
+  const results = [];
+
+  // Pass 1: native <table> elements; tableFilter drops accessibility artifacts.
+  const nativeTables = root.tagName === 'TABLE' ? [root] : Array.from(root.querySelectorAll('table'));
+  for (const table of nativeTables) {
+    if (tableFilter(table, opts)) continue;
+    results.push({ handle: table, isNew: !isSeen(table) });
+  }
+
+  // Pass 2: cheap ARIA pass for div-based grid roots. Skip a root already
+  // covered by pass 1, and skip a grid root whose only table descendants are
+  // accessibility artifacts pass 1 dropped (so a grid that embeds nothing but
+  // a phantom a11y table is still found here).
+  const rootIsAriaRoot = root.tagName !== 'TABLE' && typeof root.matches === 'function' && root.matches(GRID_ARIA_SELECTOR);
+  const ariaCandidates = (rootIsAriaRoot ? [root] : []).concat(Array.from(root.querySelectorAll(GRID_ARIA_SELECTOR)));
+  for (const el of ariaCandidates) {
+    if (el.tagName === 'TABLE') continue;
+    if (results.some((r) => r.handle === el)) continue;
+    const nestedTables = typeof el.querySelectorAll === 'function' ? Array.from(el.querySelectorAll('table')) : [];
+    if (nestedTables.some((t) => !tableFilter(t, opts))) continue; // a real native table inside — pass 1 owns it
+    results.push({ handle: el, isNew: !isSeen(el) });
+  }
+
+  return results;
 }

--- a/chrome-extension/lib/dr-table/detect.js
+++ b/chrome-extension/lib/dr-table/detect.js
@@ -73,22 +73,20 @@ const DEFAULT_STYLE_PROBE = {
 
 /**
  * NumericProbe: parses a cell's text to a number for the "does this look
- * numeric" checks in looksLikeGrid/isDataTable. Prefers DR_NUMBER.toNumber
- * (the same parsing the round pass uses, handling currency/comma/percent
- * strip and parenthesized negatives) when the lib/dr-number package is
- * loaded; falls back to a plain digit-regex parse when it is not.
+ * numeric" checks in looksLikeGrid/isDataTable. This default is a
+ * self-contained, byte-equivalent port of the predicate detection used
+ * before the lib/dr-table extraction: strip currency/comma/percent/
+ * whitespace symbols, then parseFloat. It deliberately does NOT delegate to
+ * DR_NUMBER.toNumber — that parser's unicode-minus and parenthesized-negative
+ * handling changes which tables are detected (dates, times, and unit-suffixed
+ * cells lose their toggle; accounting negatives gain one). A caller that
+ * wants DR_NUMBER-aware detection passes a custom probe via opts.numericProbe.
  */
 const DEFAULT_NUMERIC_PROBE = {
   parse(text) {
-    if (typeof DR_NUMBER !== 'undefined' && DR_NUMBER && typeof DR_NUMBER.toNumber === 'function') {
-      return DR_NUMBER.toNumber(text);
-    }
-    if (typeof toNumber === 'function') {
-      return toNumber(text);
-    }
-    const match = String(text).match(/-?\d+(\.\d+)?/);
-    if (!match) return null;
-    const parsed = Number(match[0]);
+    const cleaned = String(text).trim().replace(/[$€£¥,\s%]/g, '');
+    if (cleaned === '') return null;
+    const parsed = parseFloat(cleaned);
     return isFinite(parsed) ? parsed : null;
   },
 };

--- a/chrome-extension/lib/dr-table/index.js
+++ b/chrome-extension/lib/dr-table/index.js
@@ -1,0 +1,31 @@
+/**
+ * DynamicRounding lib/dr-table package bundle.
+ *
+ * Loaded LAST within lib/dr-table, after detect.js. detect.js still declares
+ * its functions and classes as bare top-level names on the shared global
+ * scope (ui-toggle.js and content.js keep consuming those bare names
+ * unchanged — this sprint does not migrate any consumer). This file adds one
+ * more thing: a single DR_TABLE object that groups every public function and
+ * class the package exposes, so future consumers can start depending on
+ * DR_TABLE.x instead of the bare name without another move.
+ *
+ * No logic lives here — this is a pure re-export list. Do not add behavior.
+ */
+
+const DR_TABLE = {
+  // detect.js
+  findCellTextNode,
+  NativeTableAdapter,
+  GridAdapter,
+  makeAdapter,
+  getSuperscriptRanges,
+  isCellWholeLink,
+  filterLinkMatches,
+  replaceTextPreservingHTML,
+  applyExtractedPatches,
+  looksLikeGrid,
+  findTargetTable,
+  findTables,
+  isPhantomA11yTable,
+  isDataTable,
+};

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -23,7 +23,8 @@
         "lib/dr-number/core.js",
         "lib/dr-number/parsing.js",
         "lib/dr-number/index.js",
-        "dom-adapters.js",
+        "lib/dr-table/detect.js",
+        "lib/dr-table/index.js",
         "ui-toggle.js",
         "content.js"
       ]

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -10624,6 +10624,186 @@ function fireMouseClick(buttonEl, fn) {
   }
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint extract-dr-table (adversarial hardening): end-to-end double-invocation
+// coverage through the REAL captured content.js listeners — not a direct call
+// to markAndToggleIfNewGrid with a hand-built {handle, isNew} object (that is
+// already covered above, but only exercises the wrapper in isolation).
+//
+// Before this sprint, findTargetTable itself wrote the dr-ext-grid marker
+// inline, so a table seen twice never grew a second widget. That guard now
+// lives across two calls (findTargetTable reports isNew; the caller's
+// markAndToggleIfNewGrid marks+builds only when isNew). This test proves the
+// split still reproduces the old guarantee end-to-end: firing the actual
+// captured 'contextmenu' listener twice on the same never-before-seen grid,
+// and then firing the actual captured 'MENU_CLICKED' onMessage listener
+// against that same target, builds exactly one toggle widget.
+// ---------------------------------------------------------------------------
+(function doubleInvocation_contextmenuAndMenuClicked_noDuplicateWidget() {
+  // A minimal div-based "grid" using the same ARIA-free, querySelectorAll-less
+  // fallback shape GridAdapter already supports (repetitive children): no
+  // real Text nodes, so GridAdapter's setText() finds nothing to patch and
+  // safely no-ops. This fixture only needs to prove marker/widget bookkeeping,
+  // not actual cell rewriting (covered elsewhere).
+  function makeCell(text) { return { nodeType: 1, textContent: text, children: [] }; }
+  function makeRow(texts) { return { nodeType: 1, className: 'row', children: texts.map(makeCell) }; }
+  const rows = [
+    makeRow(['A', '100']), makeRow(['B', '200']), makeRow(['C', '300']),
+    makeRow(['D', '400']), makeRow(['E', '500']),
+  ];
+  const gridClassList = (() => {
+    const c = [];
+    return {
+      _c: c,
+      add(x) { if (!c.includes(x)) c.push(x); },
+      remove(x) { const i = c.indexOf(x); if (i >= 0) c.splice(i, 1); },
+      contains(x) { return c.includes(x); },
+    };
+  })();
+  const gridEl = {
+    nodeType: 1, tagName: 'DIV', className: 'grid-wrapper', children: rows,
+    classList: gridClassList, parentElement: null, parentNode: null,
+    // runToggleAction calls table.querySelector(...) directly, with no `&&`
+    // guard, so this must exist (returning "not already rounded").
+    querySelector() { return null; },
+    getBoundingClientRect() { return { top: 10, right: 100, bottom: 50, left: 10, width: 90, height: 40 }; },
+  };
+  const clickTarget = {
+    nodeType: 1, tagName: 'DIV', parentElement: gridEl, parentNode: gridEl,
+    closest(sel) { return null; }, // first right-click: no <table>/.dr-ext-grid ancestor yet
+  };
+
+  let buttonCreateCount = 0;
+  function mockCreateElement(tag) {
+    if (tag === 'button') {
+      buttonCreateCount++;
+      return {
+        type: '', className: '', style: {}, dataset: {},
+        classList: { add() {}, remove() {}, contains() { return false; } },
+        setAttribute() {}, getAttribute() { return null; },
+        addEventListener() {}, appendChild() {}, parentElement: null,
+      };
+    }
+    return { className: '', style: {}, textContent: '', appendChild() {} };
+  }
+
+  let contextmenuHandler = null;
+  let onMessageHandler = null;
+  const captureDoc = {
+    addEventListener(type, handler) { if (type === 'contextmenu') contextmenuHandler = handler; },
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: { appendChild() {}, observe() {} },
+    head: { appendChild() {} },
+    createElement: mockCreateElement,
+  };
+  const sentMessages = [];
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener(fn) { onMessageHandler = fn; } },
+      sendMessage(msg) { sentMessages.push(msg); },
+    },
+  };
+
+  const savedDoc = global.document;
+  const savedChrome = global.chrome;
+  const savedGCS = global.getComputedStyle;
+  global.document = captureDoc;
+  global.chrome = captureChrome;
+  // findTargetTable's walk-up (case 3) calls looksLikeGrid, which reads layout
+  // via the bare `getComputedStyle` global (not the window.getComputedStyle
+  // stub set up once at the top of this file). Provide a flex display so the
+  // fixture clears looksLikeGrid's layout gate.
+  global.getComputedStyle = () => ({ display: 'flex' });
+
+  try {
+    eval(contentScriptBundle);
+
+    eq('double-invocation: contextmenu handler was captured', typeof contextmenuHandler, 'function');
+    eq('double-invocation: MENU_CLICKED onMessage handler was captured', typeof onMessageHandler, 'function');
+    if (typeof contextmenuHandler !== 'function' || typeof onMessageHandler !== 'function') return;
+
+    // --- First right-click: new grid discovered via walk-up -> marked + widget built ---
+    contextmenuHandler({ target: clickTarget });
+
+    eq('double-invocation: first contextmenu marks the grid with dr-ext-grid',
+      gridEl.classList.contains('dr-ext-grid'), true);
+    eq('double-invocation: first contextmenu builds exactly one toggle widget',
+      buttonCreateCount, 1);
+
+    // --- Second right-click on the SAME target: findTargetTable now resolves
+    // this grid via case 2 (closest('.dr-ext-grid')), since it is already
+    // marked -- the replacement for the old inline-write re-entry guard. ---
+    clickTarget.closest = function(sel) { return sel === '.dr-ext-grid' ? gridEl : null; };
+    contextmenuHandler({ target: clickTarget });
+
+    eq('double-invocation: second contextmenu on the same grid builds NO second widget',
+      buttonCreateCount, 1);
+
+    // --- MENU_CLICKED dispatch against the same last-right-clicked element:
+    // must reuse the existing widget too, not build another. ---
+    onMessageHandler({ action: 'MENU_CLICKED' }, {}, () => {});
+
+    eq('double-invocation: MENU_CLICKED on an already-marked grid builds NO widget',
+      buttonCreateCount, 1);
+    eq('double-invocation: MENU_CLICKED still runs the toggle action (RANGE_OK sent)',
+      sentMessages.some((m) => m.action === 'RANGE_OK'), true);
+  } finally {
+    global.document = savedDoc;
+    global.chrome = savedChrome;
+    global.getComputedStyle = savedGCS;
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint extract-dr-table (adversarial hardening): static purity scan.
+// Detection functions (findTargetTable, findTables, looksLikeGrid, isDataTable,
+// isPhantomA11yTable) must never write to the page — no classList.add,
+// createElement, appendChild, or createToggleForTable inside their bodies.
+// Write-layer helpers (replaceTextPreservingHTML, applyExtractedPatches,
+// GridAdapter's setText) legitimately create/mutate nodes and are correctly
+// excluded from this scan — they are reachable only from explicit write calls
+// (roundTable / reapplyGridRounding), never from detection.
+// ---------------------------------------------------------------------------
+(function detectionFunctions_sourceScan_noPageWrites() {
+  if (detectCode === null) {
+    eq('purity scan: source file lib/dr-table/detect.js present in manifest', false, true);
+    return;
+  }
+  const FORBIDDEN = ['classList.add', 'createElement', 'appendChild', 'createToggleForTable'];
+  const DETECTION_FNS = ['findTargetTable', 'findTables', 'looksLikeGrid', 'isDataTable', 'isPhantomA11yTable'];
+
+  // Extract a top-level `function name(` body by brace-matching from the
+  // opening brace to its balanced close. Good enough for this file's flat,
+  // non-string-brace-heavy source.
+  function extractFunctionBody(src, fnName) {
+    const sig = new RegExp(`function ${fnName}\\s*\\(`);
+    const m = sig.exec(src);
+    if (!m) return null;
+    const braceStart = src.indexOf('{', m.index);
+    if (braceStart === -1) return null;
+    let depth = 0;
+    for (let i = braceStart; i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}') {
+        depth--;
+        if (depth === 0) return src.slice(braceStart, i + 1);
+      }
+    }
+    return null;
+  }
+
+  for (const fnName of DETECTION_FNS) {
+    const body = extractFunctionBody(detectCode, fnName);
+    eq(`purity scan: ${fnName} body located in lib/dr-table/detect.js`, body !== null, true);
+    if (body === null) continue;
+    for (const token of FORBIDDEN) {
+      eq(`purity scan: ${fnName} does not call/reference "${token}"`,
+        body.includes(token), false);
+    }
+  }
+})();
+
 // AC1 (live): flashTargetedTable (already in global scope from the main eval)
 // adds 'dr-ext-target-flash' to the passed table's classList.
 (function tableContextmenuActivation_flashFn() {

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -2959,6 +2959,89 @@ function makeIsDataTable(rowsSpec) {
     isDataTable(table), false);
 })();
 
+// ---------------------------------------------------------------------------
+// Regression: DEFAULT_NUMERIC_PROBE must stay byte-equivalent to the old
+// pre-extraction predicate (trim -> strip CLEAN_REGEX chars -> parseFloat ->
+// isFinite). A prior version of this probe delegated to DR_NUMBER.toNumber,
+// which uses Number() plus unicode-minus/parenthesized-negative handling and
+// disagrees with parseFloat on exactly these shapes: date-only, time-only,
+// and value-with-unit cells (parseFloat accepts a numeric prefix; Number does
+// not), and accounting-negative cells (Number, via the parens rewrite, parses
+// them; parseFloat does not). Each assertion below fails against the
+// DR_NUMBER-delegating probe and passes against the restored parseFloat-based
+// one — verified by running this file against the pre-fix commit.
+// ---------------------------------------------------------------------------
+
+// Date-only column: parseFloat('2024-01-15') -> 2024 (numeric prefix) -> true.
+// DR_NUMBER.toNumber('2024-01-15') -> Number('2024-01-15') -> NaN -> false.
+(function isDataTable_dateOnlyColumn() {
+  const table = makeIsDataTable([
+    ['Date',       'Owner'],
+    ['2024-01-15', 'Alice'],
+  ]);
+  eq('isDataTable: date-only column ("2024-01-15") -> true (matches old parseFloat predicate)',
+    isDataTable(table), true);
+})();
+
+// Slash-formatted date column: same parseFloat-prefix argument as above.
+(function isDataTable_slashDateColumn() {
+  const table = makeIsDataTable([
+    ['Date',        'Owner'],
+    ['15/03/2024',  'Bob'],
+  ]);
+  eq('isDataTable: slash date column ("15/03/2024") -> true (matches old parseFloat predicate)',
+    isDataTable(table), true);
+})();
+
+// Time-only column: parseFloat('09:30') -> 9 (numeric prefix) -> true.
+// DR_NUMBER.toNumber('09:30') -> Number('09:30') -> NaN -> false.
+(function isDataTable_timeOnlyColumn() {
+  const table = makeIsDataTable([
+    ['Time',  'Event'],
+    ['09:30', 'Standup'],
+  ]);
+  eq('isDataTable: time-only column ("09:30") -> true (matches old parseFloat predicate)',
+    isDataTable(table), true);
+})();
+
+// Value-with-unit column: CLEAN_REGEX strips the space ("3.5 kg" -> "3.5kg"),
+// then parseFloat('3.5kg') -> 3.5 -> true.
+// DR_NUMBER.toNumber('3.5 kg') -> Number('3.5kg') -> NaN -> false.
+(function isDataTable_unitSuffixColumn() {
+  const table = makeIsDataTable([
+    ['Weight', 'Item'],
+    ['3.5 kg', 'Box'],
+  ]);
+  eq('isDataTable: unit-suffix column ("3.5 kg") -> true (matches old parseFloat predicate)',
+    isDataTable(table), true);
+})();
+
+// All-text table: no cell parses as numeric under either probe -> false.
+// (Distinct fixture from isDataTable_3x3_allText above, kept local to this
+// regression block so it reads as a self-contained before/after set.)
+(function isDataTable_allTextColumn() {
+  const table = makeIsDataTable([
+    ['Status', 'Owner'],
+    ['Open',   'Alice'],
+  ]);
+  eq('isDataTable: all-text table -> false (no cell parses as numeric under either probe)',
+    isDataTable(table), false);
+})();
+
+// Accounting-negative cell: old CLEAN_REGEX + parseFloat leaves the
+// parentheses in place; parseFloat('(1,234)' -> '(1234)') -> NaN -> false.
+// DR_NUMBER.toNumber rewrites "(1234)" -> "-1234" -> -1234 -> true. Verify
+// against the parent branch's own behavior (git show refactor/extract-dr-number)
+// before asserting: the parent's predicate also returns false here.
+(function isDataTable_accountingNegativeColumn() {
+  const table = makeIsDataTable([
+    ['Amount',   'Item'],
+    ['(1,234)',  'Refund'],
+  ]);
+  eq('isDataTable: accounting-negative cell ("(1,234)") -> false (matches parent-branch predicate)',
+    isDataTable(table), false);
+})();
+
 // --- Sprint trim-trailing-zeros (chrome-extension): whole-number short-circuit ---
 
 // restoreFormatting drops trailing zeros for whole-number results under 10

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -68,7 +68,7 @@ const contentScriptBundle = contentScriptFiles
   .join('\n');
 const coreCode = sourceByName('lib/dr-number/core.js');
 const parsingCode = sourceByName('lib/dr-number/parsing.js');
-const domAdaptersCode = sourceByName('dom-adapters.js');
+const detectCode = sourceByName('lib/dr-table/detect.js');
 const uiToggleCode = sourceByName('ui-toggle.js');
 // Combined source for "source-includes" assertions that no longer care which
 // content-script file a symbol physically lives in after the Phase 2 split.
@@ -134,10 +134,13 @@ Object.defineProperty(globalThis, 'lastRightClickedTable', {
 // Expose grid-detection helpers for the grid-detection test suite.
 globalThis.looksLikeGrid = looksLikeGrid;
 globalThis.findTargetTable = findTargetTable;
+globalThis.findTables = findTables;
 // Expose TableAdapter abstraction for the grid-adapter test suite.
 globalThis.makeAdapter = makeAdapter;
 globalThis.NativeTableAdapter = NativeTableAdapter;
 globalThis.GridAdapter = GridAdapter;
+// Expose the lib/dr-table package bundle, mirroring DR_NUMBER below.
+globalThis.DR_TABLE = DR_TABLE;
 // Expose grid-virtualization internals for the grid-virtualization test suite.
 globalThis.reapplyGridRounding = reapplyGridRounding;
 globalThis.computeGridRoundedValues = computeGridRoundedValues;
@@ -147,6 +150,9 @@ globalThis.GRID_REAPPLY_DEBOUNCE_MS = GRID_REAPPLY_DEBOUNCE_MS;
 // Expose phantom a11y predicate and its threshold constant for tests
 globalThis.isPhantomA11yTable = isPhantomA11yTable;
 globalThis.OFFSCREEN_LEFT_PX_THRESHOLD = OFFSCREEN_LEFT_PX_THRESHOLD;
+// Expose content.js's badge/marker call-site wrapper (sprint extract-dr-table)
+// for direct unit testing.
+globalThis.markAndToggleIfNewGrid = markAndToggleIfNewGrid;
 `);
 
 let passed = 0;
@@ -1690,7 +1696,7 @@ function withLinkCreateTreeWalker(fn) {
 
 (function quoteRegressionGuards() {
   // 5a. cell.innerText || cell.textContent is the read source (static analysis).
-  // Lives in the NativeTableAdapter (dom-adapters.js) after the Phase 2 split.
+  // Lives in the NativeTableAdapter (lib/dr-table/detect.js) after the Phase 2 split.
   const contentSrc = allContentSrc;
   eq('regression: read source is cell.innerText || cell.textContent',
     contentSrc.includes('cell.innerText || cell.textContent'), true);
@@ -1821,12 +1827,12 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     /defaults\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
   eq('sidebar-defaults: sidebar.js applies DR_DEFAULTS to the UI on load',
     /applyDefaultsToUI[\s\S]*DR_DEFAULTS/.test(sidebarJsSource), true);
-  eq('sidebar-defaults: manifest content_scripts load order is defaults, dr-number package, dom-adapters, ui-toggle, content',
+  eq('sidebar-defaults: manifest content_scripts load order is defaults, dr-number package, dr-table package, ui-toggle, content',
     JSON.stringify(manifest.content_scripts[0].js) === JSON.stringify([
       'defaults.js',
       'lib/dr-number/rounding.js', 'lib/dr-number/core.js',
       'lib/dr-number/parsing.js', 'lib/dr-number/index.js',
-      'dom-adapters.js', 'ui-toggle.js', 'content.js',
+      'lib/dr-table/detect.js', 'lib/dr-table/index.js', 'ui-toggle.js', 'content.js',
     ]), true);
 
   // AC3: (sidebar-tidyup) the old "section-heading" with "Include numbers in cells containing:"
@@ -3384,7 +3390,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   const roundingSrc = sourceByName('lib/dr-number/rounding.js');
   const contentSrc = sourceByName('content.js');
   if (roundingSrc === null || contentSrc === null || coreCode === null ||
-      parsingCode === null || domAdaptersCode === null || uiToggleCode === null) {
+      parsingCode === null || detectCode === null || uiToggleCode === null) {
     eq('x-floor flip: source files present in manifest', false, true);
     return;
   }
@@ -3408,11 +3414,11 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   const vm = require('vm');
   const ctx = vm.createContext(sandbox);
   // content.js runs its observer/listener wiring at load and depends on the
-  // extracted layers (core/parsing/dom-adapters/ui-toggle), so eval them in the
+  // extracted layers (core/parsing/detect/ui-toggle), so eval them in the
   // same order the manifest loads them before content.js.
   vm.runInContext(
     patchedRounding + '\n' + coreCode + '\n' + parsingCode + '\n' +
-    domAdaptersCode + '\n' + uiToggleCode + '\n' + contentSrc +
+    detectCode + '\n' + uiToggleCode + '\n' + contentSrc +
     '\nthis.__roundWithOffset = roundWithOffset;', ctx);
   const patchedRound = sandbox.__roundWithOffset;
 
@@ -4317,22 +4323,23 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 })();
 
 // The extracted layers (the lib/dr-number package: rounding.js, core.js,
-// parsing.js, index.js, plus the Phase 2 split: dom-adapters.js, ui-toggle.js)
-// must all load AFTER defaults.js and BEFORE content.js — content.js runs last
-// because it holds the only load-time-executing code (listeners and the
-// MutationObserver wiring). This ordering is duplicated in three places (manifest
-// content_scripts, sidebar.html, and this harness's eval concatenation); they must
-// stay in lockstep.
+// parsing.js, index.js; the lib/dr-table package: detect.js, index.js; plus
+// ui-toggle.js) must all load AFTER defaults.js and BEFORE content.js —
+// content.js runs last because it holds the only load-time-executing code
+// (listeners and the MutationObserver wiring). This ordering is duplicated in
+// three places (manifest content_scripts, sidebar.html, and this harness's
+// eval concatenation); they must stay in lockstep.
 (function layerLoadOrderAcrossEntryPoints() {
   const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest.json'), 'utf8'));
   const js = manifest.content_scripts[0].js;
   const after = (a, b) => js.indexOf(a) > -1 && js.indexOf(b) > -1 && js.indexOf(a) < js.indexOf(b);
-  eq('manifest: rounding.js < core.js < parsing.js < index.js < dom-adapters.js < ui-toggle.js < content.js',
+  eq('manifest: rounding.js < core.js < parsing.js < dr-number index.js < detect.js < dr-table index.js < ui-toggle.js < content.js',
     after('lib/dr-number/rounding.js', 'lib/dr-number/core.js') &&
     after('lib/dr-number/core.js', 'lib/dr-number/parsing.js') &&
     after('lib/dr-number/parsing.js', 'lib/dr-number/index.js') &&
-    after('lib/dr-number/index.js', 'dom-adapters.js') &&
-    after('dom-adapters.js', 'ui-toggle.js') &&
+    after('lib/dr-number/index.js', 'lib/dr-table/detect.js') &&
+    after('lib/dr-table/detect.js', 'lib/dr-table/index.js') &&
+    after('lib/dr-table/index.js', 'ui-toggle.js') &&
     after('ui-toggle.js', 'content.js'), true);
   eq('manifest: content.js loads last', js[js.length - 1], 'content.js');
 
@@ -4343,11 +4350,12 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
     /lib\/dr-number\/rounding\.js[\s\S]*lib\/dr-number\/core\.js[\s\S]*sidebar\.js/.test(sidebarHtml), true);
   eq('sidebar.html does not load content-only lib/dr-number/parsing.js', sidebarHtml.includes('lib/dr-number/parsing.js'), false);
   eq('sidebar.html does not load content-only lib/dr-number/index.js', sidebarHtml.includes('lib/dr-number/index.js'), false);
-  eq('sidebar.html does not load content-only dom-adapters.js', sidebarHtml.includes('dom-adapters.js'), false);
+  eq('sidebar.html does not load content-only lib/dr-table/detect.js', sidebarHtml.includes('lib/dr-table/detect.js'), false);
+  eq('sidebar.html does not load content-only lib/dr-table/index.js', sidebarHtml.includes('lib/dr-table/index.js'), false);
   eq('sidebar.html does not load content-only ui-toggle.js', sidebarHtml.includes('ui-toggle.js'), false);
 
   // NOTE: the main bootstrap eval() (top of this file) no longer concatenates
-  // coreCode/parsingCode/domAdaptersCode/uiToggleCode/code directly — it evals
+  // coreCode/parsingCode/detectCode/uiToggleCode/code directly — it evals
   // the manifest-driven contentScriptBundle instead (see the
   // manifestDrivenSourceLoading self-test below for that ordering guarantee).
   // This assertion instead checks that later per-layer eval sites in this file
@@ -4355,8 +4363,8 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
   // in layer order, since a few sections still build their own eval string
   // from the individual layer sources.
   const testsSource = fs.readFileSync(path.join(__dirname, 'tests.js'), 'utf8');
-  eq('tests.js: per-layer eval sites reference core→parsing→dom-adapters→ui-toggle→content in layer order',
-    /coreCode[\s\S]*parsingCode[\s\S]*domAdaptersCode[\s\S]*uiToggleCode[\s\S]*code\b/.test(
+  eq('tests.js: per-layer eval sites reference core→parsing→detect→ui-toggle→content in layer order',
+    /coreCode[\s\S]*parsingCode[\s\S]*detectCode[\s\S]*uiToggleCode[\s\S]*code\b/.test(
       testsSource.slice(testsSource.indexOf('eval('))), true);
 })();
 
@@ -6759,7 +6767,7 @@ function withFindTargetEnv(elements, fn) {
     const result = findTargetTable(inner);
 
     eq('findTargetTable: returns outermost ancestor (S6), not inner pane',
-      result, outer);
+      result.handle, outer);
   });
 })();
 
@@ -6803,11 +6811,11 @@ function withFindTargetEnv(elements, fn) {
 
     // Must return outerOk, not failsLLG or body
     eq('findTargetTable: stops at failing parent, returns outermost passing container',
-      result, outerOk);
+      result.handle, outerOk);
 
     // Must NOT return the body sentinel or the failing container
     eq('findTargetTable: does not return failing container',
-      result === failsLLG, false);
+      result.handle === failsLLG, false);
   });
 })();
 
@@ -6833,7 +6841,11 @@ function withFindTargetEnv(elements, fn) {
     const result = findTargetTable(clickTarget);
 
     eq('findTargetTable: prefers native <table> ancestor over grid heuristic',
-      result, tableEl);
+      result.handle, tableEl);
+    // A bare <table> ancestor is a case the caller already knows how to
+    // handle (it never gets the dr-ext-grid marker); isNew is always false.
+    eq('findTargetTable: native <table> ancestor reports isNew: false',
+      result.isNew, false);
   });
 })();
 
@@ -6892,14 +6904,21 @@ function withFindTargetEnv(elements, fn) {
     const result = findTargetTable(clickTarget);
 
     eq('findTargetTable: returns already-tagged .dr-ext-grid ancestor immediately',
-      result, existingGrid);
+      result.handle, existingGrid);
+    // Already marked — the caller has already handled this one; isNew is false.
+    eq('findTargetTable: already-tagged .dr-ext-grid ancestor reports isNew: false',
+      result.isNew, false);
   });
 })();
 
-// FT6: findTargetTable — marks the outermost grid with dr-ext-grid class (AC2)
-// After findTargetTable discovers a new grid via walk-up, it must add
-// 'dr-ext-grid' to the outermost element.
-(function findTargetTable_marksOutermostWithClass() {
+// FT6: findTargetTable — REPORTS a new grid via { handle, isNew: true } and
+// does not mark it itself (sprint extract-dr-table: detection moved to
+// lib/dr-table and now only reports; the caller — content.js's
+// markAndToggleIfNewGrid — owns the dr-ext-grid write and the widget build).
+// This test used to assert findTargetTable itself added the class (AC2 under
+// the old contract); it is reworked here to assert the new split instead:
+// findTargetTable must resolve the new grid AND must leave it unmarked.
+(function findTargetTable_reportsNewGridWithoutMarking() {
   withFindTargetEnv([], function() {
     const makeRows5 = () => [
       makeGridRow([{text:'A',width:100},{text:'100'}], 'row', 20),
@@ -6919,10 +6938,53 @@ function withFindTargetEnv(elements, fn) {
 
     inner.closest = function(sel) { return null; };
 
-    findTargetTable(inner);
+    const result = findTargetTable(inner);
 
-    eq('findTargetTable: marks outermost grid with dr-ext-grid class',
-      outer.classList.contains('dr-ext-grid'), true);
+    eq('findTargetTable: resolves the new grid to the outermost element',
+      result.handle, outer);
+    eq('findTargetTable: reports isNew: true for a not-yet-marked grid',
+      result.isNew, true);
+    eq('findTargetTable: does NOT write the dr-ext-grid marker itself (reports only)',
+      outer.classList.contains('dr-ext-grid'), false);
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// content.js markAndToggleIfNewGrid — the badge/marker call-site wrapper that
+// replaced findTargetTable's old internal mutation. It owns exactly what
+// findTargetTable used to do inline: write the dr-ext-grid marker and build
+// the toggle widget, but only for a first-time (isNew) discovery.
+// ---------------------------------------------------------------------------
+(function markAndToggleIfNewGrid_newGridGetsMarkedAndWidget() {
+  withFindTargetEnv([], function() {
+    const savedToggleStyleInjected = toggleStyleInjected;
+    const table = makePass1DataTable();
+    table.parentElement = { tagName: 'DIV', getAttribute: () => null, style: {}, parentElement: null, parentNode: null };
+
+    const handleReturned = markAndToggleIfNewGrid({ handle: table, isNew: true });
+
+    eq('markAndToggleIfNewGrid: returns found.handle',
+      handleReturned, table);
+    eq('markAndToggleIfNewGrid: adds dr-ext-grid to a newly discovered grid',
+      table.classList.contains('dr-ext-grid'), true);
+    eq('markAndToggleIfNewGrid: builds the toggle widget for a newly discovered grid',
+      tableToggles.has(table), true);
+
+    cleanupPass1Tables([table]);
+    toggleStyleInjected = savedToggleStyleInjected;
+  });
+})();
+
+(function markAndToggleIfNewGrid_alreadySeenHandleSkipsMarkAndWidget() {
+  withFindTargetEnv([], function() {
+    const table = makePass1DataTable();
+
+    markAndToggleIfNewGrid({ handle: table, isNew: false });
+
+    eq('markAndToggleIfNewGrid: does not mark an already-seen handle',
+      table.classList.contains('dr-ext-grid'), false);
+    eq('markAndToggleIfNewGrid: does not build a widget for an already-seen handle',
+      tableToggles.has(table), false);
   });
 })();
 
@@ -7034,12 +7096,12 @@ function makeNativeTableEl(rowsSpec) {
 
   // Source scan: nothing in the class may assign textContent/innerHTML on a
   // cell. Catches a setText re-added under a different name.
-  if (domAdaptersCode === null) {
-    eq('TA1b: source file dom-adapters.js present in manifest', false, true);
+  if (detectCode === null) {
+    eq('TA1b: source file lib/dr-table/detect.js present in manifest', false, true);
     return;
   }
-  const start = domAdaptersCode.indexOf('class NativeTableAdapter');
-  const rest = domAdaptersCode.slice(start);
+  const start = detectCode.indexOf('class NativeTableAdapter');
+  const rest = detectCode.slice(start);
   const classBody = rest.slice(0, rest.indexOf('\n}\n'));
 
   eq('TA1b (setup): NativeTableAdapter class body located',
@@ -7424,7 +7486,7 @@ function makeGridWrapper(rowData, opts) {
   // The _makeCellObj method must ONLY use tn.nodeValue = s.
   // Source scan: the setText implementation inside _makeCellObj must not contain
   // 'textContent =' (with a write) or 'innerHTML =' outside the native-table path.
-  // GridAdapter now lives in dom-adapters.js (Phase 2 split).
+  // GridAdapter now lives in lib/dr-table/detect.js (Phase 2 split).
   const src = allContentSrc;
 
   // Extract _makeCellObj body (from _makeCellObj to the closing brace of its returned object)
@@ -7741,7 +7803,7 @@ function makeGridWrapper(rowData, opts) {
 // nodeValue-safe. It will flag a regression if someone adds an innerHTML= write
 // in the adapter's setText or in a new grid-specific roundTable branch.
 (function gr6j_gridSetText_sourceGuard_noInnerHTMLInAdapterSetText() {
-  // GridAdapter now lives in dom-adapters.js (Phase 2 split).
+  // GridAdapter now lives in lib/dr-table/detect.js (Phase 2 split).
   const src = allContentSrc;
 
   // Extract _makeCellObj body (the GridAdapter's cell factory, ~1000 chars)
@@ -10412,27 +10474,30 @@ function fireMouseClick(buttonEl, fn) {
   const sidebarSrc = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
 
   // AC1 (source): contextmenu handler calls flashTargetedTable(table) inside
-  // the `if (table)` guard.
-  // Pattern: `if (table) { ... flashTargetedTable(table) ...` within the handler.
+  // the `if (found)` guard. Sprint extract-dr-table: findTargetTable now
+  // reports { handle, isNew } instead of the table itself, so the handler
+  // guards on `found` and derives `table` from markAndToggleIfNewGrid(found)
+  // before flashing it.
+  // Pattern: `if (found) { ... flashTargetedTable(table) ...` within the handler.
   eq('table-activation AC1 source: contextmenu handler calls flashTargetedTable(table)',
-    /if\s*\(\s*table\s*\)[\s\S]{0,300}flashTargetedTable\(\s*table\s*\)/.test(contentSrc),
+    /if\s*\(\s*found\s*\)[\s\S]{0,300}flashTargetedTable\(\s*table\s*\)/.test(contentSrc),
     true);
 
-  // AC1 (source): the call to flashTargetedTable is inside the `if (table)` block
+  // AC1 (source): the call to flashTargetedTable is inside the `if (found)` block
   // — it cannot appear BEFORE the guard.
-  // We verify that flashTargetedTable does NOT appear before the first `if (table)`.
+  // We verify that flashTargetedTable does NOT appear before the first `if (found)`.
   const contextmenuMatch = contentSrc.match(/document\.addEventListener\s*\(\s*['"]contextmenu['"][\s\S]*?\}\s*,\s*true\s*\)/);
   const handlerSrc = contextmenuMatch ? contextmenuMatch[0] : '';
   const flashIndex = handlerSrc.indexOf('flashTargetedTable');
-  const guardIndex = handlerSrc.indexOf('if (table)');
-  eq('table-activation AC1 source: flashTargetedTable appears after if(table) guard in handler',
+  const guardIndex = handlerSrc.indexOf('if (found)');
+  eq('table-activation AC1 source: flashTargetedTable appears after if(found) guard in handler',
     flashIndex !== -1 && guardIndex !== -1 && flashIndex > guardIndex,
     true);
 
-  // AC3 (source): TABLE_ACTIVATED sendMessage is inside the `if (table)` block,
+  // AC3 (source): TABLE_ACTIVATED sendMessage is inside the `if (found)` block,
   // meaning a non-table right-click cannot trigger it.
   const sendMsgIndex = handlerSrc.indexOf('TABLE_ACTIVATED');
-  eq('table-activation AC3 source: TABLE_ACTIVATED send is inside if(table) guard',
+  eq('table-activation AC3 source: TABLE_ACTIVATED send is inside if(found) guard',
     sendMsgIndex !== -1 && sendMsgIndex > guardIndex,
     true);
 
@@ -12390,7 +12455,7 @@ function fireMouseClick(buttonEl, fn) {
     'defaults.js',
     'lib/dr-number/rounding.js', 'lib/dr-number/core.js',
     'lib/dr-number/parsing.js', 'lib/dr-number/index.js',
-    'dom-adapters.js', 'ui-toggle.js', 'content.js',
+    'lib/dr-table/detect.js', 'lib/dr-table/index.js', 'ui-toggle.js', 'content.js',
   ];
 
   // AC1: no content-script filename literal reaches readFileSync/path.join
@@ -12472,9 +12537,11 @@ function fireMouseClick(buttonEl, fn) {
   // removed from manifest.json; update it alongside the manifest edit.
   // Sprint extract-dr-number replaced rounding.js/core.js/parsing.js with the
   // four-file lib/dr-number package (rounding.js, core.js, parsing.js,
-  // index.js), raising the count from 7 to 8.
-  eq('manifest-driven loading: manifest content_scripts[0].js lists exactly 8 files today',
-    manifest.content_scripts[0].js.length, 8);
+  // index.js), raising the count from 7 to 8. Sprint extract-dr-table then
+  // replaced dom-adapters.js with the two-file lib/dr-table package
+  // (detect.js, index.js), raising the count from 8 to 9.
+  eq('manifest-driven loading: manifest content_scripts[0].js lists exactly 9 files today',
+    manifest.content_scripts[0].js.length, 9);
 })();
 
 // ---------------------------------------------------------------------------
@@ -12514,8 +12581,8 @@ function fireMouseClick(buttonEl, fn) {
 (function libPathsLoadBeforeNonLibContentScripts() {
   // defaults.js is the one deliberate exception: it is the shared-defaults
   // config file and loads first, ahead of the lib/dr-number package itself.
-  // Every OTHER non-lib content script (dom-adapters.js, ui-toggle.js,
-  // content.js — the DOM/UI consumers) must load after every lib/ path.
+  // Every OTHER non-lib content script (ui-toggle.js, content.js — the DOM/UI
+  // consumers) must load after every lib/ path.
   const js = manifest.content_scripts[0].js;
   const isLib = (f) => f.startsWith('lib/');
   const isConsumer = (f) => !isLib(f) && f !== 'defaults.js';
@@ -12567,6 +12634,178 @@ function fireMouseClick(buttonEl, fn) {
     declaredNames.length > 0, true);
   eq('lib/dr-number bundle: DR_NUMBER keys are exactly the top-level functions declared in rounding.js + core.js + parsing.js',
     Object.keys(globalThis.DR_NUMBER || {}).sort(), declaredNames);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint extract-dr-table: table detection now lives under lib/dr-table/
+// (detect.js, index.js), mirroring the lib/dr-number package structure and
+// discipline checks above. Four groups of tests:
+//   1. DR_TABLE bundle discipline (mirrors drNumberBundleIsPublished /
+//      indexJsDeclaresExactlyOneGlobal, but against an explicit hand-written
+//      list, not a source-derived one — detect.js also carries write-engine
+//      helpers alongside detection, so "every top-level function" is not the
+//      right criterion here the way it is for the pure lib/dr-number files).
+//   2. The jsdom-less criterion: detection runs with no Chrome globals at all.
+//   3. VendorProfiles: a custom list replaces (not merges with) the default.
+//   4. findTables' tableFilter: default drops a phantom a11y table; a
+//      pass-through filter keeps it.
+// ---------------------------------------------------------------------------
+(function drTableBundleIsPublished() {
+  const EXPECTED_DR_TABLE_NAMES = [
+    'findCellTextNode',
+    'NativeTableAdapter',
+    'GridAdapter',
+    'makeAdapter',
+    'getSuperscriptRanges',
+    'isCellWholeLink',
+    'filterLinkMatches',
+    'replaceTextPreservingHTML',
+    'applyExtractedPatches',
+    'looksLikeGrid',
+    'findTargetTable',
+    'findTables',
+    'isPhantomA11yTable',
+    'isDataTable',
+  ].sort();
+
+  eq('lib/dr-table/index.js: DR_TABLE exists on the global scope after the main eval',
+    typeof globalThis.DR_TABLE, 'object');
+  eq('lib/dr-table/index.js: DR_TABLE exposes exactly the expected public names',
+    Object.keys(globalThis.DR_TABLE || {}).sort(), EXPECTED_DR_TABLE_NAMES);
+  eq('lib/dr-table/index.js: every DR_TABLE entry is itself a function (classes included — typeof a class is "function")',
+    EXPECTED_DR_TABLE_NAMES.every((n) => typeof (globalThis.DR_TABLE || {})[n] === 'function'),
+    true);
+})();
+
+(function drTableIndexJsDeclaresExactlyOneGlobal() {
+  const indexSrc = sourceByName('lib/dr-table/index.js');
+  if (indexSrc === null) {
+    eq('lib/dr-table/index.js: source present in manifest', false, true);
+    return;
+  }
+  const topLevelDeclarations = indexSrc.match(/^(const|let|var|function\b|class\b)/gm) || [];
+  eq('lib/dr-table/index.js: exactly one top-level declaration in the file',
+    topLevelDeclarations.length, 1);
+  eq('lib/dr-table/index.js: the sole top-level declaration is DR_TABLE',
+    /^const DR_TABLE\b/m.test(indexSrc), true);
+})();
+
+// jsdom-less criterion: detect.js is evaluated ALONE, in a vm context with no
+// `chrome`, no `window`, and no `getComputedStyle` at all, against a minimal
+// fake document holding one plain <table>. Detection must still find the
+// table and must not throw — this is the acceptance bar for "runs under
+// jsdom-style stubs with no Chrome globals."
+(function detectionRunsWithNoChromeGlobals() {
+  if (detectCode === null) {
+    eq('jsdom-less: source file lib/dr-table/detect.js present in manifest', false, true);
+    return;
+  }
+  const vm = require('vm');
+
+  const fakeTable = {
+    tagName: 'TABLE',
+    rows: [
+      { cells: [{ textContent: 'Name' }, { textContent: '100' }] },
+      { cells: [{ textContent: 'Foo' },  { textContent: '200' }] },
+    ],
+  };
+  const fakeDoc = {
+    querySelectorAll(sel) {
+      if (sel === 'table') return [fakeTable];
+      return [];
+    },
+  };
+
+  // The sandbox carries ONLY fakeDoc/fakeTable and whatever detectCode itself
+  // declares — no window, no getComputedStyle, no chrome, no document global.
+  const sandbox = { fakeDoc, fakeTable, results: null, threw: null };
+  const ctx = vm.createContext(sandbox);
+
+  vm.runInContext(
+    detectCode + `
+    try {
+      var found = findTables(fakeDoc);
+      results = {
+        isDataTable: isDataTable(fakeTable),
+        tablesFound: found.length,
+        firstIsFakeTable: found[0] && found[0].handle === fakeTable,
+        firstIsNew: found[0] && found[0].isNew,
+      };
+    } catch (e) {
+      threw = e.message;
+    }
+    `,
+    ctx
+  );
+
+  eq('jsdom-less: detection does not throw with no chrome/window/getComputedStyle',
+    sandbox.threw, null);
+  eq('jsdom-less: isDataTable finds a plain 2x2 numeric table with no getComputedStyle',
+    sandbox.results && sandbox.results.isDataTable, true);
+  eq('jsdom-less: findTables finds the one plain table under a minimal fake document',
+    sandbox.results && sandbox.results.tablesFound, 1);
+  eq('jsdom-less: findTables resolves to the same table object',
+    sandbox.results && sandbox.results.firstIsFakeTable, true);
+  eq('jsdom-less: findTables reports the plain table as isNew (no registry supplied)',
+    sandbox.results && sandbox.results.firstIsNew, true);
+})();
+
+// VendorProfiles: a custom list replaces the default, and GridAdapter honors
+// it for scroll-container resolution — proving the port is genuinely
+// pluggable, not just a constant renamed in place.
+(function gridAdapter_customVendorProfilesHonored() {
+  const scrollEl = { tagName: 'DIV', className: 'my-lib-scroll' };
+  const wrapperEl = {
+    tagName: 'DIV',
+    className: 'my-lib-wrapper',
+    matches() { return false; },
+    querySelector(sel) {
+      return sel === '.my-lib-scroll-container' ? scrollEl : null;
+    },
+  };
+  const customProfiles = [
+    { name: 'my-lib', classToken: 'my-lib-', scrollContainerSelectors: ['.my-lib-scroll-container'], pinnedPaneSelectors: [] },
+  ];
+
+  const adapter = new GridAdapter(wrapperEl, { vendorProfiles: customProfiles });
+  eq('GridAdapter: a custom vendorProfiles scroll-container selector is honored',
+    adapter._getScrollContainer(), scrollEl);
+
+  // Sanity: the DEFAULT profiles do not know this vendor's selector, so the
+  // custom list above is what made the resolution succeed, not a coincidence.
+  const adapterDefault = new GridAdapter(wrapperEl, {});
+  eq('GridAdapter: default vendorProfiles do not resolve an unrelated vendor selector (sanity)',
+    adapterDefault._getScrollContainer(), wrapperEl);
+})();
+
+// findTables' tableFilter: default (isPhantomA11yTable) drops a phantom a11y
+// table; a pass-through filter keeps it. reuses makePass1DataTable / the
+// aria-hidden phantom shape from the pass1-filter suite above.
+(function findTables_tableFilterDefaultVsPassThrough() {
+  const phantomTable = makePass1DataTable();
+  const hiddenParent = {
+    tagName: 'DIV',
+    getAttribute: (name) => (name === 'aria-hidden' ? 'true' : null),
+    style: {},
+    parentElement: null,
+    parentNode: null,
+  };
+  phantomTable.parentElement = hiddenParent;
+  phantomTable.parentNode = null;
+
+  const root = {
+    tagName: 'BODY',
+    querySelectorAll(sel) {
+      return sel === 'table' ? [phantomTable] : [];
+    },
+  };
+
+  eq('findTables: sanity — the fixture is both a valid data table and a phantom a11y table',
+    isDataTable(phantomTable) && isPhantomA11yTable(phantomTable), true);
+  eq('findTables: default tableFilter (isPhantomA11yTable) drops a phantom a11y table',
+    findTables(root).length, 0);
+  eq('findTables: a pass-through tableFilter keeps the phantom a11y table',
+    findTables(root, { tableFilter: () => false }).length, 1);
 })();
 
 // --- Report ---


### PR DESCRIPTION
Sprint 5 of [docs/sprint-plans/decoupling-migration.md](https://github.com/ArieFisher/dynamic-rounding/blob/main/docs/sprint-plans/decoupling-migration.md). Stacked on #216.

## What

Table detection moves from `dom-adapters.js` into `chrome-extension/lib/dr-table/` (`detect.js` via git mv, plus `index.js` publishing the `DR_TABLE` bundle, 14 names). Four ports with working defaults decouple it from the browser:

- **StyleProbe** — the guarded layout reads, faithful to the old semantics at all four read sites
- **NumericProbe** — one self-contained predicate, byte-equivalent to the old `parseFloat`-after-currency-strip test
- **VendorProfiles** — the Databricks and AG Grid selectors as data, custom lists honored
- **doc** — the page document passed in, with a global fallback

Detection stops changing the page: `findTargetTable` returns `{handle, isNew}` and writes nothing; a new `content.js` wrapper (`markAndToggleIfNewGrid`) applies the marker and builds the widget at both call sites. An end-to-end test fires the real contextmenu listener twice plus the `MENU_CLICKED` handler against one grid and asserts exactly one widget. A vm test proves detection finds a table with no Chrome globals and no `getComputedStyle`. The phantom accessibility-table filter becomes an optional predicate (`opts.tableFilter`), defaulting to current behavior.

One review round caught a real regression before merge: the numeric-probe default originally delegated to `DR_NUMBER.toNumber`, which flipped detection on date-only, time, unit-suffix, and accounting-negative tables. The probe is now the old predicate verbatim, with six regression assertions that fail under the delegating version.

## Acceptance criteria

- [x] Detection runs in a no-Chrome-globals context and finds the table
- [x] Detection code contains no widget construction or marker write; callers badge
- [x] Vendor selectors live in one data structure; a custom list is honored
- [x] All three suites pass (extension 1,514; js 158; python 116); detection verdicts on all fixtures match the parent branch

## Reviewer notes

- Follow-up issues: #219 (`findTables` is a parallel implementation the live scanners do not call yet), #220 (`NodeFilter` bare global in `getSuperscriptRanges`), #221 (detection and rounding parse numbers differently, preserved deliberately).
- `vendorProfiles` is pluggable in signature only — production `GridAdapter` sites pass no opts; only tests exercise custom lists.
- Write-layer helpers keep bare `document` reads; they are unreachable from detection and out of this sprint's scope.
