### PR TITLE
chore(extension): delete the unused rounding entry point, modes, and validator

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -11,8 +11,8 @@
 // here too via shared global scope.
 
 // EPSILON, X_FLOOR_THRESHOLD, roundWithOffset, and roundCellSetAware live in
-// rounding.js (loaded by manifest content_scripts ahead of this file) so the
-// sidebar can call the same arithmetic for its preview band.
+// rounding.js, loaded by manifest content_scripts ahead of this file. The
+// sidebar loads rounding.js separately via a script tag in sidebar.html.
 
 // DR_DEFAULTS is loaded from defaults.js (declared first in manifest content_scripts).
 // It is shared with sidebar.js so the sidebar UI's initial state and the
@@ -1067,5 +1067,5 @@ function toggleOriginalValues(table) {
 
 // findMaxMagnitude and toNumber (plus DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP,
 // VALIDATION_LIMIT, CLEAN_REGEX, PARENS_REGEX) live in core.js, loaded by
-// manifest content_scripts ahead of this file so the sidebar shares the same
-// coercion helpers.
+// manifest content_scripts ahead of this file. The sidebar loads core.js
+// separately via a script tag in sidebar.html.

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1065,7 +1065,7 @@ function toggleOriginalValues(table) {
   syncSwitchForTable(table);
 }
 
-// ROUND_DYNAMIC, singleValueMode, datasetMode, findMaxMagnitude, toNumber, and
-// validateOffset (plus DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP, VALIDATION_LIMIT,
-// CLEAN_REGEX, PARENS_REGEX) live in core.js, loaded by manifest content_scripts
-// ahead of this file so the sidebar can call the same ROUND_DYNAMIC core.
+// findMaxMagnitude and toNumber (plus DEFAULT_OFFSET_TOP, DEFAULT_NUM_TOP,
+// VALIDATION_LIMIT, CLEAN_REGEX, PARENS_REGEX) live in core.js, loaded by
+// manifest content_scripts ahead of this file so the sidebar shares the same
+// coercion helpers.

--- a/chrome-extension/lib/dr-number/core.js
+++ b/chrome-extension/lib/dr-number/core.js
@@ -13,7 +13,7 @@
  * rounding.js, which must load before this file.
  */
 
-// Constants owned by the core dispatch/coercion layer.
+// Constants owned by the coercion + magnitude layer.
 const CLEAN_REGEX = /[$€£¥,\s%]/g;
 const PARENS_REGEX = /^\((.+)\)$/;
 const DEFAULT_OFFSET_TOP = -0.5;

--- a/chrome-extension/lib/dr-number/core.js
+++ b/chrome-extension/lib/dr-number/core.js
@@ -1,12 +1,13 @@
 /**
- * DynamicRounding domain core (dispatch + coercion layer).
+ * DynamicRounding domain core (coercion + magnitude helpers).
  *
  * Loaded by both content.js (page context, via manifest content_scripts) and
  * sidebar.js (extension side-panel context, via <script> tag), AFTER rounding.js
  * and BEFORE content.js. Must remain framework-free and side-effect-free: no
  * chrome.*, no DOM access. All symbols land on the global object of whichever
- * script loads this file, so both contexts call the same ROUND_DYNAMIC the
- * standalone js/round_dynamic.js implements.
+ * script loads this file, so both contexts share the same findMaxMagnitude and
+ * toNumber. This is the extension's own copy; the standalone js/round_dynamic.js
+ * implements a separate, unrelated entry point for Google Sheets.
  *
  * The arithmetic primitives (roundWithOffset, roundCellSetAware) live in
  * rounding.js, which must load before this file.
@@ -18,48 +19,6 @@ const PARENS_REGEX = /^\((.+)\)$/;
 const DEFAULT_OFFSET_TOP = -0.5;
 const DEFAULT_NUM_TOP = 1;
 const VALIDATION_LIMIT = 20;
-
-function ROUND_DYNAMIC(values, offset_top, offset_other, num_top) {
-  const firstIsArray = Array.isArray(values);
-
-  if (firstIsArray) {
-    return datasetMode(values, offset_top, offset_other, num_top);
-  } else {
-    return singleValueMode(values, offset_top);
-  }
-}
-
-function singleValueMode(value, offset) {
-  offset = (offset === undefined || offset === "") ? DEFAULT_OFFSET_TOP : offset;
-  validateOffset(offset, "offset");
-
-  if (value === "" || value === null) return "";
-
-  const num = toNumber(value);
-  if (num === null) return value;
-  if (num === 0) return 0;
-
-  return roundWithOffset(num, offset);
-}
-
-function datasetMode(range, offset_top, offset_other, num_top) {
-  offset_top = (offset_top === undefined || offset_top === "") ? DEFAULT_OFFSET_TOP : offset_top;
-  offset_other = (offset_other === undefined || offset_other === "") ? offset_top : offset_other;
-  num_top = (num_top === undefined || num_top === "") ? DEFAULT_NUM_TOP : num_top;
-  validateOffset(offset_top, "offset_top");
-  validateOffset(offset_other, "offset_other");
-
-  if (!Array.isArray(range[0])) {
-    range = [range];
-  }
-
-  const numericRange = range.map(row => row.map(cell => toNumber(cell)));
-  const max_mag = findMaxMagnitude(numericRange);
-
-  return range.map((row, r) =>
-    row.map((cell, c) => roundCellSetAware(cell, numericRange[r][c], max_mag, offset_top, offset_other, num_top))
-  );
-}
 
 function findMaxMagnitude(numericRange) {
   let max_mag = null;
@@ -92,10 +51,4 @@ function toNumber(value) {
     return isFinite(parsed) ? parsed : null;
   }
   return null;
-}
-
-function validateOffset(offset, paramName) {
-  if (offset < -VALIDATION_LIMIT || offset > VALIDATION_LIMIT) {
-    throw new Error(paramName + " must be between -" + VALIDATION_LIMIT + " and " + VALIDATION_LIMIT + ", got " + offset);
-  }
 }

--- a/chrome-extension/lib/dr-number/index.js
+++ b/chrome-extension/lib/dr-number/index.js
@@ -22,12 +22,8 @@ const DR_NUMBER = {
   trimNum,
 
   // core.js
-  ROUND_DYNAMIC,
-  singleValueMode,
-  datasetMode,
   findMaxMagnitude,
   toNumber,
-  validateOffset,
 
   // parsing.js
   lettersToColIndex,

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -12511,6 +12511,29 @@ function fireMouseClick(buttonEl, fn) {
     true);
 })();
 
+// ---------------------------------------------------------------------------
+// Sprint delete-dead-code removed ROUND_DYNAMIC, singleValueMode, datasetMode,
+// and validateOffset from core.js as unreachable: nothing in the extension
+// ever called ROUND_DYNAMIC or the two mode functions it dispatched to, and
+// validateOffset only existed to serve them. These typeof checks read the
+// bare names the main eval's function declarations leave in this module's
+// scope (the same sloppy-mode leak DR_NUMBER's helpers rely on before their
+// explicit globalThis bridge) — so a reintroduced declaration in core.js
+// flips a result from 'undefined' to 'function' even if nobody re-adds a
+// globalThis bridge or a DR_NUMBER entry for it.
+// ---------------------------------------------------------------------------
+(function deletedRoundingEntryPointsStayDeleted() {
+  eq('core.js: ROUND_DYNAMIC stays deleted', typeof ROUND_DYNAMIC, 'undefined');
+  eq('core.js: singleValueMode stays deleted', typeof singleValueMode, 'undefined');
+  eq('core.js: datasetMode stays deleted', typeof datasetMode, 'undefined');
+  eq('core.js: validateOffset stays deleted', typeof validateOffset, 'undefined');
+
+  const deletedNames = ['ROUND_DYNAMIC', 'singleValueMode', 'datasetMode', 'validateOffset'];
+  eq('lib/dr-number/index.js: DR_NUMBER does not re-expose any deleted rounding entry point',
+    deletedNames.some((n) => Object.prototype.hasOwnProperty.call(globalThis.DR_NUMBER || {}, n)),
+    false);
+})();
+
 (function libPathsLoadBeforeNonLibContentScripts() {
   // defaults.js is the one deliberate exception: it is the shared-defaults
   // config file and loads first, ahead of the lib/dr-number package itself.

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -12491,7 +12491,7 @@ function fireMouseClick(buttonEl, fn) {
     // rounding.js
     'roundWithOffset', 'roundCellSetAware', 'stepForOffset', 'formatStep', 'trimNum',
     // core.js
-    'ROUND_DYNAMIC', 'singleValueMode', 'datasetMode', 'findMaxMagnitude', 'toNumber', 'validateOffset',
+    'findMaxMagnitude', 'toNumber',
     // parsing.js
     'lettersToColIndex', 'parseRangeEndpoint', 'parseRangeToken', 'parseRangeExpr',
     'isInRanges', 'resolveOffset', 'resolveNumTop', 'getExclusionReason',


### PR DESCRIPTION
Sprint 3 of [docs/sprint-plans/decoupling-migration.md](https://github.com/ArieFisher/dynamic-rounding/blob/main/docs/sprint-plans/decoupling-migration.md). Stacked on #216.

## What

Deletes the extension's never-used copies of the Sheets API from `lib/dr-number/core.js`: `ROUND_DYNAMIC`, `singleValueMode`, `datasetMode`, `validateOffset`. `findMaxMagnitude` and `toNumber` survive byte-identical. The `DR_NUMBER` bundle and the expected-names test drop the four entries. New lock assertions keep the names deleted: each must be `undefined` in the evaluated scope, and the bundle must not own the keys — mutation-verified (re-adding `ROUND_DYNAMIC` fails the suite).

The constants `DEFAULT_OFFSET_TOP`, `DEFAULT_NUM_TOP`, and `VALIDATION_LIMIT` were scoped for deletion only if unread; verification found live readers (`content.js` twice, `resolveOffset` in `parsing.js`), so they stay.

Comment corrections: the `core.js` header no longer claims Sheets and the extension share one entry point (the Sheets copy in `js/round_dynamic.js` is independent); three load-path comments in `content.js` and `core.js` now state that the sidebar gets its scripts from `sidebar.html` script tags, not from the manifest list.

## Acceptance criteria

- [x] The four deleted names appear nowhere in `chrome-extension/` as code (README names the algorithm, not the symbol)
- [x] `findMaxMagnitude` and `toNumber` byte-identical
- [x] All three suites pass (extension 1,456; js 158; python 116)

## Reviewer notes

- Follow-up issue: #217 — the two kept defaults still duplicate values in `defaults.js`; resolving that means pointing `content.js` at `DR_DEFAULTS`, which belongs with the settings-ownership sprint.
- The typeof locks key on function declarations; a reintroduction as an arrow-function const would evade them (same limitation tracked in #214).

