### PR TITLE
refactor(extension): settings live in the application model

### DIFF
--- a/chrome-extension/adapters/messaging.js
+++ b/chrome-extension/adapters/messaging.js
@@ -61,6 +61,17 @@
  *     publish (without re-sending it back out), so a cross-context topic
  *     behaves the same as a same-context one from a subscriber's point of
  *     view.
+ *   - publish() takes an optional third argument, opts. On the extension-
+ *     page relay branch (chrome.tabs.sendMessage), opts.onDelivery, when a
+ *     function, is invoked after delivery settles — this is how a caller
+ *     (e.g. sidebar.js) reacts to a delivery outcome (chrome.runtime.
+ *     lastError on failure) the exact way sendToActiveTab did before this
+ *     topic existed. The bus always supplies chrome.tabs.sendMessage its own
+ *     callback and touches chrome.runtime.lastError inside it — regardless
+ *     of whether the caller passed onDelivery — so a failed delivery never
+ *     logs Chrome's "Unchecked runtime.lastError" warning. The bus itself
+ *     stays generic: it forwards the outcome, but never inspects it or knows
+ *     what a caller does with it.
  *
  * Loaded after the lib/ packages and before app/store.js — the store
  * publishes through this bus, so the bus must exist first.
@@ -133,7 +144,7 @@ const DR_BUS = (function () {
   const MAX_PUBLISH_DEPTH = 20;
   let publishDepth = 0;
 
-  function publish(topic, payload) {
+  function publish(topic, payload, opts) {
     assertKnownTopic(topic);
     publishDepth++;
     try {
@@ -146,6 +157,7 @@ const DR_BUS = (function () {
       deliverLocally(topic, payload);
       const wireAction = TOPICS[topic].wireAction;
       if (!wireAction || typeof chrome === 'undefined' || !chrome.runtime) return;
+      const onDelivery = opts && typeof opts.onDelivery === 'function' ? opts.onDelivery : null;
       if (chrome.tabs && typeof chrome.tabs.query === 'function' && typeof chrome.tabs.sendMessage === 'function') {
         // Extension-page context (the sidebar): chrome.runtime.sendMessage
         // cannot reach a content script, so relay via the active tab —
@@ -154,7 +166,15 @@ const DR_BUS = (function () {
           chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
             if (!tabs || !tabs[0]) return;
             try {
-              chrome.tabs.sendMessage(tabs[0].id, Object.assign({ action: wireAction }, payload));
+              chrome.tabs.sendMessage(tabs[0].id, Object.assign({ action: wireAction }, payload), () => {
+                // Always touch chrome.runtime.lastError, even when the caller
+                // supplied no onDelivery — otherwise a failed delivery logs
+                // Chrome's "Unchecked runtime.lastError" warning. The bus
+                // reads it purely to consume it; interpreting it is the
+                // caller's job via onDelivery, same as sendToActiveTab did.
+                void chrome.runtime.lastError;
+                if (onDelivery) onDelivery();
+              });
             } catch (e) {
               // no content script on this tab (or it hasn't loaded yet); harmless.
             }

--- a/chrome-extension/adapters/messaging.js
+++ b/chrome-extension/adapters/messaging.js
@@ -138,9 +138,11 @@ const DR_BUS = (function () {
   // synchronous (see the header), so that nested publish() runs on top of
   // this one's still-live stack frame. A cycle with no caller-side guard
   // would recurse until the real call stack overflows (issue #240). This
-  // cap allows any legitimate shallow chain (the deepest today, a guarded
-  // two-topic bounce-back, reaches 4) while turning an unguarded cycle into
-  // a clear, catchable error instead of a crash.
+  // cap allows any legitimate shallow chain (the deepest in production, the
+  // intent:selectTable -> state:selectedTableChanged hop, reaches 2; a
+  // guarded two-topic bounce-back reaches 4, but only in the reentrancy
+  // test) while turning an unguarded cycle into a clear, catchable error
+  // instead of a crash.
   const MAX_PUBLISH_DEPTH = 20;
   let publishDepth = 0;
 

--- a/chrome-extension/adapters/messaging.js
+++ b/chrome-extension/adapters/messaging.js
@@ -11,12 +11,16 @@
  * Two topic families, and only two — every topic in DR_BUS.TOPICS carries
  * one of these two family tags:
  *
- *   - 'intent'       Published by views (e.g. ui-toggle.js) to report a user
- *                     action. The controller in content.js is the sole
- *                     subscriber. Every intent topic this sprint stays
- *                     inside the content-script scope: the view and its
- *                     controller share one JS context, so intent delivery
- *                     never needs chrome.runtime.
+ *   - 'intent'       Published by views (e.g. ui-toggle.js, sidebar.js) to
+ *                     report a user action. The controller in content.js is
+ *                     the sole subscriber. Most intent topics stay inside
+ *                     the content-script scope (the view and its controller
+ *                     share one JS context, so delivery never needs
+ *                     chrome.runtime) — but a view running in a different
+ *                     extension context (the sidebar is its own page, not
+ *                     part of the tab's content script) carries a wireAction
+ *                     so the same publish() call reaches the controller
+ *                     across contexts too.
  *   - 'state-change' Published by the model (app/store.js) whenever a
  *                     stored field changes. A view subscribes to redraw on
  *                     future changes, or simply reads the store's getters
@@ -36,14 +40,22 @@
  *     handler directly, in subscription order, before returning. A
  *     controller that calls a store setter in response to a subscribed
  *     intent sees the store already updated by the time publish() returns.
+ *     Because delivery is synchronous, a handler that itself publishes
+ *     (directly, or by way of a store setter) can re-enter publish() before
+ *     the original call returns; see the depth guard below.
  *   - A topic MAY also carry a wireAction: the name of an existing
- *     chrome.runtime message action that sidebar.js/background.js already
- *     understand. When present, publish() additionally relays the payload
- *     as that action's message over chrome.runtime.sendMessage, so a
- *     cross-context subscriber keeps seeing the wire format it always has —
- *     no topic uses this yet (every topic this sprint stays same-context);
- *     the mechanism exists so a future topic can adopt an existing wire
- *     action instead of inventing a second, competing message shape.
+ *     chrome.runtime message action that sidebar.js/background.js/content.js
+ *     already understand. When present, publish() additionally relays the
+ *     payload as that action's message, over whichever transport reaches
+ *     the OTHER context from the one currently publishing:
+ *       - From a content script, chrome.runtime.sendMessage() reaches every
+ *         extension page (background, the open sidebar) — it cannot reach a
+ *         content script (chrome.runtime.sendMessage's own contract).
+ *       - From an extension page (the sidebar), chrome.tabs is available
+ *         and chrome.runtime.sendMessage cannot reach a content script at
+ *         all, so the relay instead queries the active tab and uses
+ *         chrome.tabs.sendMessage — the exact transport sidebar.js already
+ *         used for its content-script calls before this topic existed.
  *     Symmetrically, an incoming chrome.runtime message whose action
  *     matches a registered wireAction is redelivered here as a same-context
  *     publish (without re-sending it back out), so a cross-context topic
@@ -64,6 +76,16 @@ const DR_BUS = (function () {
     'intent:selectTable': { family: INTENT, wireAction: null },
     'state:selectedTableChanged': { family: STATE_CHANGE, wireAction: null },
     'state:sidebarOpenChanged': { family: STATE_CHANGE, wireAction: null },
+    // Published by the sidebar's controls (a different extension context
+    // from the model) on every settings change. wireAction reuses
+    // APPLY_SIDEBAR_SETTINGS, the message name content.js already handles,
+    // so the wire format is unchanged — only the sender's code path is.
+    'intent:settingsChanged': { family: INTENT, wireAction: 'APPLY_SIDEBAR_SETTINGS' },
+    // Published by the model (app/store.js) after every settings change,
+    // regardless of source. The controller subscribes to apply the new
+    // value to the selected table — this is the bus's first state-change
+    // subscriber (see the depth guard below, issue #240).
+    'state:settingsChanged': { family: STATE_CHANGE, wireAction: null },
   };
 
   const subscribers = new Map(); // topic name -> Set<handler>
@@ -100,16 +122,57 @@ const DR_BUS = (function () {
     }
   }
 
+  // A handler invoked by deliverLocally() may itself publish (directly, or
+  // through a store setter) before returning — same-context delivery is
+  // synchronous (see the header), so that nested publish() runs on top of
+  // this one's still-live stack frame. A cycle with no caller-side guard
+  // would recurse until the real call stack overflows (issue #240). This
+  // cap allows any legitimate shallow chain (the deepest today, a guarded
+  // two-topic bounce-back, reaches 4) while turning an unguarded cycle into
+  // a clear, catchable error instead of a crash.
+  const MAX_PUBLISH_DEPTH = 20;
+  let publishDepth = 0;
+
   function publish(topic, payload) {
     assertKnownTopic(topic);
-    deliverLocally(topic, payload);
-    const wireAction = TOPICS[topic].wireAction;
-    if (wireAction && typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
-      try {
-        chrome.runtime.sendMessage(Object.assign({ action: wireAction }, payload));
-      } catch (e) {
-        // extension context may not be available; harmless.
+    publishDepth++;
+    try {
+      if (publishDepth > MAX_PUBLISH_DEPTH) {
+        throw new Error(
+          'DR_BUS: publish depth exceeded ' + MAX_PUBLISH_DEPTH +
+          ' while publishing "' + topic + '" — likely an unguarded reentrant publish cycle'
+        );
       }
+      deliverLocally(topic, payload);
+      const wireAction = TOPICS[topic].wireAction;
+      if (!wireAction || typeof chrome === 'undefined' || !chrome.runtime) return;
+      if (chrome.tabs && typeof chrome.tabs.query === 'function' && typeof chrome.tabs.sendMessage === 'function') {
+        // Extension-page context (the sidebar): chrome.runtime.sendMessage
+        // cannot reach a content script, so relay via the active tab —
+        // the same transport sidebar.js already used for this call.
+        try {
+          chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            if (!tabs || !tabs[0]) return;
+            try {
+              chrome.tabs.sendMessage(tabs[0].id, Object.assign({ action: wireAction }, payload));
+            } catch (e) {
+              // no content script on this tab (or it hasn't loaded yet); harmless.
+            }
+          });
+        } catch (e) {
+          // extension context may not be available; harmless.
+        }
+      } else if (typeof chrome.runtime.sendMessage === 'function') {
+        // Content-script context: broadcast to every extension page
+        // (background, the open sidebar) — unchanged from before this topic.
+        try {
+          chrome.runtime.sendMessage(Object.assign({ action: wireAction }, payload));
+        } catch (e) {
+          // extension context may not be available; harmless.
+        }
+      }
+    } finally {
+      publishDepth--;
     }
   }
 

--- a/chrome-extension/app/store.js
+++ b/chrome-extension/app/store.js
@@ -8,8 +8,11 @@
 /**
  * The application model.
  *
- * Owns, this sprint, the two fields that used to live as file-level `let`
- * bindings in content.js and were written into directly from ui-toggle.js:
+ * Owns the fields that used to live as file-level `let` bindings in
+ * content.js (written into directly from ui-toggle.js) or, for settings,
+ * nowhere at all — content.js used to pull them from the sidebar's live DOM
+ * on every sidebar open, via a ten-retry polling loop (see the app-model-
+ * settings sprint that replaced it):
  *
  *   - selectedTable   The table the user last targeted — by right-click, or
  *                      by clicking a different table's toggle while the
@@ -18,6 +21,14 @@
  *                      (setTableBound) names the same idea from the
  *                      sidebar's side. One field, one name: selectedTable.
  *   - sidebarOpen     Whether the side panel is currently open.
+ *   - settings        The current rounding options (the sidebar's
+ *                      checkboxes/sliders/range expression, flattened to one
+ *                      object). Initialized from DR_DEFAULTS so the model
+ *                      always holds a valid value, even before the sidebar
+ *                      has ever been opened. The sidebar is the only writer
+ *                      (via the intent:settingsChanged bus topic); the
+ *                      controller applies every new value to the selected
+ *                      table by subscribing to the resulting state-change.
  *
  * Reads go through the getters below. The only way to change a field is one
  * of the setter methods, and each setter does exactly two things: update the
@@ -35,6 +46,7 @@
 const DR_STORE = (function () {
   let selectedTable = null;
   let sidebarOpen = false;
+  let settings = Object.assign({}, DR_DEFAULTS);
 
   function getSelectedTable() {
     return selectedTable;
@@ -44,12 +56,18 @@ const DR_STORE = (function () {
     return sidebarOpen;
   }
 
+  // Returns a fresh copy — callers may not mutate the store's internal
+  // settings object by mutating what they read.
+  function getSettings() {
+    return Object.assign({}, settings);
+  }
+
   // A view that opens or reconnects (the sidebar re-opening, most notably)
   // pulls this instead of trusting a state-change message it may have
   // missed while it was gone — the bus keeps no history, so a missed
   // publish is gone for good from the bus's point of view.
   function getSnapshot() {
-    return { selectedTable, sidebarOpen };
+    return { selectedTable, sidebarOpen, settings: getSettings() };
   }
 
   function setSelectedTable(table) {
@@ -62,11 +80,18 @@ const DR_STORE = (function () {
     DR_BUS.publish('state:sidebarOpenChanged', { sidebarOpen });
   }
 
+  function setSettings(newSettings) {
+    settings = Object.assign({}, DR_DEFAULTS, newSettings || {});
+    DR_BUS.publish('state:settingsChanged', { settings: getSettings() });
+  }
+
   return {
     getSelectedTable,
     isSidebarOpen,
+    getSettings,
     getSnapshot,
     setSelectedTable,
     setSidebarOpen,
+    setSettings,
   };
 })();

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -35,6 +35,20 @@ DR_BUS.subscribe('intent:selectTable', ({ table }) => {
   DR_STORE.setSelectedTable(table);
 });
 
+// The bus's first state-change subscriber (see adapters/messaging.js's depth
+// guard, issue #240): whenever the model's settings change — regardless of
+// source — apply the new value to whichever table is currently selected.
+// The sidebar's own control-change messages are handled directly by the
+// APPLY_SIDEBAR_SETTINGS listener below (DR_STORE.setSettings there is what
+// triggers this subscriber); this also covers any future in-context caller
+// that sets settings without going through that message.
+DR_BUS.subscribe('state:settingsChanged', ({ settings }) => {
+  const selected = DR_STORE.getSelectedTable();
+  if (selected) {
+    applySidebarRounding(selected, settings);
+  }
+});
+
 // Per-table memory of the options used for the most recent roundTable() run.
 // Consulted by toggleOriginalValues() when re-running the pipeline so that the
 // "toggle back to rounded" path uses the same parameters as the original render.
@@ -117,13 +131,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
   if (request.action === 'SIDEBAR_OPENED') {
     DR_STORE.setSidebarOpen(true);
-    // Reconnect: pull the model's current selection rather than trust
-    // whatever this file's variables happened to hold before — the sidebar
-    // may be reopening after a close, and DR_STORE is the single owner of
-    // record for which table is selected.
+    // Reconnect: pull the model's own selection and settings — the sidebar
+    // may be reopening after a close, and DR_STORE owns both of record.
     const selected = DR_STORE.getSelectedTable();
     if (selected) {
-      requestSidebarSettingsAndApply(selected);
+      applySidebarRounding(selected, DR_STORE.getSettings());
       // Tell the sidebar its cached preview samples are stale; it will re-pull
       // GET_PREVIEW_SAMPLES against the now-current targeted table.
       try {
@@ -143,11 +155,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 
   if (request.action === 'APPLY_SIDEBAR_SETTINGS') {
-    const selected = DR_STORE.getSelectedTable();
-    if (selected) {
-      applySidebarRounding(selected, request.settings || DR_DEFAULTS);
-    }
+    // Record it; the state-change subscriber above applies it to the table.
+    DR_STORE.setSettings(request.settings || DR_DEFAULTS);
     sendResponse({ ok: true });
+    return;
+  }
+
+  if (request.action === 'GET_SETTINGS') {
+    // Inverse of the old sidebar pull: the sidebar asks the model instead.
+    sendResponse({ settings: DR_STORE.getSettings() });
     return;
   }
 
@@ -170,23 +186,6 @@ window.addEventListener('pagehide', () => {
     // extension context may already be gone
   }
 });
-
-// Ask the sidebar for its current UI state, then apply. The sidebar may not
-// have finished loading when SIDEBAR_OPENED fires from the background, so we
-// retry a few times before falling back to defaults.
-function requestSidebarSettingsAndApply(table, attempt = 0) {
-  chrome.runtime.sendMessage({ action: 'GET_SIDEBAR_SETTINGS' }, (response) => {
-    if (chrome.runtime.lastError || !response || !response.settings) {
-      if (attempt < 10) {
-        setTimeout(() => requestSidebarSettingsAndApply(table, attempt + 1), 50);
-      } else {
-        applySidebarRounding(table, DR_DEFAULTS);
-      }
-      return;
-    }
-    applySidebarRounding(table, response.settings);
-  });
-}
 
 function applySidebarRounding(table, options) {
   const opts = Object.assign({}, DR_DEFAULTS, options || {});
@@ -417,12 +416,10 @@ function decisionToLegacyInfo(decision) {
 // mode:'time' decisions are deliberately left out of the sample pool even
 // though the ladder classifies them.
 //
-// options defaults to DR_DEFAULTS, matching the one real call site
-// (extractPreviewSamples, called with no settings argument by the
-// GET_PREVIEW_SAMPLES handler above). Wiring the preview to the sidebar's
-// live settings instead of DR_DEFAULTS is out of scope for this change; the
-// optional parameter exists so tests can exercise the ladder's option-gated
-// rules directly.
+// options defaults to DR_DEFAULTS when the caller passes none (tests exercise
+// the ladder's option-gated rules directly this way); the real call site,
+// extractPreviewSamples below, passes the model's live settings so the
+// preview band classifies cells exactly as roundTable will.
 function collectNumericCells(table, options) {
   const opts = Object.assign({}, DR_DEFAULTS, options || {});
   const rangeParse = parseRangeExpr(opts.rangeExpr);
@@ -520,13 +517,17 @@ function collectNumericCells(table, options) {
 // the band shows the actual offset_top vs offset_other split that
 // roundCellSetAware will apply to the table.
 function extractPreviewSamples(table) {
-  const cells = collectNumericCells(table);
+  // Live settings, not shipped defaults — otherwise the preview band and the
+  // table disagree the moment the sidebar's slider or checkboxes diverge
+  // from DR_DEFAULTS (issue this sprint fixes).
+  const liveSettings = DR_STORE.getSettings();
+  const cells = collectNumericCells(table, liveSettings);
   if (cells.length === 0) {
     return { samples: { top: [], bottom: [] }, maxMag: null };
   }
-  const numTop = DR_DEFAULTS.numTop || 1;
-  const topOffset = typeof DR_DEFAULTS.offsetTop === 'number' ? DR_DEFAULTS.offsetTop : -0.5;
-  const otherOffset = typeof DR_DEFAULTS.offsetOther === 'number' ? DR_DEFAULTS.offsetOther : -0.5;
+  const numTop = liveSettings.numTop || 1;
+  const topOffset = typeof liveSettings.offsetTop === 'number' ? liveSettings.offsetTop : -0.5;
+  const otherOffset = typeof liveSettings.offsetOther === 'number' ? liveSettings.offsetOther : -0.5;
 
   // Reorder a magnitude bucket so cells that visibly *change* under the band's
   // default offset come first. Picking the raw document-order cell can land on

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -373,6 +373,7 @@
   <script src="defaults.js"></script>
   <script src="lib/dr-number/rounding.js"></script>
   <script src="lib/dr-number/core.js"></script>
+  <script src="adapters/messaging.js"></script>
   <script src="sidebar.js"></script>
 </body>
 </html>

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -473,24 +473,15 @@ function updateDisabledState() {
   }
 }
 
-function sendToActiveTab(message) {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (!tabs[0]) {
-      statusEl.textContent = 'No active tab.';
-      return;
-    }
-    chrome.tabs.sendMessage(tabs[0].id, message, () => {
-      if (chrome.runtime.lastError) {
-        setTableBound(false);
-      } else {
-        statusEl.textContent = '';
-      }
-    });
-  });
-}
-
+// Cross-context: this page and content.js are separate extension contexts,
+// so the settings change is reported as an intent over DR_BUS rather than
+// writing the model directly (mirrors ui-toggle.js's intent:selectTable in
+// the content-script context). DR_BUS relays it to the active tab's content
+// script — the same chrome.tabs.query + chrome.tabs.sendMessage transport
+// this file used directly before this topic existed (see
+// adapters/messaging.js's publish()).
 function applyNow() {
-  sendToActiveTab({ action: 'APPLY_SIDEBAR_SETTINGS', settings: currentSettings() });
+  DR_BUS.publish('intent:settingsChanged', { settings: currentSettings() });
 }
 
 enabledEl.addEventListener('change', () => {
@@ -535,8 +526,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     flashSidebarContainer();
   } else if (request.action === 'CLOSE_SIDEBAR') {
     window.close();
-  } else if (request.action === 'GET_SIDEBAR_SETTINGS') {
-    sendResponse({ settings: currentSettings() });
   } else if (request.action === 'RANGE_ERROR') {
     statusEl.textContent = request.error || 'Invalid range expression.';
     statusEl.dataset.source = 'range';
@@ -570,36 +559,76 @@ window.addEventListener('unload', () => {
   }
 });
 
-// Seed the UI from the shared defaults so the sidebar and content.js never
-// drift apart. Editing defaults.js updates both at once.
-function applyDefaultsToUI() {
-  enabledEl.checked = DR_DEFAULTS.enabled !== false;
+// Populate every control from a settings object. DR_DEFAULTS and a pulled
+// live-settings snapshot share this one path so the sidebar and content.js
+// can never drift apart no matter which one supplied the values.
+function applySettingsToUI(settings) {
+  const s = Object.assign({}, DR_DEFAULTS, settings || {});
+  enabledEl.checked = s.enabled !== false;
   for (const id in CHECKBOX_TO_SETTING) {
     const el = document.getElementById(id);
-    if (el) el.checked = !!DR_DEFAULTS[CHECKBOX_TO_SETTING[id]];
+    if (el) el.checked = !!s[CHECKBOX_TO_SETTING[id]];
   }
-  if (dateGranularityEl && DR_DEFAULTS.dateGranularity) {
-    dateGranularityEl.value = DR_DEFAULTS.dateGranularity;
+  if (dateGranularityEl && s.dateGranularity) {
+    dateGranularityEl.value = s.dateGranularity;
   }
-  if (timeGranularityEl && DR_DEFAULTS.timeGranularity) {
-    timeGranularityEl.value = DR_DEFAULTS.timeGranularity;
+  if (timeGranularityEl && s.timeGranularity) {
+    timeGranularityEl.value = s.timeGranularity;
   }
-  topVal = snap(typeof DR_DEFAULTS.offsetTop === 'number' ? DR_DEFAULTS.offsetTop : DEFAULT_OFFSET);
-  botVal = topVal;
-  linked = true;
+  topVal = snap(typeof s.offsetTop === 'number' ? s.offsetTop : DEFAULT_OFFSET);
+  botVal = snap(typeof s.offsetOther === 'number' ? s.offsetOther : topVal);
+  linked = (topVal === botVal);
   renderSliders();
+  if (rangeExprEl) rangeExprEl.value = typeof s.rangeExpr === 'string' ? s.rangeExpr : '';
 }
-applyDefaultsToUI();
+
+// Seed the UI from the shared defaults so the sidebar and content.js never
+// drift apart even before a table has ever been selected (RESET_SIDEBAR_TO_
+// DEFAULTS, and this file's own fallback when the live pull below fails).
+function applyDefaultsToUI() {
+  applySettingsToUI(DR_DEFAULTS);
+}
+
+// Reconnect: pull the model's current settings from content.js (the
+// settings' sole owner) rather than resetting to shipped defaults on every
+// sidebar open — a close/reopen must not lose what the user configured. No
+// active tab, no content script yet, or no response at all falls back to
+// defaults, same as before this pull existed.
+//
+// fetchPreviewSamples runs only after the pull settles (success or fallback),
+// never in parallel with it: fetchPreviewSamples's own setTableBound call is
+// what forces enabledEl back off when no table is bound, and that must stay
+// the last word — racing it against this pull could let a pulled "enabled:
+// true" win the UI over an actual no-table state.
+function pullSettingsAndApplyToUI() {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (!tabs[0]) {
+      applyDefaultsToUI();
+      fetchPreviewSamples();
+      return;
+    }
+    chrome.tabs.sendMessage(tabs[0].id, { action: 'GET_SETTINGS' }, (response) => {
+      if (chrome.runtime.lastError || !response || !response.settings) {
+        applyDefaultsToUI();
+      } else {
+        applySettingsToUI(response.settings);
+      }
+      fetchPreviewSamples();
+    });
+  });
+}
 
 // Default to unbound until fetchPreviewSamples resolves.
 setTableBound(false);
 
-// Pull samples from whichever table the user has right-clicked. If no table
-// was targeted, content.js returns nulls and the bands render the prompt.
-fetchPreviewSamples();
-
-// Defensively clear rangeExpr so browser autofill can never leak a stale value
-// into a hidden field and silently constrain content.js output.
+// Defensively clear rangeExpr so browser autofill can never leak a stale
+// value into a hidden field before the settings pull below (which sets it
+// from the model) resolves.
 if (rangeExprEl) rangeExprEl.value = '';
+
+// Pulls live settings, then (see above) pulls preview samples for whichever
+// table the user has right-clicked. If no table was targeted, content.js
+// returns nulls and the bands render the prompt.
+pullSettingsAndApplyToUI();
 
 updateDisabledState();

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -480,8 +480,20 @@ function updateDisabledState() {
 // script — the same chrome.tabs.query + chrome.tabs.sendMessage transport
 // this file used directly before this topic existed (see
 // adapters/messaging.js's publish()).
+//
+// onDelivery reproduces sendToActiveTab's old response callback exactly: on
+// chrome.runtime.lastError (no content script on the tab — delivery failed)
+// unbind the sidebar UI; on success, clear any stale #status message.
 function applyNow() {
-  DR_BUS.publish('intent:settingsChanged', { settings: currentSettings() });
+  DR_BUS.publish('intent:settingsChanged', { settings: currentSettings() }, {
+    onDelivery: function () {
+      if (chrome.runtime.lastError) {
+        setTableBound(false);
+      } else {
+        statusEl.textContent = '';
+      }
+    }
+  });
 }
 
 enabledEl.addEventListener('change', () => {

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -334,7 +334,14 @@ function renderPreviewBands() {
   renderBotBand(botBandEl, cachedSamples.bottom, botVal, cachedMaxMag);
 }
 
-function fetchPreviewSamples() {
+// pulledSettings is optional: when this call is the tail end of
+// pullSettingsAndApplyToUI (sidebar reopen), it carries the settings object
+// just pulled from the model. setTableBound(true) below resets enabledEl to
+// the shared default on every bind, which is correct for a live rebind
+// (PREVIEW_SAMPLES_CHANGED) but would clobber a pulled enabled:false with a
+// bound table — so when pulledSettings is present, its enabled value wins
+// back over that default once the bind has resolved.
+function fetchPreviewSamples(pulledSettings) {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (!tabs[0]) return;
     chrome.tabs.sendMessage(tabs[0].id, { action: 'GET_PREVIEW_SAMPLES' }, (response) => {
@@ -346,6 +353,10 @@ function fetchPreviewSamples() {
         cachedSamples = response.samples;
         cachedMaxMag = response.maxMag;
         setTableBound(response.samples !== null);
+        if (response.samples !== null && pulledSettings) {
+          enabledEl.checked = pulledSettings.enabled !== false;
+          updateDisabledState();
+        }
       }
       renderPreviewBands();
     });
@@ -611,7 +622,10 @@ function applyDefaultsToUI() {
 // never in parallel with it: fetchPreviewSamples's own setTableBound call is
 // what forces enabledEl back off when no table is bound, and that must stay
 // the last word — racing it against this pull could let a pulled "enabled:
-// true" win the UI over an actual no-table state.
+// true" win the UI over an actual no-table state. When the pull DID resolve a
+// settings object, that same object is threaded into fetchPreviewSamples so
+// it can restore a pulled "enabled: false" after its own bound branch resets
+// enabledEl to the shared default (see fetchPreviewSamples above).
 function pullSettingsAndApplyToUI() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (!tabs[0]) {
@@ -622,10 +636,11 @@ function pullSettingsAndApplyToUI() {
     chrome.tabs.sendMessage(tabs[0].id, { action: 'GET_SETTINGS' }, (response) => {
       if (chrome.runtime.lastError || !response || !response.settings) {
         applyDefaultsToUI();
+        fetchPreviewSamples();
       } else {
         applySettingsToUI(response.settings);
+        fetchPreviewSamples(response.settings);
       }
-      fetchPreviewSamples();
     });
   });
 }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -14900,6 +14900,144 @@ const LADDER_OPTS = {
 })();
 
 // ---------------------------------------------------------------------------
+// Sprint app-model-settings, bucket-2 fix: a pulled enabled:false must survive
+// sidebar reopen when the reopen lands on a TABLE THAT IS BOUND. This drives
+// sidebar.js's real pullSettingsAndApplyToUI() -> applySettingsToUI() ->
+// fetchPreviewSamples() chain end to end (same eval harness shape as
+// appModelSettings_settingsPublish_deliveryFeedback_behavioral above).
+//
+// The bug: pullSettingsAndApplyToUI applies the pulled settings (correctly
+// setting enabledEl.checked = false), then calls fetchPreviewSamples(), whose
+// response callback calls setTableBound(true) once GET_PREVIEW_SAMPLES
+// resolves with a bound table — and setTableBound's bound branch
+// unconditionally does `enabledEl.checked = DR_DEFAULTS.enabled !== false`,
+// which is true, clobbering the pulled false. The comment that used to sit
+// above pullSettingsAndApplyToUI only reasoned about the no-table case.
+// ---------------------------------------------------------------------------
+(function appModelSettings_pulledEnabledSurvivesReopenOnBoundTable() {
+  const defaultsSrc = sourceByName('defaults.js');
+  const roundingSrc = sourceByName('lib/dr-number/rounding.js');
+  const coreSrc = sourceByName('lib/dr-number/core.js');
+  if (defaultsSrc === null || roundingSrc === null || coreSrc === null || messagingCode === null) {
+    eq('reopen-bound: source files (defaults/rounding/core/messaging) present in manifest',
+      false, true);
+    return;
+  }
+
+  // Same minimal element stub as the other full-sidebar.js eval harnesses in
+  // this file (see appModelSettings_settingsPublish_deliveryFeedback_behavioral).
+  function makeEl() {
+    return {
+      addEventListener() {}, removeEventListener() {},
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      style: {}, value: '', checked: false, disabled: false, textContent: '', innerHTML: '',
+      appendChild() {}, querySelector() { return makeEl(); }, querySelectorAll() { return []; },
+      getBoundingClientRect() { return { top: 0, left: 0, width: 0, height: 0, bottom: 0, right: 0 }; },
+      matches() { return false; }, closest() { return null; }, dataset: {},
+      setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
+    };
+  }
+
+  const statusEl = makeEl();
+  const enabledEl = makeEl();
+
+  const bodyClasses = new Set();
+  const captureBody = {
+    classList: {
+      add(cls) { bodyClasses.add(cls); },
+      remove(cls) { bodyClasses.delete(cls); },
+      contains(cls) { return bodyClasses.has(cls); },
+      toggle(cls, force) {
+        if (force === undefined) {
+          if (bodyClasses.has(cls)) bodyClasses.delete(cls); else bodyClasses.add(cls);
+        } else if (force) bodyClasses.add(cls); else bodyClasses.delete(cls);
+      },
+    },
+    addEventListener() {},
+    get offsetWidth() { return 0; },
+  };
+
+  const captureDoc = {
+    addEventListener() {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: captureBody,
+    getElementById(id) {
+      if (id === 'status') return statusEl;
+      if (id === 'enabled') return enabledEl;
+      return makeEl();
+    },
+    createElement() { return makeEl(); },
+  };
+
+  // The model holds enabled:false. GET_SETTINGS returns that pulled settings
+  // object; GET_PREVIEW_SAMPLES returns a non-null samples object, i.e. the
+  // reopen landed on a table that is bound (the reviewer's reachable end
+  // state). Both resolve synchronously so the whole
+  // pullSettingsAndApplyToUI() -> fetchPreviewSamples() chain — including
+  // sidebar.js's own module-level call to pullSettingsAndApplyToUI() on
+  // load — settles deterministically within the single eval() call below.
+  const pulledSettings = Object.assign({}, DR_DEFAULTS, { enabled: false });
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener() {} },
+      sendMessage() {},
+      lastError: null,
+    },
+    tabs: {
+      query(q, cb) { cb([{ id: 42 }]); },
+      sendMessage(tabId, msg, cb) {
+        if (msg.action === 'GET_SETTINGS') {
+          cb({ settings: pulledSettings });
+        } else if (msg.action === 'GET_PREVIEW_SAMPLES') {
+          cb({ samples: { top: [], bottom: [] }, maxMag: 0 });
+        } else {
+          cb({ ok: true });
+        }
+      },
+    },
+  };
+
+  const savedDoc = global.document;
+  const savedChrome = global.chrome;
+  const savedWindow = global.window;
+  global.document = captureDoc;
+  global.chrome = captureChrome;
+  global.window = { addEventListener() {}, close() {}, getComputedStyle: () => ({ display: 'block' }) };
+
+  let evalError = null;
+  try {
+    try {
+      eval(
+        defaultsSrc + '\n' +
+        roundingSrc + '\n' +
+        coreSrc + '\n' +
+        messagingCode + '\n' +
+        fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8')
+      );
+    } catch (e) {
+      // The stubs above are built to let the whole module-level
+      // pullSettingsAndApplyToUI() -> fetchPreviewSamples() chain resolve
+      // synchronously and without throwing, unlike the sibling harness (which
+      // only needs the 'change' listener captured before its own pull runs).
+      // Record any throw instead of silently swallowing it — an unstubbed
+      // DOM method here must fail this test loudly, not make enabledEl.checked
+      // read its untouched initial value and pass for the wrong reason.
+      evalError = e;
+    }
+
+    eq('reopen-bound: sidebar.js\'s module-level pull ran to completion with no stub gaps',
+      evalError, null);
+    eq('reopen-bound: the pulled enabled:false survives the reopen once the preview response resolves (samples !== null)',
+      enabledEl.checked, false);
+  } finally {
+    global.document = savedDoc;
+    global.chrome = savedChrome;
+    global.window = savedWindow;
+  }
+})();
+
+// ---------------------------------------------------------------------------
 // Sprint app-model-settings, adversarial: the full wire path, not the store
 // directly. appModelSettings_previewAndTableAgreeOnLiveSettings (above) calls
 // DR_STORE.setSettings() straight from the test — it never exercises

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -14554,13 +14554,172 @@ const LADDER_OPTS = {
   eq('wire payload: settings payload is nested exactly as sendToActiveTab sent it, unchanged',
     JSON.stringify(msg.settings), JSON.stringify({ offsetTop: -2, rangeExpr: 'A1:B2' }));
 
-  // ADVERSARIAL — currently fails: the parent's sendToActiveTab always
-  // passed a response callback (chrome.tabs.sendMessage's 3rd argument) and
-  // used it to reflect delivery failure back into the UI (setTableBound(false)
-  // on chrome.runtime.lastError) and to clear statusEl on success. publish()
-  // drops that callback, so a failed settings-apply delivery is now silent.
+  // ADVERSARIAL regression pin (see PR notes): the parent's sendToActiveTab
+  // always passed a response callback (chrome.tabs.sendMessage's 3rd
+  // argument) and used it to reflect delivery failure back into the UI
+  // (setTableBound(false) on chrome.runtime.lastError) and to clear statusEl
+  // on success. This only pins the MECHANISM — that publish() still passes a
+  // callback — not the behavior; see appModelSettings_settingsPublish_
+  // deliveryFeedback_behavioral below for the behavioral coverage.
   eq('wire payload: publish() passes a response callback to chrome.tabs.sendMessage, matching sendToActiveTab\'s delivery-failure handling (regression — see PR notes)',
     typeof callback, 'function');
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint app-model-settings, adversarial fix (behavioral): the pin above only
+// proves publish() PASSES a callback to chrome.tabs.sendMessage — it says
+// nothing about what that callback does. This drives sidebar.js's real
+// applyNow() -> DR_BUS.publish() path end to end and checks the two
+// behaviors refactor/app-model-selection's sendToActiveTab had: a failed
+// delivery (chrome.runtime.lastError) must unbind the sidebar via
+// setTableBound(false); a successful delivery must clear #status.
+// ---------------------------------------------------------------------------
+(function appModelSettings_settingsPublish_deliveryFeedback_behavioral() {
+  const defaultsSrc = sourceByName('defaults.js');
+  const roundingSrc = sourceByName('lib/dr-number/rounding.js');
+  const coreSrc = sourceByName('lib/dr-number/core.js');
+  if (defaultsSrc === null || roundingSrc === null || coreSrc === null || messagingCode === null) {
+    eq('settings publish delivery: source files (defaults/rounding/core/messaging) present in manifest',
+      false, true);
+    return;
+  }
+
+  // Minimal element stub — same shape as the other sidebar.js eval harnesses
+  // in this file (see tableContextmenuActivation_sidebarFlash above).
+  function makeEl() {
+    return {
+      addEventListener() {}, removeEventListener() {},
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      style: {}, value: '', checked: false, disabled: false, textContent: '', innerHTML: '',
+      appendChild() {}, querySelector() { return makeEl(); }, querySelectorAll() { return []; },
+      getBoundingClientRect() { return { top: 0, left: 0, width: 0, height: 0, bottom: 0, right: 0 }; },
+      matches() { return false; }, closest() { return null; }, dataset: {},
+    };
+  }
+
+  // #status and #enabled are the two elements setTableBound touches; capture
+  // the exact objects sidebar.js's document.getElementById() hands back so we
+  // can read their mutations directly, with no need to export any function.
+  const statusEl = makeEl();
+  const enabledEl = makeEl();
+  enabledEl.checked = true;
+  let enabledChangeHandler = null;
+  enabledEl.addEventListener = function (type, fn) { if (type === 'change') enabledChangeHandler = fn; };
+
+  const bodyClasses = new Set();
+  const captureBody = {
+    classList: {
+      add(cls) { bodyClasses.add(cls); },
+      remove(cls) { bodyClasses.delete(cls); },
+      contains(cls) { return bodyClasses.has(cls); },
+      toggle(cls, force) {
+        if (force === undefined) {
+          if (bodyClasses.has(cls)) bodyClasses.delete(cls); else bodyClasses.add(cls);
+        } else if (force) bodyClasses.add(cls); else bodyClasses.delete(cls);
+      },
+    },
+    addEventListener() {},
+    get offsetWidth() { return 0; },
+  };
+
+  const captureDoc = {
+    addEventListener() {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: captureBody,
+    getElementById(id) {
+      if (id === 'status') return statusEl;
+      if (id === 'enabled') return enabledEl;
+      return makeEl();
+    },
+    createElement() { return makeEl(); },
+  };
+
+  // chrome.tabs.query/sendMessage resolve synchronously so the whole chain —
+  // sidebar.js's applyNow() -> DR_BUS.publish() -> chrome.tabs.sendMessage's
+  // own callback -> sidebar.js's onDelivery — runs deterministically within
+  // one call, with queuedLastError controlling chrome.runtime.lastError at
+  // the moment onDelivery reads it (matching real sendMessage semantics).
+  const sentTabMessages = [];
+  let queuedLastError = null;
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener() {} },
+      sendMessage() {},
+      get lastError() { return queuedLastError; },
+    },
+    tabs: {
+      query(q, cb) { cb([{ id: 42 }]); },
+      sendMessage(tabId, msg, cb) {
+        sentTabMessages.push(msg);
+        if (typeof cb === 'function') cb();
+      },
+    },
+  };
+
+  const savedDoc = global.document;
+  const savedChrome = global.chrome;
+  const savedWindow = global.window;
+  global.document = captureDoc;
+  global.chrome = captureChrome;
+  global.window = { addEventListener() {}, close() {}, getComputedStyle: () => ({ display: 'block' }) };
+
+  // sidebar.js's top-level code — including its own change/click listener
+  // registrations — resolves `document`/`chrome`/`window` dynamically off
+  // the global object every time it runs, not just at eval time. The
+  // captured enabledChangeHandler is called below, well after the initial
+  // eval, so the stubs must stay installed for that call too — restore the
+  // real globals only once every scenario below has run.
+  try {
+    try {
+      eval(
+        defaultsSrc + '\n' +
+        roundingSrc + '\n' +
+        coreSrc + '\n' +
+        messagingCode + '\n' +
+        fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8')
+      );
+    } catch (e) {
+      // sidebar.js's module-level settings/preview pull can throw past this
+      // point in this stub environment (chrome.tabs.sendMessage's callback
+      // gets no real response) — the 'change' listener registers before that
+      // runs, so we only need it captured.
+    }
+
+    eq('settings publish delivery: sidebar\'s enabled-checkbox change handler was captured',
+      typeof enabledChangeHandler, 'function');
+    if (typeof enabledChangeHandler !== 'function') return;
+
+    // --- Failure: chrome.runtime.lastError set -> setTableBound(false) ran. ---
+    bodyClasses.delete('no-table');
+    enabledEl.checked = true;
+    statusEl.textContent = '';
+    queuedLastError = { message: 'Could not establish connection.' };
+    sentTabMessages.length = 0;
+    enabledChangeHandler();
+
+    eq('settings publish delivery: one APPLY_SIDEBAR_SETTINGS message sent for the change',
+      sentTabMessages.length, 1);
+    eq('settings publish delivery: failed delivery adds the no-table class (setTableBound(false) ran)',
+      bodyClasses.has('no-table'), true);
+    eq('settings publish delivery: failed delivery flips the enabled checkbox off (setTableBound(false) ran)',
+      enabledEl.checked, false);
+    eq('settings publish delivery: failed delivery sets #status to the no-table message (setTableBound(false) ran)',
+      statusEl.textContent, 'Right-click a table to connect it here.');
+
+    // --- Success: no lastError -> #status is cleared. ---
+    bodyClasses.delete('no-table');
+    statusEl.textContent = 'a stale status message';
+    queuedLastError = null;
+    enabledChangeHandler();
+
+    eq('settings publish delivery: successful delivery clears #status',
+      statusEl.textContent, '');
+  } finally {
+    global.document = savedDoc;
+    global.chrome = savedChrome;
+    global.window = savedWindow;
+  }
 })();
 
 // ---------------------------------------------------------------------------

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -14506,6 +14506,64 @@ const LADDER_OPTS = {
 })();
 
 // ---------------------------------------------------------------------------
+// Sprint app-model-settings, adversarial: wire-payload parity with the parent
+// branch's sendToActiveTab (refactor/app-model-selection, before this sprint
+// inverted the transport). The message body itself is unchanged — {action,
+// settings}, same field names, same nesting, no extra bus-envelope fields —
+// but sendToActiveTab always passed chrome.tabs.sendMessage a THIRD argument,
+// a response callback, and used it to react to delivery: clear statusEl on
+// success, setTableBound(false) on chrome.runtime.lastError (no content
+// script on the tab). adapters/messaging.js's publish() relay calls
+// chrome.tabs.sendMessage with only two arguments — no callback — so that
+// reaction is silently gone for the settings-apply path: a real Chrome would
+// also log an "Unchecked runtime.lastError" warning on every failed delivery.
+// This isolates DR_BUS in its own vm sandbox (messaging.js has no DOM
+// dependency) and pins the call shape directly, independent of sidebar.js's
+// heavier DOM requirements.
+// ---------------------------------------------------------------------------
+(function appModelSettings_wirePayload_parityWithParentSendToActiveTab() {
+  if (messagingCode === null) {
+    eq('wire payload: adapters/messaging.js present in manifest', false, true);
+    return;
+  }
+  const vm = require('vm');
+  const sentCalls = [];
+  const sandbox = {
+    chrome: {
+      tabs: {
+        query(q, cb) { cb([{ id: 7 }]); },
+        sendMessage(...args) { sentCalls.push(args); },
+      },
+      runtime: {},
+    },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(messagingCode + '\nthis.__DR_BUS = DR_BUS;', sandbox);
+
+  sandbox.__DR_BUS.publish('intent:settingsChanged', { settings: { offsetTop: -2, rangeExpr: 'A1:B2' } });
+
+  eq('wire payload: exactly one chrome.tabs.sendMessage call for one publish()',
+    sentCalls.length, 1);
+  if (sentCalls.length !== 1) return;
+
+  const [tabId, msg, callback] = sentCalls[0];
+  eq('wire payload: message action is unchanged (APPLY_SIDEBAR_SETTINGS)',
+    msg.action, 'APPLY_SIDEBAR_SETTINGS');
+  eq('wire payload: message field names are exactly {action, settings} — no extra bus-envelope fields',
+    Object.keys(msg).sort(), ['action', 'settings'].sort());
+  eq('wire payload: settings payload is nested exactly as sendToActiveTab sent it, unchanged',
+    JSON.stringify(msg.settings), JSON.stringify({ offsetTop: -2, rangeExpr: 'A1:B2' }));
+
+  // ADVERSARIAL — currently fails: the parent's sendToActiveTab always
+  // passed a response callback (chrome.tabs.sendMessage's 3rd argument) and
+  // used it to reflect delivery failure back into the UI (setTableBound(false)
+  // on chrome.runtime.lastError) and to clear statusEl on success. publish()
+  // drops that callback, so a failed settings-apply delivery is now silent.
+  eq('wire payload: publish() passes a response callback to chrome.tabs.sendMessage, matching sendToActiveTab\'s delivery-failure handling (regression — see PR notes)',
+    typeof callback, 'function');
+})();
+
+// ---------------------------------------------------------------------------
 // Sprint app-model-settings: settings live in DR_STORE, sourced from
 // DR_DEFAULTS at init, changed only through setSettings (publishing the
 // whole new value), and read back through getSettings().
@@ -14680,6 +14738,149 @@ const LADDER_OPTS = {
     getResponse.settings.rangeExpr, 'B2:E8');
   eq('reconnect: a changed boolean flag survives the close/reopen',
     getResponse.settings.simplifyMixedCells, false);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint app-model-settings, adversarial: the full wire path, not the store
+// directly. appModelSettings_previewAndTableAgreeOnLiveSettings (above) calls
+// DR_STORE.setSettings() straight from the test — it never exercises
+// content.js's own onMessage listener or the state:settingsChanged
+// subscriber, which is the actual code path a real APPLY_SIDEBAR_SETTINGS
+// message drives. This test dispatches that message through the captured
+// listener (the AC1 pattern) against a table already bound as "selected",
+// lets the real subscriber call applySidebarRounding, and checks the
+// resulting cells against extractPreviewSamples computed from the same
+// settings on an identical table — so the assertion covers the message
+// arriving, not just the pure math agreeing.
+// ---------------------------------------------------------------------------
+(function appModelSettings_wireMessageAppliesLiveSettingsToBoundTableAndPreviewAgrees() {
+  function makeWiredMockTable(rowsSpec) {
+    const table = makeMockTable(rowsSpec);
+    table.classList = { remove() {}, add() {}, contains() { return false; } };
+    table.offsetWidth = 0;
+    table.querySelectorAll = () => [];
+    return table;
+  }
+
+  // Values chosen so the offsets below visibly change them (unlike, say,
+  // 1,000,000 / 50 at offsetTop -2 / offsetOther 0.25, which round to
+  // themselves and would pass this test even if rounding silently no-op'd).
+  const rowsSpec = [[
+    { tag: 'td', text: '1,234,567' },
+    { tag: 'td', text: '37' },
+  ]];
+  const CUSTOM_OFFSET_TOP = -2;
+  const CUSTOM_OFFSET_OTHER = 0.25;
+
+  let capturedListener = null;
+  let wiredDR_STORE = null;
+  let wiredExtractPreviewSamples = null;
+  let boundTable = null;
+  let ackResponse = null;
+
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener(fn) { capturedListener = fn; } },
+      sendMessage: () => {},
+      lastError: null,
+    },
+  };
+  const captureDoc = {
+    addEventListener: () => {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    // applySidebarRounding's ensureHighlightStyleInjected() needs these —
+    // the reconnect/AC1 tests above never reach that call (no selected
+    // table, so the subscriber's `if (selected)` guard short-circuits).
+    createElement: () => ({ textContent: '', appendChild() {} }),
+    head: { appendChild() {} },
+    documentElement: { appendChild() {} },
+    body: { appendChild: () => {}, observe: () => {} },
+  };
+  const captureWindow = {
+    addEventListener: () => {},
+    getComputedStyle: () => ({ display: 'block', visibility: 'visible' }),
+  };
+
+  const saved = { chrome: global.chrome, document: global.document, window: global.window };
+  global.chrome = captureChrome;
+  global.document = captureDoc;
+  global.window = captureWindow;
+
+  try {
+    withCreateTreeWalker(() => {
+      try {
+        eval(contentScriptBundle + `
+          wiredDR_STORE = DR_STORE;
+          wiredExtractPreviewSamples = extractPreviewSamples;
+        `);
+      } catch (e) {
+        // module-level init may fail against the stub DOM; the onMessage
+        // listener and the two wiring assignments above both run before any
+        // dynamic/async code (see the AC1 test).
+      }
+
+      if (typeof capturedListener !== 'function' || !wiredDR_STORE) return;
+
+      // Bind a table as "selected" — mirrors what the contextmenu handler
+      // does for real, so the state:settingsChanged subscriber has
+      // something to apply the incoming message to.
+      boundTable = makeWiredMockTable(rowsSpec);
+      wiredDR_STORE.setSelectedTable(boundTable);
+
+      const customSettings = Object.assign({}, DR_DEFAULTS, {
+        simplifyFirstRow: true, simplifyFirstColumn: true,
+        offsetTop: CUSTOM_OFFSET_TOP, offsetOther: CUSTOM_OFFSET_OTHER,
+        numTop: 1, rangeExpr: '',
+      });
+
+      // The real wire message, dispatched through the real onMessage
+      // listener — not DR_STORE.setSettings() called directly from the test.
+      capturedListener(
+        { action: 'APPLY_SIDEBAR_SETTINGS', settings: customSettings },
+        {},
+        (r) => { ackResponse = r; }
+      );
+    });
+  } finally {
+    global.chrome = saved.chrome;
+    global.document = saved.document;
+    global.window = saved.window;
+  }
+
+  eq('wire E2E: content.js onMessage listener was captured',
+    typeof capturedListener, 'function');
+  eq('wire E2E: APPLY_SIDEBAR_SETTINGS was acknowledged',
+    ackResponse && ackResponse.ok, true);
+  if (!boundTable) return;
+
+  // The subscriber applied the message straight to the bound table — no
+  // separate "apply" call from the test.
+  const renderedTop = toNumber(boundTable.rows[0].cells[0].innerText);
+  const renderedBottom = toNumber(boundTable.rows[0].cells[1].innerText);
+  eq('wire E2E: the fixture top value actually changed under rounding (test validity check)',
+    renderedTop !== 1234567, true);
+  eq('wire E2E: the fixture bottom value actually changed under rounding (test validity check)',
+    renderedBottom !== 37, true);
+  eq('wire E2E: the bound table was actually rounded by the real subscriber path',
+    boundTable.rows[0].cells[0].classList.contains('dr-ext-rounded'), true);
+
+  // A fresh, identically-populated table for the preview extractor, so its
+  // read of DR_STORE.getSettings() cannot see already-rounded text.
+  const previewTable = makeWiredMockTable(rowsSpec);
+  const preview = wiredExtractPreviewSamples(previewTable);
+  eq('wire E2E: preview top band has the large cell',
+    preview.samples.top.length, 1);
+  eq('wire E2E: preview bottom band has the small cell',
+    preview.samples.bottom.length, 1);
+
+  const previewTop = roundWithOffset(preview.samples.top[0].num, CUSTOM_OFFSET_TOP);
+  const previewBottom = roundWithOffset(preview.samples.bottom[0].num, CUSTOM_OFFSET_OTHER);
+
+  eq('wire E2E: the table cell the real message pipeline rendered matches the preview-predicted top value',
+    renderedTop, previewTop);
+  eq('wire E2E: the table cell the real message pipeline rendered matches the preview-predicted bottom value',
+    renderedBottom, previewBottom);
 })();
 
 // ---------------------------------------------------------------------------

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1899,16 +1899,40 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
   }
   const sidebarSrc = fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8');
 
-  // --- Sidebar pull: content.js requests, sidebar.js responds ---
+  // --- Sprint app-model-settings inverted this pull: settings now live in
+  // DR_STORE (content-script context), so content.js applies from its own
+  // model instead of polling the sidebar, and the sidebar asks content.js
+  // for the current value instead of answering that old poll. ---
 
-  eq('pull: content.js sends GET_SIDEBAR_SETTINGS',
-    /chrome\.runtime\.sendMessage\(\s*\{\s*action:\s*['"]GET_SIDEBAR_SETTINGS['"]/.test(contentSrc), true);
+  eq('pull (inverted): content.js no longer sends GET_SIDEBAR_SETTINGS',
+    /chrome\.runtime\.sendMessage\(\s*\{\s*action:\s*['"]GET_SIDEBAR_SETTINGS['"]/.test(contentSrc), false);
 
-  eq('pull: content.js no longer applies defaults on SIDEBAR_OPENED',
+  eq('pull (inverted): the ten-retry settings-polling function is gone from content.js',
+    /requestSidebarSettingsAndApply/.test(contentSrc), false);
+
+  // No timing-based settings access remains: content.js's only other
+  // setTimeout use is the unrelated grid-virtualization re-apply debounce
+  // (GRID_REAPPLY_DEBOUNCE_MS), which is not a retry loop and does not
+  // reference settings/attempt/GET_SIDEBAR_SETTINGS at all.
+  const setTimeoutCalls = contentSrc.match(/setTimeout\([\s\S]{0,120}/g) || [];
+  eq('pull (inverted): every remaining setTimeout in content.js is the grid re-apply debounce, not a settings retry',
+    setTimeoutCalls.every((call) => !/attempt|GET_SIDEBAR_SETTINGS|requestSidebarSettingsAndApply/.test(call)),
+    true);
+
+  eq('pull (inverted): content.js no longer applies defaults on SIDEBAR_OPENED',
     /SIDEBAR_OPENED[\s\S]{0,200}applySidebarRounding\([^)]*DR_DEFAULTS/.test(contentSrc), false);
 
-  eq('pull: sidebar.js handles GET_SIDEBAR_SETTINGS and responds with currentSettings()',
-    /GET_SIDEBAR_SETTINGS[\s\S]{0,120}sendResponse\([^)]*currentSettings\(\)/.test(sidebarSrc), true);
+  eq('pull (inverted): content.js applies the model\'s own settings on SIDEBAR_OPENED',
+    /SIDEBAR_OPENED[\s\S]{0,400}applySidebarRounding\([^)]*DR_STORE\.getSettings\(\)/.test(contentSrc), true);
+
+  eq('pull (inverted): sidebar.js no longer handles GET_SIDEBAR_SETTINGS',
+    /GET_SIDEBAR_SETTINGS/.test(sidebarSrc), false);
+
+  eq('pull (inverted): content.js handles GET_SETTINGS and responds with the model\'s settings',
+    /GET_SETTINGS['"][\s\S]{0,200}sendResponse\([^)]*DR_STORE\.getSettings\(\)/.test(contentSrc), true);
+
+  eq('pull (inverted): sidebar.js pulls settings via chrome.tabs.sendMessage GET_SETTINGS on open',
+    /chrome\.tabs\.sendMessage\([^,]*,\s*\{\s*action:\s*['"]GET_SETTINGS['"]/.test(sidebarSrc), true);
 
   // --- Unified rounding path: drop data-rounded-value, cache innerHTML ---
 
@@ -12361,11 +12385,20 @@ function fireMouseClick(buttonEl, fn) {
     }
 
     // Static guard: the real setTableBound flips enabledEl.checked off and runs
-    // updateDisabledState (not just a class toggle).
+    // updateDisabledState (not just a class toggle). Isolate the function's own
+    // body (rather than scanning from the first "setTableBound" text match
+    // anywhere in the file) so a coincidental match elsewhere — e.g. an
+    // unrelated setTableBound(...) call sitting near an unrelated
+    // updateDisabledState() call in some other function — cannot pass this
+    // for the wrong reason.
+    const setTableBoundFnMatch = sidebarSrc.match(/function setTableBound\([\s\S]*?\n}/);
+    const setTableBoundFnBody = setTableBoundFnMatch ? setTableBoundFnMatch[0] : '';
+    eq('no-table toggle: sidebar.js setTableBound function body was isolated (sanity check on the scan itself)',
+      setTableBoundFnBody.length > 0, true);
     eq('no-table toggle: sidebar.js setTableBound sets enabledEl.checked = false when unbound',
-      /setTableBound[\s\S]{0,400}enabledEl\.checked\s*=\s*false/.test(sidebarSrc), true);
+      /enabledEl\.checked\s*=\s*false/.test(setTableBoundFnBody), true);
     eq('no-table toggle: sidebar.js setTableBound calls updateDisabledState',
-      /setTableBound[\s\S]{0,400}updateDisabledState\(\)/.test(sidebarSrc), true);
+      /updateDisabledState\(\)/.test(setTableBoundFnBody), true);
 
     // AC2 gap — ADVERSARIAL: verify that the sidebar does NOT have a runtime
     // message handler that directly calls setTableBound(true) when a table is
@@ -14235,13 +14268,22 @@ const LADDER_OPTS = {
     topicNames.every((t) => KNOWN_FAMILIES.includes(topics[t].family)), true);
   eq('DR_BUS.TOPICS: enumerates exactly the expected topics',
     topicNames.slice().sort(),
-    ['intent:selectTable', 'state:selectedTableChanged', 'state:sidebarOpenChanged'].sort());
+    ['intent:selectTable', 'state:selectedTableChanged', 'state:sidebarOpenChanged',
+     'intent:settingsChanged', 'state:settingsChanged'].sort());
   eq('DR_BUS.TOPICS: intent:selectTable is in the intent family',
     topics['intent:selectTable'].family, 'intent');
   eq('DR_BUS.TOPICS: state:selectedTableChanged is in the state-change family',
     topics['state:selectedTableChanged'].family, 'state-change');
   eq('DR_BUS.TOPICS: state:sidebarOpenChanged is in the state-change family',
     topics['state:sidebarOpenChanged'].family, 'state-change');
+  eq('DR_BUS.TOPICS: intent:settingsChanged is in the intent family',
+    topics['intent:settingsChanged'].family, 'intent');
+  eq('DR_BUS.TOPICS: state:settingsChanged is in the state-change family',
+    topics['state:settingsChanged'].family, 'state-change');
+  eq('DR_BUS.TOPICS: intent:settingsChanged carries the APPLY_SIDEBAR_SETTINGS wireAction (cross-context: sidebar page -> content script)',
+    topics['intent:settingsChanged'].wireAction, 'APPLY_SIDEBAR_SETTINGS');
+  eq('DR_BUS.TOPICS: state:settingsChanged has no wireAction (same-context: model -> controller only)',
+    topics['state:settingsChanged'].wireAction, null);
 
   // Publishing to an unregistered topic is rejected rather than silently
   // dropped, so the registry stays authoritative rather than aspirational.
@@ -14343,8 +14385,8 @@ const LADDER_OPTS = {
   const storeFieldNames = Array.from(storeSrc.matchAll(/\b(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g))
     .map((m) => m[1])
     .filter((name) => name !== 'DR_STORE');
-  eq('static scan: app/store.js declares its two private fields (sanity check on the scan itself)',
-    storeFieldNames.slice().sort(), ['selectedTable', 'sidebarOpen'].sort());
+  eq('static scan: app/store.js declares its three private fields (sanity check on the scan itself)',
+    storeFieldNames.slice().sort(), ['selectedTable', 'sidebarOpen', 'settings'].sort());
   const storeFieldWrites = storeFieldNames.filter((name) => {
     const assignRe = new RegExp('\\b' + name + '\\s*=[^=]');
     return assignRe.test(uiToggleSrcForScan) || assignRe.test(contentSrcForScan);
@@ -14417,6 +14459,227 @@ const LADDER_OPTS = {
     threw, null);
   eq('DR_BUS reentrancy: B fires exactly twice (initial A->B hop, then one guarded bounce back through A)',
     counter, 2);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint app-model-settings (issue #240): the depth guard itself. The cycle
+// above is self-limiting (a caller-side counter stops it after one bounce);
+// this one is NOT — neither handler has a stop condition, so without the
+// bus's own guard this would recurse until the real call stack overflows.
+// ---------------------------------------------------------------------------
+(function appModelSettings_busReentrancy_unguardedCycleTerminatesSafely() {
+  const TOPIC_A = 'state:selectedTableChanged';
+  const TOPIC_B = 'state:sidebarOpenChanged';
+
+  const unsubA = DR_BUS.subscribe(TOPIC_A, () => { DR_BUS.publish(TOPIC_B, { sidebarOpen: true }); });
+  const unsubB = DR_BUS.subscribe(TOPIC_B, () => { DR_BUS.publish(TOPIC_A, { table: null }); });
+
+  let threw = null;
+  try {
+    DR_BUS.publish(TOPIC_A, { table: null });
+  } catch (e) {
+    threw = e.message;
+  } finally {
+    unsubA();
+    unsubB();
+  }
+
+  eq('DR_BUS reentrancy (unguarded cycle): publish() throws a catchable error instead of crashing with a real stack overflow',
+    typeof threw, 'string');
+  eq('DR_BUS reentrancy (unguarded cycle): the thrown error names the depth guard, not a raw engine stack-overflow error',
+    /publish depth exceeded/.test(threw || ''), true);
+
+  // The guard must reset cleanly — every nested publish() decrements the
+  // depth counter in a finally as the exception unwinds — so an unrelated
+  // publish afterward must behave normally, not still read as "deep".
+  let secondThrew = null;
+  const unsubCheck = DR_BUS.subscribe(TOPIC_A, () => {});
+  try {
+    DR_BUS.publish(TOPIC_A, { table: null });
+  } catch (e) {
+    secondThrew = e.message;
+  } finally {
+    unsubCheck();
+  }
+  eq('DR_BUS reentrancy (unguarded cycle): the depth counter recovers — a later unrelated publish does not throw',
+    secondThrew, null);
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint app-model-settings: settings live in DR_STORE, sourced from
+// DR_DEFAULTS at init, changed only through setSettings (publishing the
+// whole new value), and read back through getSettings().
+// ---------------------------------------------------------------------------
+(function appModelSettings_storeSettingsField() {
+  eq('DR_STORE.getSettings: defaults to DR_DEFAULTS-shaped values at store init',
+    DR_STORE.getSettings().offsetTop, DR_DEFAULTS.offsetTop);
+
+  const savedSettings = DR_STORE.getSettings();
+  try {
+    let stateChangePayload = 'NOT_CALLED';
+    const unsubscribe = DR_BUS.subscribe('state:settingsChanged', (payload) => {
+      stateChangePayload = payload;
+    });
+    const newSettings = Object.assign({}, DR_DEFAULTS, { offsetTop: 0.25, rangeExpr: 'A1:C9' });
+    try {
+      DR_STORE.setSettings(newSettings);
+    } finally {
+      unsubscribe();
+    }
+    eq('DR_STORE.setSettings: getSettings() reflects the new value',
+      DR_STORE.getSettings().offsetTop, 0.25);
+    eq('DR_STORE.setSettings: the resulting state-change carries the whole new value, not a delta',
+      stateChangePayload && stateChangePayload.settings && stateChangePayload.settings.rangeExpr, 'A1:C9');
+
+    // getSettings() returns a copy — mutating what a caller read must not
+    // corrupt the store's own internal value (immutability convention).
+    const read = DR_STORE.getSettings();
+    read.offsetTop = 999;
+    eq('DR_STORE.getSettings: returns a copy, not a live reference — mutating it does not affect the store',
+      DR_STORE.getSettings().offsetTop, 0.25);
+  } finally {
+    DR_STORE.setSettings(savedSettings);
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint app-model-settings, AC2: the preview band and the table must round
+// the same cell to the same value once a setting changes — the bug this
+// sprint fixes was extractPreviewSamples reading DR_DEFAULTS while roundTable
+// read the model, so they disagreed the moment a slider moved off default.
+// ---------------------------------------------------------------------------
+(function appModelSettings_previewAndTableAgreeOnLiveSettings() {
+  const savedSettings = DR_STORE.getSettings();
+  try {
+    const customSettings = Object.assign({}, DR_DEFAULTS, {
+      simplifyFirstRow: true,
+      simplifyFirstColumn: true,
+      offsetTop: -2,
+      offsetOther: 0.25,
+      numTop: 1,
+      rangeExpr: '',
+    });
+    // Validity check on the fixture itself: these offsets must differ from
+    // DR_DEFAULTS, or a regression back to reading DR_DEFAULTS would slip
+    // through this test undetected.
+    eq('preview/table agreement: fixture offsets differ from DR_DEFAULTS (test validity check)',
+      customSettings.offsetTop !== DR_DEFAULTS.offsetTop && customSettings.offsetOther !== DR_DEFAULTS.offsetOther,
+      true);
+    DR_STORE.setSettings(customSettings);
+
+    const previewTable = makeMockTable([[
+      { tag: 'td', text: '1,000,000' },
+      { tag: 'td', text: '50' },
+    ]]);
+    const preview = extractPreviewSamples(previewTable);
+    eq('preview/table agreement: top band has the large cell',
+      preview.samples.top.length, 1);
+    eq('preview/table agreement: bottom band has the small cell',
+      preview.samples.bottom.length, 1);
+
+    const expectedTop = roundWithOffset(1000000, customSettings.offsetTop);
+    const expectedBottom = roundWithOffset(50, customSettings.offsetOther);
+
+    // What the sidebar's preview band would render for these two cells,
+    // built from the same sample the model supplied.
+    eq('preview/table agreement: preview top sample rounds via the live offsetTop',
+      roundWithOffset(preview.samples.top[0].num, customSettings.offsetTop), expectedTop);
+    eq('preview/table agreement: preview bottom sample rounds via the live offsetOther',
+      roundWithOffset(preview.samples.bottom[0].num, customSettings.offsetOther), expectedBottom);
+
+    // What the table actually renders for the identical cells, applied the
+    // way the state:settingsChanged subscriber does — straight from the model.
+    const liveTable = makeMockTable([[
+      { tag: 'td', text: '1,000,000' },
+      { tag: 'td', text: '50' },
+    ]]);
+    withCreateTreeWalker(() => {
+      roundTable(liveTable, DR_STORE.getSettings());
+    });
+    const renderedTop = toNumber(liveTable.rows[0].cells[0].innerText);
+    const renderedBottom = toNumber(liveTable.rows[0].cells[1].innerText);
+
+    eq('preview/table agreement: the table cell value matches the preview-predicted top value',
+      renderedTop, expectedTop);
+    eq('preview/table agreement: the table cell value matches the preview-predicted bottom value',
+      renderedBottom, expectedBottom);
+  } finally {
+    DR_STORE.setSettings(savedSettings);
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// Sprint app-model-settings, AC5: settings survive a sidebar close and
+// reopen — pulled from the model (GET_SETTINGS), not reset to DR_DEFAULTS.
+// Uses the same isolated-eval capture pattern as the APPLY_SIDEBAR_SETTINGS
+// AC1 test above, so this shared-scope DR_STORE is untouched by it.
+// ---------------------------------------------------------------------------
+(function appModelSettings_settingsSurviveSidebarReconnect() {
+  let capturedListener = null;
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener(fn) { capturedListener = fn; } },
+      sendMessage: () => {},
+      lastError: null,
+    },
+  };
+  const captureDoc = {
+    addEventListener: () => {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: { appendChild: () => {}, observe: () => {} },
+  };
+  const captureWindow = {
+    addEventListener: () => {},
+    getComputedStyle: () => ({ display: 'block', visibility: 'visible' }),
+  };
+
+  const saved = { chrome: global.chrome, document: global.document, window: global.window };
+  global.chrome = captureChrome;
+  global.document = captureDoc;
+  global.window = captureWindow;
+  try {
+    eval(contentScriptBundle);
+  } catch (e) {
+    // module-level code may fail in the stub environment; the onMessage
+    // listener registers before any dynamic code runs (see the AC1 test).
+  } finally {
+    global.chrome = saved.chrome;
+    global.document = saved.document;
+    global.window = saved.window;
+  }
+
+  eq('reconnect: the isolated listener was captured',
+    typeof capturedListener, 'function');
+  if (typeof capturedListener !== 'function') return;
+
+  // The sidebar sets a custom value (an "open" session), then — simulated by
+  // nothing happening in between — closes and reopens, pulling the model.
+  const customSettings = {
+    enabled: true, simplifyMixedCells: false, simplifyMixedCurrency: true,
+    simplifyMixedPercent: true, simplifyFirstRow: false, simplifyFirstColumn: false,
+    simplifyDates: true, simplifyTimes: false, dateGranularity: 'year', timeGranularity: 'hour',
+    offsetTop: 0.25, offsetOther: -1.5, numTop: 1, rangeExpr: 'B2:E8',
+  };
+  let applyResponse = null;
+  capturedListener({ action: 'APPLY_SIDEBAR_SETTINGS', settings: customSettings }, {}, (r) => { applyResponse = r; });
+  eq('reconnect: APPLY_SIDEBAR_SETTINGS was acknowledged before the (simulated) close',
+    applyResponse && applyResponse.ok, true);
+
+  // Reopen: exactly what pullSettingsAndApplyToUI's GET_SETTINGS request does.
+  let getResponse = null;
+  capturedListener({ action: 'GET_SETTINGS' }, {}, (r) => { getResponse = r; });
+
+  eq('reconnect: GET_SETTINGS returns a settings object',
+    !!(getResponse && getResponse.settings), true);
+  eq('reconnect: offsetTop survives the close/reopen',
+    getResponse.settings.offsetTop, 0.25);
+  eq('reconnect: offsetOther survives the close/reopen',
+    getResponse.settings.offsetOther, -1.5);
+  eq('reconnect: rangeExpr survives the close/reopen',
+    getResponse.settings.rangeExpr, 'B2:E8');
+  eq('reconnect: a changed boolean flag survives the close/reopen',
+    getResponse.settings.simplifyMixedCells, false);
 })();
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Sprint 9 of [docs/sprint-plans/decoupling-migration.md](https://github.com/ArieFisher/dynamic-rounding/blob/main/docs/sprint-plans/decoupling-migration.md).

## What

Settings move into the application model. `DR_STORE` owns them (initialized from `DR_DEFAULTS`); the sidebar's controls publish `intent:settingsChanged`, carried cross-context over the existing `APPLY_SIDEBAR_SETTINGS` wire message via the bus's now-active relay (`chrome.tabs.sendMessage` from the extension page, byte-identical payload to the old path); the controller applies changes from a `state:settingsChanged` subscription.

The ten-retry settings poll is deleted. The pull inverted: the sidebar asks the content script (`GET_SETTINGS`) when it opens, instead of the controller polling the sidebar's DOM. The preview-sample extractor reads live settings from the store, closing the preview-band-versus-table mismatch — pinned end to end through the real message path with values that visibly change.

The bus gains its reentrancy guard (issue #240): a depth cap with an unconditional unwind, unreachable in production (deepest real chain is 2) and proven to throw a named error on an unguarded cycle.

Two review rounds caught real defects before merge: the relay had dropped the response callback the old send path used (delivery failures no longer unbound the sidebar UI) — restored via an optional per-publish delivery callback with six behavioral assertions; and the pulled `enabled` value was clobbered on reopen by the bound-state reset to defaults, leaving the checkbox ON over a raw table — fixed by threading the pulled settings through the preview fetch, mutation-proven.

## Acceptance criteria

- [x] No timing-based settings access remains
- [x] Preview band and table round from the same live values, end to end through the real message path
- [x] Settings survive sidebar close and reopen (model pull; UI application pinned including `enabled`)
- [x] All three suites pass (extension 1,806 after merging main; js 256; python 214)

## Reviewer notes

- Follow-up issues: #249 (the no-active-tab status message is gone from the send path; needs a bus-side delivery signal), #250 (pin the depth counter's recovery on a subscriber throw), #251 (the bound-state reset still assumes the default `enabled` on a live rebind — pre-existing, the model now makes a proper fix possible).
- Settings are per-tab, matching where the model lives; the background closes the sidebar on tab switch, so one panel never outlives its tab.
- Rejected alternative: a same-topic reentrancy bar instead of the depth cap — it would have broken the sanctioned select-inside-toggle republish.
