### PR TITLE
refactor(extension): the registry, originals, and applied flag live in the application model

### DIFF
--- a/chrome-extension/app/store.js
+++ b/chrome-extension/app/store.js
@@ -30,15 +30,19 @@
  *                      controller applies every new value to the selected
  *                      table by subscribing to the resulting state-change.
  *
- * Reads go through the getters below. The only way to change a field is one
- * of the setter methods, and each setter does exactly two things: update the
- * field, then DR_BUS.publish() the field's whole new value as a
- * state-change. No caller can assign these fields directly — there is
- * nothing to assign; the fields are closed over, not exposed.
+ * Reads go through the getters below. The only way to change selectedTable,
+ * sidebarOpen, or settings is one of the setter methods, and each setter
+ * does exactly two things: update the field, then DR_BUS.publish() the
+ * field's whole new value as a state-change. No caller can assign these
+ * fields directly — there is nothing to assign; the fields are closed over,
+ * not exposed.
+ *
+ * The table registry (app-model-registry sprint) is a fourth field with a
+ * different shape and a different update contract — see the section below.
  *
  * The store holds no DOM logic and calls no chrome API itself; the one side
- * effect any setter has, beyond updating its own field, is a publish
- * through DR_BUS.
+ * effect any of the three scalar setters has, beyond updating its own
+ * field, is a publish through DR_BUS.
  *
  * Loaded after adapters/messaging.js (DR_BUS) and before ui-toggle.js.
  */
@@ -47,6 +51,74 @@ const DR_STORE = (function () {
   let selectedTable = null;
   let sidebarOpen = false;
   let settings = Object.assign({}, DR_DEFAULTS);
+
+  // --- Table registry ---
+  //
+  // Before this sprint, "which tables/grids has the extension found" lived
+  // in three places at once: a WeakMap and a Set in ui-toggle.js
+  // (tableToggles, trackedTables), and the dr-ext-grid marker class read
+  // back with classList.contains/closest wherever a caller needed to know
+  // "have I already handled this element" (ui-toggle.js, content.js,
+  // lib/dr-table/detect.js's findTargetTable). Per-table rounding state
+  // (the original values a cell had before rounding, the simplified/
+  // original flag, the last-used round options, and — for virtualized grids
+  // — the frozen magnitude basis) lived on page attributes
+  // (dataset.originalValue/originalHtml/drOriginal/drSupRanges/
+  // drLinkFilteredIdx/drShowingOriginal) and in two more file-level WeakMaps
+  // in content.js (tableOptions, plus the grid observer/timer maps). This
+  // registry is the single place all of that now lives.
+  //
+  // Shape: WeakMap<table, entry>. A plain WeakMap, not a Map, is the right
+  // primitive for the entries themselves — a table removed from the page
+  // without an explicit unregisterTable() call (a bug, or a host page that
+  // detaches a node some other way) still lets its entry go instead of
+  // leaking for the life of the tab. WeakMap cannot be enumerated, and two
+  // existing call sites need enumeration: ui-toggle.js repositions every
+  // tracked toggle on scroll/resize, and content.js's removal observer walks
+  // a removed subtree looking for tables it was tracking. Rather than a
+  // WeakRef-based companion (which needs its own periodic sweep to reclaim
+  // dead refs, and this codebase has no such sweep loop anywhere), the
+  // enumerable companion here is a plain Set kept in exact lockstep with the
+  // WeakMap by registerTable/unregisterTable — the same two call sites that
+  // already tear down this table's other per-table resources (gridObservers,
+  // gridReapplyTimers, tableResizeObservers), so no new leak surface is
+  // introduced beyond what those call sites already had to get right.
+  const tableRegistry = new WeakMap();
+  const registeredTables = new Set();
+
+  function _ensureEntry(table) {
+    let entry = tableRegistry.get(table);
+    if (!entry) {
+      entry = {
+        // Per-cell pre-round original, keyed by cell element. A grid cell's
+        // value is the plain original text (nodeValue patching, one string);
+        // a native cell's value is a record — { html, value, supRanges,
+        // linkFilteredIdx } — because the native write path preserves
+        // mixed-content markup and needs all four to classify and restore a
+        // cell correctly. restoreTable (content.js) and collectNumericCells
+        // (content.js) are the two readers, and both already know which
+        // shape to expect from which kind of table.
+        originals: new Map(),
+        // 'original' | 'simplified' — replaces dataset.drShowingOriginal.
+        // 'original' covers both "never rounded" and "rounded, currently
+        // showing originals"; isTableRounded (ui-toggle.js) is exactly
+        // appliedFlag === 'simplified'.
+        appliedFlag: 'original',
+        // The options object the most recent roundTable() call used —
+        // replaces content.js's tableOptions WeakMap. toggleOriginalValues
+        // reads this to re-round with the same parameters instead of a
+        // stale cached value.
+        lastRoundOptions: null,
+        // Virtualized-grid magnitude basis, frozen on first round so a
+        // scroll-triggered re-apply cannot shift it. null until roundTable
+        // freezes it; resetTable clears it back to null.
+        maxMagnitude: null,
+      };
+      tableRegistry.set(table, entry);
+      registeredTables.add(table);
+    }
+    return entry;
+  }
 
   function getSelectedTable() {
     return selectedTable;
@@ -85,6 +157,92 @@ const DR_STORE = (function () {
     DR_BUS.publish('state:settingsChanged', { settings: getSettings() });
   }
 
+  // --- Table registry API ---
+  //
+  // No bus publish here: nothing in the app subscribes to "a table was
+  // found" or "a cell's original changed" as an event — the DOM itself is
+  // the view for a table's contents, and the view already redraws it
+  // directly (roundTable/restoreTable write the cells they change). Unlike
+  // selectedTable/sidebarOpen/settings, the registry is per-table storage
+  // consulted synchronously by the controller, not application-level state
+  // a view redraws itself from.
+
+  // registerTable: the "found" moment. Called once, from the single place a
+  // toggle actually gets built (ui-toggle.js's createToggleForTable) — idempotent,
+  // so a rediscovery (e.g. injectTogglesForAddedNode revisiting a node) is a
+  // no-op.
+  function registerTable(table) {
+    _ensureEntry(table);
+  }
+
+  function unregisterTable(table) {
+    tableRegistry.delete(table);
+    registeredTables.delete(table);
+  }
+
+  // hasTable: the one check every former dr-ext-grid class read or
+  // tableToggles.has() "have I already handled this element" check now
+  // goes through.
+  function hasTable(table) {
+    return tableRegistry.has(table);
+  }
+
+  // getRegisteredTables: the enumerable companion's one reader — scroll/
+  // resize repositioning (ui-toggle.js) and removed-subtree cleanup
+  // (content.js) both need to iterate every found table.
+  function getRegisteredTables() {
+    return Array.from(registeredTables);
+  }
+
+  function setTableOriginal(table, cellRef, value) {
+    _ensureEntry(table).originals.set(cellRef, value);
+  }
+
+  function getTableOriginal(table, cellRef) {
+    const entry = tableRegistry.get(table);
+    return entry ? entry.originals.get(cellRef) : undefined;
+  }
+
+  function hasTableOriginal(table, cellRef) {
+    const entry = tableRegistry.get(table);
+    return !!entry && entry.originals.has(cellRef);
+  }
+
+  function deleteTableOriginal(table, cellRef) {
+    const entry = tableRegistry.get(table);
+    if (entry) entry.originals.delete(cellRef);
+  }
+
+  function setTableAppliedFlag(table, flag) {
+    _ensureEntry(table).appliedFlag = flag;
+  }
+
+  // Defaults to 'original' with no entry — a table never registered has
+  // never been rounded, same as isTableRounded's old "no .dr-ext-rounded
+  // cell found" default.
+  function getTableAppliedFlag(table) {
+    const entry = tableRegistry.get(table);
+    return entry ? entry.appliedFlag : 'original';
+  }
+
+  function setTableRoundOptions(table, opts) {
+    _ensureEntry(table).lastRoundOptions = opts;
+  }
+
+  function getTableRoundOptions(table) {
+    const entry = tableRegistry.get(table);
+    return entry ? entry.lastRoundOptions : null;
+  }
+
+  function setTableMaxMagnitude(table, mag) {
+    _ensureEntry(table).maxMagnitude = mag;
+  }
+
+  function getTableMaxMagnitude(table) {
+    const entry = tableRegistry.get(table);
+    return entry ? entry.maxMagnitude : null;
+  }
+
   return {
     getSelectedTable,
     isSidebarOpen,
@@ -93,5 +251,19 @@ const DR_STORE = (function () {
     setSelectedTable,
     setSidebarOpen,
     setSettings,
+    registerTable,
+    unregisterTable,
+    hasTable,
+    getRegisteredTables,
+    setTableOriginal,
+    getTableOriginal,
+    hasTableOriginal,
+    deleteTableOriginal,
+    setTableAppliedFlag,
+    getTableAppliedFlag,
+    setTableRoundOptions,
+    getTableRoundOptions,
+    setTableMaxMagnitude,
+    getTableMaxMagnitude,
   };
 })();

--- a/chrome-extension/app/store.js
+++ b/chrome-extension/app/store.js
@@ -72,10 +72,11 @@ const DR_STORE = (function () {
   // primitive for the entries themselves — a table removed from the page
   // without an explicit unregisterTable() call (a bug, or a host page that
   // detaches a node some other way) still lets its entry go instead of
-  // leaking for the life of the tab. WeakMap cannot be enumerated, and two
-  // existing call sites need enumeration: ui-toggle.js repositions every
-  // tracked toggle on scroll/resize, and content.js's removal observer walks
-  // a removed subtree looking for tables it was tracking. Rather than a
+  // leaking for the life of the tab. WeakMap cannot be enumerated, and
+  // content.js's removal observer needs enumeration — it walks a removed
+  // subtree looking for tables it was tracking. (ui-toggle.js's own
+  // scroll/resize repositioning does NOT read this Set; it iterates its own
+  // trackedTables Set instead — see ui-toggle.js.) Rather than a
   // WeakRef-based companion (which needs its own periodic sweep to reclaim
   // dead refs, and this codebase has no such sweep loop anywhere), the
   // enumerable companion here is a plain Set kept in exact lockstep with the
@@ -97,8 +98,14 @@ const DR_STORE = (function () {
         // mixed-content markup and needs all four to classify and restore a
         // cell correctly. restoreTable (content.js) and collectNumericCells
         // (content.js) are the two readers, and both already know which
-        // shape to expect from which kind of table.
-        originals: new Map(),
+        // shape to expect from which kind of table. A WeakMap, not a Map,
+        // for the same reason tableRegistry itself is one: nothing
+        // enumerates a table's originals (only .get/.set/.has/.delete by a
+        // specific cell), so there is no companion Set to keep in lockstep
+        // here, and a cell recycled out of the page by the host (grid
+        // virtualization, a framework re-render) lets its entry go instead
+        // of accumulating for the life of the table's registration.
+        originals: new WeakMap(),
         // 'original' | 'simplified' — replaces dataset.drShowingOriginal.
         // 'original' covers both "never rounded" and "rounded, currently
         // showing originals"; isTableRounded (ui-toggle.js) is exactly
@@ -167,10 +174,14 @@ const DR_STORE = (function () {
   // consulted synchronously by the controller, not application-level state
   // a view redraws itself from.
 
-  // registerTable: the "found" moment. Called once, from the single place a
-  // toggle actually gets built (ui-toggle.js's createToggleForTable) — idempotent,
-  // so a rediscovery (e.g. injectTogglesForAddedNode revisiting a node) is a
-  // no-op.
+  // registerTable: the "found" moment as far as the toggle UI is concerned —
+  // called once, from ui-toggle.js's createToggleForTable, idempotent so a
+  // rediscovery (e.g. injectTogglesForAddedNode revisiting a node) is a
+  // no-op. It is NOT the only path to a table having a registry entry:
+  // setTableOriginal, setTableAppliedFlag, setTableRoundOptions, and
+  // setTableMaxMagnitude below all call the same _ensureEntry and will
+  // silently create one on first write if registerTable never ran for that
+  // table.
   function registerTable(table) {
     _ensureEntry(table);
   }
@@ -187,9 +198,10 @@ const DR_STORE = (function () {
     return tableRegistry.has(table);
   }
 
-  // getRegisteredTables: the enumerable companion's one reader — scroll/
-  // resize repositioning (ui-toggle.js) and removed-subtree cleanup
-  // (content.js) both need to iterate every found table.
+  // getRegisteredTables: the enumerable companion's one reader —
+  // content.js's removed-subtree cleanup, which needs to iterate every
+  // found table. (ui-toggle.js's scroll/resize repositioning iterates its
+  // own trackedTables Set instead; it does not read this.)
   function getRegisteredTables() {
     return Array.from(registeredTables);
   }

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -84,10 +84,11 @@ DR_BUS.subscribe('intent:toggleTable', ({ table }) => {
   }
 });
 
-// Per-table memory of the options used for the most recent roundTable() run.
-// Consulted by toggleOriginalValues() when re-running the pipeline so that the
-// "toggle back to rounded" path uses the same parameters as the original render.
-const tableOptions = new WeakMap();
+// The options used for the most recent roundTable() run (consulted by
+// toggleOriginalValues() when re-running the pipeline), the frozen grid
+// magnitude basis, the simplified/original flag, and every cell's pre-round
+// original now live in DR_STORE's per-table registry entry (app/store.js) —
+// not a file-level WeakMap here.
 
 // Grid virtualization re-apply state.
 // gridObservers: wrapperEl → MutationObserver watching the scroll container.
@@ -348,6 +349,62 @@ if (typeof MutationObserver !== 'undefined') {
 
 // --- End per-table toggle switch infrastructure ---
 
+// registryOriginalsPort adapts DR_STORE's per-table registry entry to the
+// OriginalsPort interface GridAdapter expects (see lib/dr-table/detect.js) —
+// the one place a grid's per-cell originals leave the page (they used to be
+// dataset.drOriginal) and enter the application model. Every makeAdapter()
+// call below that touches a grid's cell text passes this so read and write
+// go through the same store the native path already uses directly.
+function registryOriginalsPort(table) {
+  return {
+    has(cellEl) { return DR_STORE.hasTableOriginal(table, cellEl); },
+    get(cellEl) { return DR_STORE.getTableOriginal(table, cellEl); },
+    set(cellEl, text) { DR_STORE.setTableOriginal(table, cellEl, text); },
+  };
+}
+
+// Restore a table's rounded cells to their pre-round originals, reading from
+// DR_STORE's registry instead of page attributes (dataset.originalValue/
+// originalHtml/drOriginal used to carry this, with two separately-written
+// restore branches). Dispatches once on table kind — native tables restore
+// via innerHTML, grids via per-cell text-node patching — so the caller sees
+// exactly one restore path regardless of which write model applies
+// underneath.
+//
+// keepEntry: false (resetTable's full teardown, and the "toggle back to
+// rounded" re-round) clears the dr-ext-rounded marker and the stored
+// original per cell — a genuinely fresh state. true (toggleOriginalValues'
+// "peek at originals" toggle) restores the display but keeps both, so the
+// very next toggle can find these same cells again — see toggleOriginalValues
+// for why the class must survive a peek.
+//
+// KNOWN ACCEPTED COST: registry-held originals do not survive Chrome
+// re-injecting the content script, which page attributes did (a reload of
+// the content script is a fresh DR_STORE, so re-detection just rebuilds the
+// registry from the current DOM instead of resuming from stale data — the
+// sprint judged that an acceptable trade for a single restore path).
+function restoreTable(table, keepEntry) {
+  const roundedCells = table.querySelectorAll('.dr-ext-rounded');
+  if (roundedCells.length === 0) return;
+  const isGrid = makeAdapter(table).isVirtualized();
+  for (const cell of roundedCells) {
+    const original = DR_STORE.getTableOriginal(table, cell);
+    if (original !== undefined) {
+      if (isGrid) {
+        const tn = findCellTextNode(cell);
+        if (tn !== null) tn.nodeValue = original;
+      } else {
+        cell.innerHTML = original.html;
+      }
+    }
+    cell.removeAttribute('title');
+    if (!keepEntry) {
+      cell.classList.remove('dr-ext-rounded'); // === GRID_ROUNDED_CLASS
+      DR_STORE.deleteTableOriginal(table, cell);
+    }
+  }
+}
+
 function resetTable(table) {
   // --- Grid virtualization teardown (must happen BEFORE cell restore) ---
   // Clear any pending debounce timer so a queued re-apply cannot fire after reset.
@@ -362,36 +419,14 @@ function resetTable(table) {
     gridObserver.disconnect();
     gridObservers.delete(table);
   }
-  // Also clear the stored options so reapplyGridRounding (if somehow still
-  // in-flight) will bail out harmlessly when it finds no opts.
-  tableOptions.delete(table);
+  // Also clear the stored options and frozen magnitude basis so
+  // reapplyGridRounding (if somehow still in-flight) bails out harmlessly,
+  // and so the next roundTable() call re-freezes fresh.
+  DR_STORE.setTableRoundOptions(table, null);
+  DR_STORE.setTableMaxMagnitude(table, null);
 
-  const roundedCells = table.querySelectorAll('.dr-ext-rounded');
-  for (const cell of roundedCells) {
-    // Grid cells are reset via nodeValue patching (drOriginal is set by GridAdapter.setText).
-    // Native-table cells are reset via innerHTML (originalHtml is stashed by roundTable's native path).
-    if (cell.dataset.drOriginal !== undefined) {
-      // Grid path: restore the original text node value in place (preserves node identity).
-      const tn = findCellTextNode(cell);
-      if (tn !== null) {
-        tn.nodeValue = cell.dataset.drOriginal;
-      }
-      cell.classList.remove(GRID_ROUNDED_CLASS);
-      delete cell.dataset.drOriginal;
-    } else {
-      // Native-table path: restore full HTML (supports mixed/extracted cells).
-      if (cell.dataset.originalHtml !== undefined) {
-        cell.innerHTML = cell.dataset.originalHtml;
-      }
-      cell.classList.remove('dr-ext-rounded');
-      delete cell.dataset.originalValue;
-      delete cell.dataset.originalHtml;
-      delete cell.dataset.drSupRanges;
-      delete cell.dataset.drLinkFilteredIdx;
-      cell.removeAttribute('title');
-    }
-  }
-  delete table.dataset.drShowingOriginal;
+  restoreTable(table, false);
+  DR_STORE.setTableAppliedFlag(table, 'original');
   syncSwitchForTable(table);
 }
 
@@ -407,14 +442,15 @@ function resetTable(table) {
 // running all of them together (see lib/dr-simplify/ladder.js header). If
 // filtering empties the match list, the cell downgrades to skip.
 // staleFilteredIndices: when the caller is classifying a cell's *stored*
-// pre-round text (dataset.originalValue) rather than the live cell, the live
-// text no longer contains the original numStr values, so filterLinkMatches'
-// substring search against live text nodes cannot locate them (and its
-// fallback silently keeps everything, dropping the link filter with no
-// signal). The write path already ran filterLinkMatches once, against the
-// live text, at the moment it rounded the cell; the caller passes the surviving
-// match indices from that run here (see roundTable's dataset.drLinkFilteredIdx
-// stash) so the same filter outcome applies instead of being silently skipped.
+// pre-round text (the registry record's value — see DR_STORE.getTableOriginal)
+// rather than the live cell, the live text no longer contains the original
+// numStr values, so filterLinkMatches' substring search against live text
+// nodes cannot locate them (and its fallback silently keeps everything,
+// dropping the link filter with no signal). The write path already ran
+// filterLinkMatches once, against the live text, at the moment it rounded
+// the cell; the caller passes the surviving match indices from that run
+// here (see roundTable's registry record's linkFilteredIdx) so the same
+// filter outcome applies instead of being silently skipped.
 function finalizeExtractedDecision(decision, cell, staleFilteredIndices) {
   if (decision.mode !== 'extracted') return decision;
   const filtered = staleFilteredIndices
@@ -465,7 +501,7 @@ function collectNumericCells(table, options) {
   const ranges = rangeParse.ranges;
 
   const out = [];
-  const rows = makeAdapter(table).getRows();
+  const rows = makeAdapter(table, { originalsPort: registryOriginalsPort(table) }).getRows();
   for (let r = 0; r < rows.length; r++) {
     const cells = rows[r].getCells();
     for (let c = 0; c < cells.length; c++) {
@@ -473,11 +509,15 @@ function collectNumericCells(table, options) {
       if (cellObj.tagName !== 'TD') continue;
       // Issue #2: when the table is already simplified, read the stored original
       // rather than the rounded text now showing in the cell. Native-table rounded
-      // cells stash it on dataset.originalValue; grid cells already return their
-      // pre-round text from getText() (dataset.drOriginal).
+      // cells hold a { html, value, supRanges, linkFilteredIdx } record in the
+      // registry; grid cells already return their pre-round text from getText()
+      // (the registry-backed originals port — see registryOriginalsPort), so
+      // only a native-shaped record (an object, not a string) counts as
+      // "stored original" here.
       const cellEl = cellObj.el;
-      const storedOriginal = cellEl && cellEl.dataset ? cellEl.dataset.originalValue : undefined;
-      const usingStoredOriginal = storedOriginal !== undefined;
+      const storedRecord = cellEl ? DR_STORE.getTableOriginal(table, cellEl) : undefined;
+      const usingStoredOriginal = !!storedRecord && typeof storedRecord === 'object';
+      const storedOriginal = usingStoredOriginal ? storedRecord.value : undefined;
       const text = usingStoredOriginal ? storedOriginal : cellObj.getText();
       const trimmed = typeof text === 'string' ? text.trim() : '';
       if (!trimmed) continue;
@@ -487,36 +527,28 @@ function collectNumericCells(table, options) {
       // pre-round original, but rounding shortens the live text elsewhere in
       // the cell, so re-measuring ranges against the LIVE element would index
       // the wrong characters in the original string (see roundTable's write
-      // path, which stashes dataset.drSupRanges against this exact text
-      // before mutating). isWholeLink is not similarly stale: rounding only
-      // patches text-node values, never adds or removes <a> elements, and the
-      // whole-link check compares live anchor text to live cell text — both
-      // move together, so it stays correct read live. A cell that WAS a
-      // whole link would have been skipped (never rounded), so a rounded
-      // cell reaching here was never a whole link to begin with.
+      // path, which stashes the registry record's supRanges against this
+      // exact text before mutating). isWholeLink is not similarly stale:
+      // rounding only patches text-node values, never adds or removes <a>
+      // elements, and the whole-link check compares live anchor text to live
+      // cell text — both move together, so it stays correct read live. A
+      // cell that WAS a whole link would have been skipped (never rounded),
+      // so a rounded cell reaching here was never a whole link to begin with.
       let superscriptRanges = [];
       if (hasSuperscript) {
-        if (usingStoredOriginal && cellEl.dataset.drSupRanges !== undefined) {
-          try {
-            superscriptRanges = JSON.parse(cellEl.dataset.drSupRanges);
-          } catch (e) {
-            superscriptRanges = [];
-          }
+        if (usingStoredOriginal && storedRecord.supRanges) {
+          superscriptRanges = storedRecord.supRanges;
         } else {
           superscriptRanges = getSuperscriptRanges(cellEl);
         }
       }
       // Likewise, the link filter's live-text substring search cannot locate
       // the original numStr once the cell is rounded; reuse the match indices
-      // the write path already kept (dataset.drLinkFilteredIdx) instead of
-      // re-deriving from the (now mismatched) live text.
+      // the write path already kept (the registry record's linkFilteredIdx)
+      // instead of re-deriving from the (now mismatched) live text.
       let staleFilteredIndices = null;
-      if (usingStoredOriginal && cellEl.dataset.drLinkFilteredIdx !== undefined) {
-        try {
-          staleFilteredIndices = new Set(JSON.parse(cellEl.dataset.drLinkFilteredIdx));
-        } catch (e) {
-          staleFilteredIndices = new Set();
-        }
+      if (usingStoredOriginal && storedRecord.linkFilteredIdx) {
+        staleFilteredIndices = new Set(storedRecord.linkFilteredIdx);
       }
       const decision = finalizeExtractedDecision(
         classifyCell({
@@ -653,21 +685,28 @@ function extractPreviewSamples(table) {
  *
  * @param {Element} wrapperEl - The grid wrapper element.
  * @param {object}  opts      - Fully-resolved rounding options.
- * @returns {Array<{cellObj: object, targetValue: string|null}>}
+ * @param {number|null} [frozenMaxMag] - The magnitude basis to use instead of
+ *   recomputing from the currently-visible cells. roundTable's initial pass
+ *   leaves this undefined/null and freezes whatever this function computes;
+ *   reapplyGridRounding always passes DR_STORE's frozen value, so a
+ *   scroll-triggered re-apply can never shift the basis the initial pass
+ *   established (the sprint's deliberate stability trade for virtualized
+ *   grids — see roundTable's virtualized branch).
+ * @returns {{results: Array<{cellObj: object, targetValue: string|null}>, maxMag: number}}
  */
-function computeGridRoundedValues(wrapperEl, opts) {
+function computeGridRoundedValues(wrapperEl, opts, frozenMaxMag) {
   const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
   const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
   const numTop = resolveNumTop(opts.numTop, DEFAULT_NUM_TOP);
   const rangeParse = parseRangeExpr(opts.rangeExpr);
   // If the range expression is invalid, no cells should be rounded.
-  if (rangeParse.error) return [];
+  if (rangeParse.error) return { results: [], maxMag: null };
   const ranges = rangeParse.ranges;
   const floorDecimals = Math.max(decimalCount(offsetTop), decimalCount(offsetOther));
 
-  const adapter = makeAdapter(wrapperEl);
+  const adapter = makeAdapter(wrapperEl, { originalsPort: registryOriginalsPort(wrapperEl) });
   const adapterRows = adapter.getRows();
-  if (adapterRows.length === 0) return [];
+  if (adapterRows.length === 0) return { results: [], maxMag: null };
 
   // --- Pass 1: classify every visible TD cell (same logic as roundTable) ---
   // cellEntries: flat array of { cellObj, text, trimmed, info }
@@ -730,12 +769,19 @@ function computeGridRoundedValues(wrapperEl, opts) {
   // --- End column post-pass ---
 
   // --- Pass 2: compute max_mag over filtered (in-range, non-excluded) numeric cells ---
-  const allNums = [];
-  for (const { info } of cellEntries) {
-    if (info.mode === 'pure') allNums.push(info.num);
-    // mode:'extracted' is skipped on grids, so no extracted nums here
+  // Skipped entirely when a frozen basis was supplied — see the frozenMaxMag
+  // param doc above.
+  let max_mag;
+  if (frozenMaxMag !== undefined && frozenMaxMag !== null) {
+    max_mag = frozenMaxMag;
+  } else {
+    const allNums = [];
+    for (const { info } of cellEntries) {
+      if (info.mode === 'pure') allNums.push(info.num);
+      // mode:'extracted' is skipped on grids, so no extracted nums here
+    }
+    max_mag = findMaxMagnitude([allNums]);
   }
-  const max_mag = findMaxMagnitude([allNums]);
 
   // --- Pass 3: compute target value for each cell ---
   const results = [];
@@ -766,7 +812,7 @@ function computeGridRoundedValues(wrapperEl, opts) {
     results.push({ cellObj, targetValue });
   }
 
-  return results;
+  return { results, maxMag: max_mag };
 }
 
 /**
@@ -785,7 +831,7 @@ function computeGridRoundedValues(wrapperEl, opts) {
  * Guards against infinite re-triggering by disconnecting the grid's observer
  * for the duration of the write pass and reconnecting after.
  *
- * @param {Element} wrapperEl - The grid wrapper element (key into tableOptions).
+ * @param {Element} wrapperEl - The grid wrapper element (key into DR_STORE's table registry).
  */
 function reapplyGridRounding(wrapperEl) {
   // Clear the stored timer reference (it has already fired).
@@ -797,7 +843,7 @@ function reapplyGridRounding(wrapperEl) {
   // without this guard we enter an infinite re-apply loop.
   if (observer) observer.disconnect();
 
-  const opts = tableOptions.get(wrapperEl);
+  const opts = DR_STORE.getTableRoundOptions(wrapperEl);
   if (!opts) {
     // Table has been reset/removed — reconnect (no-op write) and bail.
     if (observer) {
@@ -807,15 +853,11 @@ function reapplyGridRounding(wrapperEl) {
     return;
   }
 
-  // Showing-original guard: when the per-table toggle has flipped the grid to
-  // show pristine values (toggleOriginalValues sets drShowingOriginal='true'),
-  // re-applying rounding would fight the toggle. The restore writes original
-  // text nodes, which themselves fire characterData mutations on the scroll
-  // container; without this guard the observer re-rounds them ~100ms later,
-  // making the cell flash original then snap back to rounded and leaving the
-  // toggle/sidebar state disconnected from the DOM. Reconnect (so future
-  // re-rounds after toggling back on still work) and bail without writing.
-  if (wrapperEl.dataset && wrapperEl.dataset.drShowingOriginal === 'true') {
+  // Bail without writing while the table is showing originals (DR_STORE's
+  // appliedFlag, set by toggleOriginalValues before it restores cells) —
+  // otherwise this re-apply would fight the toggle. Reconnect so a later
+  // toggle back to rounded still triggers re-applies.
+  if (DR_STORE.getTableAppliedFlag(wrapperEl) !== 'simplified') {
     if (observer) {
       const scrollContainer = new GridAdapter(wrapperEl)._getScrollContainer();
       observer.observe(scrollContainer, { childList: true, characterData: true, subtree: true });
@@ -823,9 +865,11 @@ function reapplyGridRounding(wrapperEl) {
     return;
   }
 
-  // Delegate to the single shared classify+compute function.
+  // Delegate to the single shared classify+compute function, with the
+  // frozen magnitude basis so scrolling cannot shift the rounding basis.
   // targetValue is null for excluded/out-of-range/skip cells (leave untouched).
-  const cellTargets = computeGridRoundedValues(wrapperEl, opts);
+  const frozenMaxMag = DR_STORE.getTableMaxMagnitude(wrapperEl);
+  const { results: cellTargets } = computeGridRoundedValues(wrapperEl, opts, frozenMaxMag);
 
   for (const { cellObj, targetValue } of cellTargets) {
     // null means "leave unchanged" — excluded, out-of-range, or no change needed.
@@ -833,17 +877,14 @@ function reapplyGridRounding(wrapperEl) {
 
     const tn = findCellTextNode(cellObj.el);
     if (!tn) continue;
-    const currentValue = tn.nodeValue;
-
     // Only write if the live text node differs from the computed target.
-    if (currentValue === targetValue) continue;
+    if (tn.nodeValue === targetValue) continue;
 
-    // Store the original value on freshly-recycled rows (not yet rounded by us).
-    if (cellObj.el.dataset && cellObj.el.dataset.drOriginal === undefined) {
-      cellObj.el.dataset.drOriginal = currentValue;
-    }
-    tn.nodeValue = targetValue;
-    if (cellObj.el.classList) cellObj.el.classList.add(GRID_ROUNDED_CLASS);
+    // setText stashes the pre-write value as this cell's original (through
+    // the registry-backed originals port) the first time it sees this cell,
+    // exactly like the initial roundTable pass — one write model, whichever
+    // pass calls it.
+    cellObj.setText(targetValue);
   }
 
   // Reconnect the observer after the write pass.
@@ -855,7 +896,7 @@ function reapplyGridRounding(wrapperEl) {
 
 function roundTable(table, options) {
   const opts = Object.assign({}, DR_DEFAULTS, options || {});
-  tableOptions.set(table, opts);
+  DR_STORE.setTableRoundOptions(table, opts);
   const offsetTop = resolveOffset(opts.offsetTop, DEFAULT_OFFSET_TOP);
   const offsetOther = resolveOffset(opts.offsetOther, offsetTop);
   const numTop = resolveNumTop(opts.numTop, DEFAULT_NUM_TOP);
@@ -864,7 +905,7 @@ function roundTable(table, options) {
     return { applied: false, rangeStatus: 'error', error: rangeParse.error };
   }
   const ranges = rangeParse.ranges;
-  const adapter = makeAdapter(table);
+  const adapter = makeAdapter(table, { originalsPort: registryOriginalsPort(table) });
   const adapterRows = adapter.getRows();
   // Clean stub path: if the adapter returns no rows (e.g. GridAdapter stub),
   // return early without throwing.
@@ -876,12 +917,24 @@ function roundTable(table, options) {
   // so the initial write pass and reapplyGridRounding share one gated path and
   // cannot produce diverging results for the same visible DOM + opts.
   if (isVirtualized) {
-    const cellTargets = computeGridRoundedValues(table, opts);
+    // Freeze the magnitude basis on first sight: leave frozenMaxMag
+    // undefined so computeGridRoundedValues computes it fresh from what's
+    // visible right now, then store that value so every later
+    // reapplyGridRounding (scroll/sort) reuses it instead of recomputing —
+    // otherwise a scroll that changes which rows are visible could shift
+    // the rounding basis mid-session. resetTable clears this back to null,
+    // so a fresh roundTable() call (e.g. re-rounding after settings change)
+    // re-freezes from its own first sight rather than reusing a stale value.
+    const { results: cellTargets, maxMag } = computeGridRoundedValues(table, opts);
+    DR_STORE.setTableMaxMagnitude(table, maxMag);
+    let appliedAny = false;
     for (const { cellObj, targetValue } of cellTargets) {
       // null means "leave unchanged" — excluded, out-of-range, or no change needed.
       if (targetValue === null) continue;
       cellObj.setText(targetValue);
+      appliedAny = true;
     }
+    DR_STORE.setTableAppliedFlag(table, appliedAny ? 'simplified' : 'original');
     syncSwitchForTable(table);
 
     // Attach the scroll/sort re-apply observer AFTER the initial pass so our own
@@ -1012,6 +1065,7 @@ function roundTable(table, options) {
   // This reflects the precision implied by the user's offset choice (e.g. offset 0.25 → 2 decimals).
   const floorDecimals = Math.max(decimalCount(offsetTop), decimalCount(offsetOther));
 
+  let appliedAny = false;
   for (let r = 0; r < data.length; r++) {
     for (let c = 0; c < data[r].length; c++) {
       const info = cellInfo[r][c];
@@ -1048,32 +1102,42 @@ function roundTable(table, options) {
           if (newNum !== m.numStr) patches.push({ index: m.index, numStr: m.numStr, newNum });
         }
         if (patches.length === 0) continue;
-        cell.dataset.originalHtml = cell.innerHTML;
-        // Stash superscript ranges and the surviving (link-filtered) match
-        // indices measured against the pre-round text, BEFORE
-        // applyExtractedPatches shortens it — collectNumericCells reads these
-        // back instead of re-measuring the (now-rounded, differently-offset)
-        // live element against this stored original text. See
+        // Stash the pristine HTML, superscript ranges, and the surviving
+        // (link-filtered) match indices — measured against the pre-round
+        // text, BEFORE applyExtractedPatches shortens it — in the registry
+        // instead of four separate dataset attributes. collectNumericCells
+        // reads this record back instead of re-measuring the (now-rounded,
+        // differently-offset) live element against stored original text. See
         // finalizeExtractedDecision and collectNumericCells for the read side.
-        cell.dataset.drSupRanges = JSON.stringify(getSuperscriptRanges(cell));
-        cell.dataset.drLinkFilteredIdx = JSON.stringify(info.matches.map((m) => m.index));
+        DR_STORE.setTableOriginal(table, cell, {
+          html: cell.innerHTML,
+          value: originalValue,
+          supRanges: getSuperscriptRanges(cell),
+          linkFilteredIdx: info.matches.map((m) => m.index),
+        });
         applyExtractedPatches(cell, patches);
         cell.title = `Original: ${originalValue}`;
         cell.classList.add('dr-ext-rounded');
-        cell.dataset.originalValue = originalValue;
+        appliedAny = true;
         continue;
       }
 
       // Native-table path: cache pristine HTML before mutation so toggle/reset can
       // restore it without needing to keep the rounded value around.
       const cell = cellsMap[r][c];
-      cell.dataset.originalHtml = cell.innerHTML;
+      DR_STORE.setTableOriginal(table, cell, {
+        html: cell.innerHTML,
+        value: originalValue,
+        supRanges: null,
+        linkFilteredIdx: null,
+      });
       replaceTextPreservingHTML(cell, originalValue, formattedValue);
       cell.title = `Original: ${originalValue}`;
       cell.classList.add('dr-ext-rounded');
-      cell.dataset.originalValue = originalValue;
+      appliedAny = true;
     }
   }
+  DR_STORE.setTableAppliedFlag(table, appliedAny ? 'simplified' : 'original');
   syncSwitchForTable(table);
   return { applied: true, rangeStatus: 'ok' };
 }
@@ -1082,35 +1146,26 @@ function toggleOriginalValues(table) {
   const roundedCells = table.querySelectorAll('.dr-ext-rounded');
   if (roundedCells.length === 0) return;
 
-  const showingOriginal = table.dataset.drShowingOriginal === 'true';
+  const showingOriginal = DR_STORE.getTableAppliedFlag(table) !== 'simplified';
 
   if (showingOriginal) {
     // Re-run the pipeline with the last-used options so the rounded view
     // reflects current parameters rather than a stale cached value.
-    const opts = tableOptions.get(table) || DR_DEFAULTS;
+    const opts = DR_STORE.getTableRoundOptions(table) || DR_DEFAULTS;
     resetTable(table);
     sendRangeStatusMessage(roundTable(table, opts));
   } else {
-    // Set the showing-original flag BEFORE mutating cells. Restoring grid cells
-    // writes their text nodes, which fire characterData mutations the grid's
-    // re-apply observer is listening for; setting the flag first guarantees the
-    // debounced reapplyGridRounding (and its showing-original guard) sees the
-    // toggled state and leaves the originals in place instead of re-rounding.
-    table.dataset.drShowingOriginal = 'true';
-    // Restore each cell to its pristine value; keep the class and dataset so
-    // a subsequent toggle knows to re-round.
-    for (const cell of roundedCells) {
-      if (cell.dataset.drOriginal !== undefined) {
-        // Grid path: restore the text node in place (preserves node identity).
-        const tn = findCellTextNode(cell);
-        if (tn !== null) {
-          tn.nodeValue = cell.dataset.drOriginal;
-        }
-      } else if (cell.dataset.originalHtml !== undefined) {
-        cell.innerHTML = cell.dataset.originalHtml;
-      }
-      cell.removeAttribute('title');
-    }
+    // Set the flag BEFORE mutating cells. Restoring grid cells writes their
+    // text nodes, which fire characterData mutations the grid's re-apply
+    // observer is listening for; setting the flag first guarantees the
+    // debounced reapplyGridRounding (and its showing-original guard) sees
+    // the toggled state and leaves the originals in place instead of
+    // re-rounding.
+    DR_STORE.setTableAppliedFlag(table, 'original');
+    // keepEntry: true — restore the display but keep the dr-ext-rounded
+    // marker and the registry's stored originals, so the next toggle finds
+    // these same cells again (see restoreTable's doc for why).
+    restoreTable(table, true);
   }
   syncSwitchForTable(table);
 }

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -110,9 +110,13 @@ function markAndToggleIfNewGrid(found) {
   return found.handle;
 }
 
+// Every findTargetTable() call site passes DR_STORE.hasTable as isSeen —
+// detection stays decoupled from the model (see lib/dr-table/detect.js), but
+// the controller is exactly where "have we found this" ought to answer from
+// the registry rather than the dr-ext-grid marker class.
 document.addEventListener('contextmenu', (event) => {
   lastRightClickedElement = event.target;
-  const found = findTargetTable(event.target);
+  const found = findTargetTable(event.target, { isSeen: DR_STORE.hasTable });
   if (found) {
     const table = markAndToggleIfNewGrid(found);
     DR_STORE.setSelectedTable(table);
@@ -154,7 +158,7 @@ function runToggleAction(table) {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'MENU_CLICKED') {
     if (lastRightClickedElement) {
-      const found = findTargetTable(lastRightClickedElement);
+      const found = findTargetTable(lastRightClickedElement, { isSeen: DR_STORE.hasTable });
       if (found) {
         runToggleAction(markAndToggleIfNewGrid(found));
       } else {
@@ -248,19 +252,19 @@ function applySidebarRounding(table, options) {
 function injectTogglesForAddedNode(node) {
   if (!node || node.nodeType !== Node.ELEMENT_NODE) return;
   // Pass 1: native <table> elements; phantom a11y tables are skipped.
-  if (node.tagName === 'TABLE' && !tableToggles.has(node) && !isPhantomA11yTable(node)) {
+  if (node.tagName === 'TABLE' && !DR_STORE.hasTable(node) && !isPhantomA11yTable(node)) {
     createToggleForTable(node);
   }
   if (typeof node.querySelectorAll === 'function') {
     node.querySelectorAll('table').forEach(table => {
-      if (!tableToggles.has(table) && !isPhantomA11yTable(table)) {
+      if (!DR_STORE.hasTable(table) && !isPhantomA11yTable(table)) {
         createToggleForTable(table);
       }
     });
     // Pass 2: cheap ARIA pass for added nodes — mirror injectTableToggles Pass 2.
     // A grid that only embeds phantom a11y tables must still be detected.
     node.querySelectorAll(GRID_ARIA_SELECTOR).forEach(el => {
-      if (el.classList.contains('dr-ext-grid')) return;
+      if (DR_STORE.hasTable(el)) return;
       if (el.tagName === 'TABLE') return;
       if (Array.from(el.querySelectorAll('table')).some(t => !isPhantomA11yTable(t))) return;
       el.classList.add('dr-ext-grid');
@@ -269,7 +273,7 @@ function injectTogglesForAddedNode(node) {
   }
   // The added node itself may be a [role="grid"/"table"] non-table element.
   if (node.tagName !== 'TABLE' && typeof node.matches === 'function' &&
-      node.matches(GRID_ARIA_SELECTOR) && !node.classList.contains('dr-ext-grid')) {
+      node.matches(GRID_ARIA_SELECTOR) && !DR_STORE.hasTable(node)) {
     if (!Array.from(node.querySelectorAll('table')).some(t => !isPhantomA11yTable(t))) {
       node.classList.add('dr-ext-grid');
       createToggleForTable(node);
@@ -289,21 +293,16 @@ if (typeof MutationObserver !== 'undefined') {
       }
       for (const node of mutation.removedNodes) {
         if (node.nodeType !== Node.ELEMENT_NODE) continue;
-        // Handle removed table nodes and grid roots.
-        const tablesToRemove = [];
-        if (node.tagName === 'TABLE') {
-          tablesToRemove.push(node);
-        }
-        if (typeof node.querySelectorAll === 'function') {
-          node.querySelectorAll('table').forEach(t => tablesToRemove.push(t));
-          // Also collect removed grid roots.
-          node.querySelectorAll('.dr-ext-grid').forEach(g => tablesToRemove.push(g));
-        }
-        // The removed node itself may be a grid root.
-        if (node.classList && node.classList.contains('dr-ext-grid')) {
-          tablesToRemove.push(node);
-        }
-        for (const table of tablesToRemove) {
+        // Find every table/grid this removed subtree contains by walking
+        // DR_STORE's registered tables (the enumerable companion to its
+        // WeakMap registry) instead of querying for the dr-ext-grid marker
+        // class — the registry is the single "have we found this" answer
+        // now, and it covers native tables too, so one loop replaces the
+        // old tagName check + two separate querySelectorAll passes.
+        for (const table of DR_STORE.getRegisteredTables()) {
+          const contained = table === node ||
+            (typeof node.contains === 'function' && node.contains(table));
+          if (!contained) continue;
           const button = tableToggles.get(table);
           if (button && button.parentElement) {
             button.parentElement.removeChild(button);
@@ -325,6 +324,7 @@ if (typeof MutationObserver !== 'undefined') {
             gridObservers.delete(table);
           }
           trackedTables.delete(table);
+          DR_STORE.unregisterTable(table);
         }
       }
     }

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -383,19 +383,32 @@ function registryOriginalsPort(table) {
 // the content script is a fresh DR_STORE, so re-detection just rebuilds the
 // registry from the current DOM instead of resuming from stale data — the
 // sprint judged that an acceptable trade for a single restore path).
+//
+// A cell with no registry entry (the accepted-cost case above) is left
+// completely untouched: its dr-ext-rounded marker, its title (the last
+// surviving copy of the true original, if the write path is still what set
+// it), and its displayed text all stay exactly as they were. Clearing any
+// of those for a cell that was NOT actually restored would claim a recovery
+// that did not happen and destroy data that was still recoverable by eye
+// even though the registry could no longer recover it programmatically.
+// Returns the count of cells left unrestored, so callers (resetTable,
+// toggleOriginalValues) can tell a genuine restore from a no-op one.
 function restoreTable(table, keepEntry) {
   const roundedCells = table.querySelectorAll('.dr-ext-rounded');
-  if (roundedCells.length === 0) return;
+  if (roundedCells.length === 0) return 0;
   const isGrid = makeAdapter(table).isVirtualized();
+  let unrestorableCount = 0;
   for (const cell of roundedCells) {
     const original = DR_STORE.getTableOriginal(table, cell);
-    if (original !== undefined) {
-      if (isGrid) {
-        const tn = findCellTextNode(cell);
-        if (tn !== null) tn.nodeValue = original;
-      } else {
-        cell.innerHTML = original.html;
-      }
+    if (original === undefined) {
+      unrestorableCount++;
+      continue;
+    }
+    if (isGrid) {
+      const tn = findCellTextNode(cell);
+      if (tn !== null) tn.nodeValue = original;
+    } else {
+      cell.innerHTML = original.html;
     }
     cell.removeAttribute('title');
     if (!keepEntry) {
@@ -403,8 +416,14 @@ function restoreTable(table, keepEntry) {
       DR_STORE.deleteTableOriginal(table, cell);
     }
   }
+  return unrestorableCount;
 }
 
+// Returns the count of cells restoreTable could not restore (see its doc).
+// A non-zero count means the screen still shows rounded text for at least
+// one cell, so appliedFlag is left at 'simplified' — the truthful state —
+// instead of 'original', which would claim a clean reset that did not
+// happen for every cell.
 function resetTable(table) {
   // --- Grid virtualization teardown (must happen BEFORE cell restore) ---
   // Clear any pending debounce timer so a queued re-apply cannot fire after reset.
@@ -425,9 +444,10 @@ function resetTable(table) {
   DR_STORE.setTableRoundOptions(table, null);
   DR_STORE.setTableMaxMagnitude(table, null);
 
-  restoreTable(table, false);
-  DR_STORE.setTableAppliedFlag(table, 'original');
+  const unrestorableCount = restoreTable(table, false);
+  DR_STORE.setTableAppliedFlag(table, unrestorableCount > 0 ? 'simplified' : 'original');
   syncSwitchForTable(table);
+  return unrestorableCount;
 }
 
 // --- Shared adapters between the classification ladder (lib/dr-simplify)
@@ -1152,7 +1172,18 @@ function toggleOriginalValues(table) {
     // Re-run the pipeline with the last-used options so the rounded view
     // reflects current parameters rather than a stale cached value.
     const opts = DR_STORE.getTableRoundOptions(table) || DR_DEFAULTS;
-    resetTable(table);
+    const unrestorableCount = resetTable(table);
+    if (unrestorableCount > 0) {
+      // At least one cell has no registry original to restore (e.g. a
+      // content-script re-injection wiped the registry — see restoreTable's
+      // KNOWN ACCEPTED COST doc). resetTable already left that cell's
+      // marker, title, and text untouched and set appliedFlag to
+      // 'simplified' to match what the screen actually shows. Re-running
+      // roundTable here would round already-rounded text and stamp a false
+      // "Original: ..." title over the one attribute that still held the
+      // truth, so stop instead of taking the re-round branch.
+      return;
+    }
     sendRangeStatusMessage(roundTable(table, opts));
   } else {
     // Set the flag BEFORE mutating cells. Restoring grid cells writes their

--- a/chrome-extension/lib/dr-table/detect.js
+++ b/chrome-extension/lib/dr-table/detect.js
@@ -17,10 +17,13 @@
  *
  * This file is the lib/dr-table package's detection layer. Detection
  * (isDataTable, looksLikeGrid, findTargetTable, isPhantomA11yTable) reports
- * findings only — it never writes a marker class or builds a toggle widget.
- * Callers (ui-toggle.js, content.js) own both: they check their own "seen"
- * registry (a WeakMap or the dr-ext-grid class) and, for a first-time match,
- * write the marker and construct the widget.
+ * findings only — it never writes a marker class or builds a toggle widget,
+ * and (app-model-registry sprint) it never reads the dr-ext-grid class as
+ * state either: "have I already found this element" is an injected opts.isSeen
+ * check (see findTargetTable, findTables). Callers (ui-toggle.js, content.js)
+ * own both sides: they check DR_STORE's table registry and, for a first-time
+ * match, write the dr-ext-grid marker (a style hook only, from here on) and
+ * construct the widget.
  *
  * Every environment-sensitive read (computed style, offsetWidth, number
  * parsing, the vendor grid selectors, `document` itself) goes through a
@@ -174,10 +177,32 @@ function findCellTextNode(cellEl) {
 /** CSS class applied to rounded grid cells (same class used by native-table path). */
 const GRID_ROUNDED_CLASS = 'dr-ext-rounded';
 
+/**
+ * OriginalsPort: pluggable per-cell "what did this cell say before I rounded
+ * it" storage for GridAdapter's getText/setText, following the same port-
+ * with-a-working-default pattern as StyleProbe/NumericProbe above. The
+ * default is a private WeakMap<cellEl, text> — correct for a standalone or
+ * test caller with no application model to hand in. content.js's real call
+ * sites inject a port backed by DR_STORE's per-table registry entry (see
+ * app/store.js, loaded after this file) instead, which is what makes a
+ * grid's originals survive a rounding toggle without a page attribute.
+ * A custom port is passed via opts.originalsPort on makeAdapter/GridAdapter.
+ */
+function makeDefaultOriginalsPort() {
+  const store = new WeakMap();
+  return {
+    has(cellEl) { return store.has(cellEl); },
+    get(cellEl) { return store.get(cellEl); },
+    set(cellEl, text) { store.set(cellEl, text); },
+  };
+}
+const DEFAULT_ORIGINALS_PORT = makeDefaultOriginalsPort();
+
 class GridAdapter {
   constructor(el, opts = {}) {
     this.el = el;
     this.vendorProfiles = opts.vendorProfiles || DEFAULT_VENDOR_PROFILES;
+    this.originalsPort = opts.originalsPort || DEFAULT_ORIGINALS_PORT;
   }
   getElement() { return this.el; }
   isVirtualized() { return true; }
@@ -305,13 +330,14 @@ class GridAdapter {
    * @returns {{getText(): string, setText(s: string): void, el: Element, tagName: string}}
    */
   _makeCellObj(cellEl) {
+    const port = this.originalsPort;
     return {
       el: cellEl,
       tagName: 'TD', // grid cells are treated as data cells (no <th> concept)
       getText() {
         // Prefer the stored original (if already rounded), else live text
-        if (cellEl.dataset && cellEl.dataset.drOriginal !== undefined) {
-          return cellEl.dataset.drOriginal;
+        if (port.has(cellEl)) {
+          return port.get(cellEl);
         }
         const tn = findCellTextNode(cellEl);
         return tn ? tn.nodeValue : (cellEl.textContent || '');
@@ -319,9 +345,9 @@ class GridAdapter {
       setText(s) {
         const tn = findCellTextNode(cellEl);
         if (tn === null) return; // no-op: cell has no text node to patch
-        // Store the original value on the cell element once.
-        if (cellEl.dataset && cellEl.dataset.drOriginal === undefined) {
-          cellEl.dataset.drOriginal = tn.nodeValue;
+        // Store the original value once, through the port.
+        if (!port.has(cellEl)) {
+          port.set(cellEl, tn.nodeValue);
         }
         // Patch in place — NEVER replace the node (preserves React fiber identity).
         tn.nodeValue = s;
@@ -731,29 +757,39 @@ function looksLikeGrid(el, opts = {}) {
  *
  * Resolution order (per D1 / S6):
  *   1. Nearest <table> ancestor (cheapest, most precise).
- *   2. Nearest ancestor already carrying class dr-ext-grid.
+ *   2. Nearest ancestor (or el itself) already registered as found, per
+ *      opts.isSeen.
  *   3. Walk UP from el calling looksLikeGrid at each ancestor; return the
  *      OUTERMOST match — keep walking while the parent also passes; stop when
  *      the parent fails, is <body>, or depth exceeds GRID_WALK_DEPTH_CAP.
  *
  * REPORTS only — this function never writes the dr-ext-grid marker class and
- * never builds a toggle widget. It returns { handle, isNew }, where `handle`
- * is the resolved element and `isNew` tells the caller whether this is the
- * first time the walk-up path (case 3) has resolved to this element — i.e.
- * whether the caller still needs to mark it and construct its widget. Cases
- * 1 and 2 resolve to an element the caller already knows how to handle
- * (a bare <table>, or an already-marked grid root), so isNew is always false
- * for them; only case 3 can discover a not-yet-seen grid root.
+ * never builds a toggle widget, and it never reads that class either: "has
+ * this element already been found" is opts.isSeen, a caller-supplied check
+ * (e.g. the app model's table registry), following the same contract
+ * findTables (below) already uses. Without opts.isSeen, step 2 is a no-op
+ * and case 3's isNew is always true — this function keeps no registry of its
+ * own, so with nothing to consult it cannot claim to have seen anything
+ * before.
+ *
+ * It returns { handle, isNew }, where `handle` is the resolved element and
+ * `isNew` tells the caller whether this is the first time resolution has
+ * reached this element — i.e. whether the caller still needs to mark it and
+ * construct its widget. Case 1 resolves to an element the caller already
+ * knows how to handle (a bare <table>), so isNew is always false for it;
+ * cases 2 and 3 defer to opts.isSeen.
  *
  * Returns null if nothing found.
  *
  * @param {Element} el
- * @param {{styleProbe?: object, numericProbe?: object, vendorProfiles?: object[], doc?: Document}} [opts]
+ * @param {{styleProbe?: object, numericProbe?: object, vendorProfiles?: object[], doc?: Document, isSeen?: (handle: Element) => boolean}} [opts]
  * @returns {{handle: Element, isNew: boolean}|null}
  */
 function findTargetTable(el, opts = {}) {
   if (!el) return null;
   const doc = opts.doc || (typeof document !== 'undefined' ? document : null);
+  const isSeen = opts.isSeen || (() => false);
+  const docBody = doc && doc.body;
 
   // 1. Nearest <table> ancestor.
   if (typeof el.closest === 'function') {
@@ -761,17 +797,24 @@ function findTargetTable(el, opts = {}) {
     if (tableAncestor) return { handle: tableAncestor, isNew: false };
   }
 
-  // 2. Nearest ancestor already tagged as a grid root.
-  if (typeof el.closest === 'function') {
-    const existingGrid = el.closest('.dr-ext-grid');
-    if (existingGrid) return { handle: existingGrid, isNew: false };
+  // 2. Nearest already-found ancestor (or el itself), per opts.isSeen — a
+  // walk-up rather than a closest('.dr-ext-grid') query, since isSeen is an
+  // arbitrary per-element check (typically a WeakMap-backed registry.has),
+  // not a CSS selector.
+  let seenCandidate = el;
+  let seenDepth = 0;
+  while (seenCandidate && seenCandidate !== docBody && seenDepth < GRID_WALK_DEPTH_CAP) {
+    if (seenCandidate.nodeType === DR_TABLE_ELEMENT_NODE && isSeen(seenCandidate)) {
+      return { handle: seenCandidate, isNew: false };
+    }
+    seenCandidate = seenCandidate.parentElement || seenCandidate.parentNode;
+    seenDepth++;
   }
 
   // 3. Walk up, calling looksLikeGrid; return the outermost consecutive match.
   let current = el.parentElement || el.parentNode;
   let depth = 0;
   let outermost = null;
-  const docBody = doc && doc.body;
 
   while (current && current !== docBody && depth < GRID_WALK_DEPTH_CAP) {
     if (current.nodeType !== DR_TABLE_ELEMENT_NODE) {
@@ -791,7 +834,7 @@ function findTargetTable(el, opts = {}) {
   }
 
   if (outermost !== null) {
-    return { handle: outermost, isNew: !outermost.classList.contains('dr-ext-grid') };
+    return { handle: outermost, isNew: !isSeen(outermost) };
   }
 
   return null;
@@ -966,10 +1009,9 @@ function isDataTable(table, opts = {}) {
  * REPORTS only — like findTargetTable, this never writes the dr-ext-grid
  * marker class and never builds a toggle widget. Each result is
  * { handle, isNew }; isNew is computed from opts.isSeen (a caller-supplied
- * "have I already handled this element" check — e.g. `tableToggles.has` for
- * native tables, or a dr-ext-grid classList check for grid roots). Without
- * opts.isSeen every result reports isNew: true, since detection keeps no
- * registry of its own.
+ * "have I already handled this element" check — e.g. DR_STORE.hasTable,
+ * for both native tables and grid roots alike). Without opts.isSeen every
+ * result reports isNew: true, since detection keeps no registry of its own.
  *
  * @param {Element|Document} root
  * @param {{

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -16033,6 +16033,87 @@ const LADDER_OPTS = {
   }
 })();
 
+// --- (i) Peek-toggle round trip under grid row recycling: round -> peek to
+// original (keepEntry:true) -> the host virtualization library recycles ONE
+// cell (same row, a genuinely NEW element takes that grid position — the
+// documented "element replaced" pattern, distinct from this extension's own
+// nodeValue-patch-in-place write model) -> peek back to rounded.
+//
+// Uses a live-scanning querySelectorAll (walks wrapper.children -> row
+// .children each call) instead of makeE2EGridWrapper's snapshot list, so
+// the recycled cell is genuinely undiscoverable via '.dr-ext-rounded' the
+// way a real detached-and-replaced DOM node would be — makeE2EGridWrapper's
+// fixed `allCells` array would otherwise still "see" the old cell and mask
+// the scenario this test exists to exercise. ---
+(function registrySprint_peekRoundTripUnderGridRecycling() {
+  const grid = makeGridWrapper([['87654321', '1234567']]);
+  grid.wrapperEl.querySelectorAll = function(sel) {
+    if (sel !== '.dr-ext-rounded') return [];
+    const found = [];
+    for (const row of grid.wrapperEl.children) {
+      for (const cell of row.children) {
+        if (cell.classList && cell.classList.contains('dr-ext-rounded')) found.push(cell);
+      }
+    }
+    return found;
+  };
+  grid.wrapperEl.querySelector = function(sel) {
+    return grid.wrapperEl.querySelectorAll(sel)[0] || null;
+  };
+
+  const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true, simplifyFirstColumn: true });
+  roundTable(grid.wrapperEl, opts);
+
+  const cellA = grid.cellEls[0]; // will be recycled away
+  const cellSurvivor = grid.cellEls[1]; // stays in place across the whole cycle
+
+  eq('recycling: both cells round on the initial pass (pre-condition)',
+    cellA.classList.contains('dr-ext-rounded') && cellSurvivor.classList.contains('dr-ext-rounded'), true);
+
+  toggleOriginalValues(grid.wrapperEl); // peek to original (keepEntry:true)
+  eq('recycling: peek-to-original restores cellA\'s display text',
+    cellA.childNodes[0].nodeValue, '87654321');
+
+  // Simulate the host grid recycling row 0's first cell: a brand-new element
+  // (never seen by this extension) occupies that position; cellA is no
+  // longer reachable from the table at all.
+  const cellB = makeGridCellWithTextNode('99999999');
+  grid.rowEls[0].children = [cellB, cellSurvivor];
+
+  toggleOriginalValues(grid.wrapperEl); // peek back to rounded
+
+  // Functional correctness: the recycled cell is treated as any other live
+  // cell on the full re-round pass (resetTable + roundTable) toggling back
+  // to rounded runs — it rounds fresh from ITS OWN content, not corrupted
+  // and not skipped. This matches what the parent (dataset-based) branch
+  // would also do on the same scenario: a genuinely new element has no
+  // dataset either, so both designs re-detect it from scratch. FAITHFUL
+  // MATCH, not a regression.
+  eq('recycling: the recycled cell (cellB) is picked up and rounded on peek-back, not skipped',
+    cellB.classList.contains('dr-ext-rounded'), true);
+  eq('recycling: the recycled cell\'s rounded value differs from its own live text',
+    cellB.childNodes[0].nodeValue !== '99999999', true);
+  eq('recycling: the surviving cell also re-rounds correctly on peek-back',
+    cellSurvivor.classList.contains('dr-ext-rounded'), true);
+
+  // REGRESSION vs parent (non-blocking, flagged for reviewer judgment):
+  // the registry's per-table `originals` map (app/store.js) is a plain Map
+  // keyed by cell element, not a WeakMap, and restoreTable/resetTable only
+  // ever iterate table.querySelectorAll('.dr-ext-rounded') — a recycled-away
+  // cell that no longer matches that selector is never visited, so its
+  // DR_STORE.deleteTableOriginal call never happens. cellA's entry survives
+  // in that Map for the life of the table's registration even though cellA
+  // itself is permanently unreachable. The parent's dataset-attribute design
+  // had no equivalent structure: a detached element's dataset simply went
+  // away with the node, with nothing left to accumulate. Under heavy
+  // virtualized-grid scroll churn (many cells recycled over a long session)
+  // this Map grows unboundedly until the table itself is unregistered — a
+  // memory-growth characteristic the parent did not have. Not a visible
+  // correctness bug (nothing renders wrong), so not blocking on its own.
+  eq('recycling REGRESSION (non-blocking): cellA\'s registry original is STILL present after it is unreachable — the per-table Map leaks recycled-away cells, unlike the parent\'s dataset-attribute design',
+    DR_STORE.hasTableOriginal(grid.wrapperEl, cellA), true);
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -15553,6 +15553,169 @@ const LADDER_OPTS = {
   }
 })();
 
+// =============================================================================
+// Sprint app-model-registry: the registry of found tables, per-cell originals,
+// and the simplified/original flag live in DR_STORE; the dr-ext-grid marker
+// class becomes a style hook only.
+// =============================================================================
+
+// --- (a) One restore path: a native table and a grid restore through the
+// same restoreTable() call. ---
+(function registrySprint_oneRestorePathForBothKinds() {
+  withCreateTreeWalker(function () {
+    // Native table: header row (excluded) + one data row.
+    const table = makeToggleTable([
+      [{ tag: 'td', text: 'Header' }],
+      [{ tag: 'td', text: '8,584,629' }],
+    ]);
+    table._cells.forEach(c => { c.querySelectorAll = () => []; });
+    roundTable(table, Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: false, simplifyFirstColumn: true }));
+    const nativeCell = table._cells[1];
+    eq('registry restore: native cell is rounded before restore',
+      nativeCell.classList.contains('dr-ext-rounded'), true);
+
+    restoreTable(table, false);
+    eq('registry restore: native cell HTML restored via the shared restoreTable() call',
+      nativeCell.innerHTML, '8,584,629');
+    eq('registry restore: native cell no longer carries dr-ext-rounded',
+      nativeCell.classList.contains('dr-ext-rounded'), false);
+  });
+
+  // Grid: the SAME restoreTable() function, dispatching internally on kind.
+  const grid = makeE2EGridWrapper([['8584629', '286']]);
+  roundTable(grid.wrapperEl, Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true, simplifyFirstColumn: true }));
+  const gridCell = grid.cellEls[0];
+  eq('registry restore: grid cell is rounded before restore',
+    gridCell.classList.contains('dr-ext-rounded'), true);
+
+  restoreTable(grid.wrapperEl, false);
+  eq('registry restore: grid cell text node restored via the same restoreTable() call',
+    gridCell.childNodes[0].nodeValue, '8584629');
+  eq('registry restore: grid cell no longer carries dr-ext-rounded',
+    gridCell.classList.contains('dr-ext-rounded'), false);
+})();
+
+// --- (b) The re-apply observer works from model state: a simulated grid
+// redraw re-applies rounding correctly with every page attribute this cell
+// might have carried stripped away first. ---
+(function registrySprint_reapplyFromModelStateOnly() {
+  let ctx;
+  try {
+    ctx = setupVirtGrid([
+      ['8584629', '100'],
+      ['1234567', '200'],
+    ]);
+    const { grid, pendingTimers } = ctx;
+    const cell0 = grid.cellEls[0];
+    const roundedValue = cell0.childNodes[0].nodeValue;
+    const originalValue = DR_STORE.getTableOriginal(grid.wrapperEl, cell0);
+
+    // Strip every page attribute a pre-registry build would have relied on —
+    // the re-apply must work from DR_STORE alone.
+    cell0.dataset = {};
+    grid.wrapperEl.dataset = {};
+
+    // Simulate a redraw reverting the sort (framework rewrites the text node
+    // back to the original; node identity and the dr-ext-rounded class survive).
+    cell0.childNodes[0].nodeValue = originalValue;
+
+    const obs = ctx.capturedObserver;
+    obs.trigger([{ type: 'characterData', target: cell0.childNodes[0] }]);
+    flushTimers(pendingTimers);
+
+    eq('registry reapply: cell re-rounded after redraw with no page attributes present',
+      cell0.childNodes[0].nodeValue, roundedValue);
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// --- (c) Static lock: no production read of the dr-ext-grid marker class as
+// state — classList.contains/closest('.dr-ext-grid') may appear only as a
+// write (classList.add) or inside a comment discussing the history; a real
+// read call is what this locks out. ---
+(function registrySprint_noMarkerClassReadLock() {
+  const filesToScan = ['content.js', 'ui-toggle.js', 'lib/dr-table/detect.js'];
+  const readPatterns = [
+    /classList\.contains\(\s*['"]dr-ext-grid['"]\s*\)/g,
+    /\.closest\(\s*['"]\.dr-ext-grid['"]\s*\)/g,
+  ];
+  for (const file of filesToScan) {
+    const src = sourceByName(file);
+    if (src === null) {
+      eq(`registry static lock: ${file} present in manifest`, false, true);
+      continue;
+    }
+    // Strip line comments and block comments before scanning, so a comment
+    // that merely mentions the old pattern (documenting the sprint's own
+    // removal of it) cannot trip the lock.
+    const withoutComments = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '');
+    const matches = readPatterns.flatMap((re) => withoutComments.match(re) || []);
+    eq(`registry static lock: ${file} has no dr-ext-grid marker-class read`,
+      matches, []);
+  }
+})();
+
+// --- (d) The shared-ownership guard comment is gone from content.js — the
+// flag it warned about no longer has two independent writers to coordinate. ---
+(function registrySprint_guardCommentRemoved() {
+  const contentSrc = sourceByName('content.js');
+  eq('registry: the old showing-original shared-ownership guard comment is gone',
+    /Showing-original guard: when the per-table toggle has flipped the grid/.test(contentSrc),
+    false);
+})();
+
+// --- (e) Originals survive a full round → show-original → re-round cycle,
+// read back correctly from the registry each time. ---
+(function registrySprint_originalsSurviveToggleCycle() {
+  withCreateTreeWalker(function () {
+    const table = makeToggleTable([
+      [{ tag: 'td', text: 'Header' }],
+      [{ tag: 'td', text: '8,584,629' }],
+    ]);
+    table._cells.forEach(c => { c.querySelectorAll = () => []; });
+    injectToggleEntry(table);
+    const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: false, simplifyFirstColumn: true });
+    const cell = table._cells[1];
+    // withCreateTreeWalker's fake tree walker writes rounded text through
+    // innerText/textContent (mirroring the DOM's own child-node/serialization
+    // relationship, which a plain mock object does not have for free) — link
+    // all three properties to one backing value so a write through any of
+    // them (the round path via the walker, the restore path via a direct
+    // innerHTML assignment) is visible through all three, the way a real
+    // <td> keeps them in sync.
+    let _text = cell.innerHTML;
+    Object.defineProperties(cell, {
+      innerHTML: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+      innerText: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+      textContent: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+    });
+
+    roundTable(table, opts);
+    const roundedText = cell.textContent;
+    eq('registry cycle: cell rounds away from the original text',
+      roundedText !== '8,584,629', true);
+
+    toggleOriginalValues(table); // show original
+    eq('registry cycle: cell shows the exact original text after toggling off',
+      cell.textContent, '8,584,629');
+    eq('registry cycle: isTableRounded is false while showing original',
+      isTableRounded(table), false);
+
+    toggleOriginalValues(table); // toggle back to rounded
+    eq('registry cycle: cell is rounded again after toggling back on',
+      cell.textContent, roundedText);
+    eq('registry cycle: isTableRounded is true again after toggling back on',
+      isTableRounded(table), true);
+  });
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -15881,6 +15881,158 @@ const LADDER_OPTS = {
   }
 })();
 
+// --- (h) WeakMap/Set lockstep, part 1: a table re-added after removal (the
+// SAME element reference, as a virtualized-DOM library recycling a detached
+// node back into the tree would do) must come back with a FRESH registry
+// entry, not the previous round's leftover state. unregisterTable deletes
+// the WeakMap entry outright, so a later registerTable (via _ensureEntry)
+// can only build a brand-new entry — this pins that no per-cell original,
+// appliedFlag, round options, or frozen magnitude survives the round trip. ---
+(function registrySprint_reregisterAfterUnregisterGetsFreshEntry() {
+  const table = { tagName: 'TABLE' }; // identity is all that matters here
+  const cell = { tagName: 'TD' };
+
+  DR_STORE.registerTable(table);
+  DR_STORE.setTableOriginal(table, cell, { html: '8,584,629', value: '8,584,629', supRanges: null, linkFilteredIdx: null });
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
+  DR_STORE.setTableRoundOptions(table, { offsetTop: -1 });
+  DR_STORE.setTableMaxMagnitude(table, 7);
+
+  eq('re-register: table is rounded with state before removal (pre-condition)',
+    DR_STORE.getTableAppliedFlag(table), 'simplified');
+
+  // Simulate the removed-node observer's cleanup: unregisterTable is the
+  // ONLY registry call it makes (content.js's removedNodes loop).
+  DR_STORE.unregisterTable(table);
+
+  eq('re-register: hasTable is false immediately after unregisterTable',
+    DR_STORE.hasTable(table), false);
+
+  // The SAME table reference comes back (e.g. a virtualized list recycling
+  // the detached DOM node into view again). registerTable is idempotent /
+  // "found again" — it must not resurrect the old entry.
+  DR_STORE.registerTable(table);
+
+  eq('re-register: appliedFlag resets to "original" (not the leftover "simplified")',
+    DR_STORE.getTableAppliedFlag(table), 'original');
+  eq('re-register: the old per-cell original does NOT leak through (hasTableOriginal is false)',
+    DR_STORE.hasTableOriginal(table, cell), false);
+  eq('re-register: getTableOriginal for the old cell reference is undefined, not the stale record',
+    DR_STORE.getTableOriginal(table, cell), undefined);
+  eq('re-register: lastRoundOptions resets to null (not the leftover options object)',
+    DR_STORE.getTableRoundOptions(table), null);
+  eq('re-register: maxMagnitude resets to null (not the leftover frozen value)',
+    DR_STORE.getTableMaxMagnitude(table), null);
+})();
+
+// --- (h) WeakMap/Set lockstep, part 2: the removed-node MutationObserver
+// callback must find and unregister a table when the removedNodes entry is
+// an ANCESTOR of the table, not the table itself — the real production
+// callback (content.js's `_tableObserver`), not GV7's manual re-
+// implementation of its cleanup steps. Exercised by re-evaluating the
+// content-script bundle with a capturing MutationObserver installed first
+// (mirrors appModelSelection_parentEquivalence_contextmenuSelectionFlow's
+// runContextmenuFixture technique above), so `_tableObserver`'s real
+// constructor closure is the one under test. ---
+(function registrySprint_ancestorRemovalUnregistersDescendantTable() {
+  const capturedInstances = [];
+  class CapturingTableObserverMO {
+    constructor(cb) { this._cb = cb; this.disconnectCalled = false; capturedInstances.push(this); }
+    observe(target, opts) { this._target = target; this._opts = opts; }
+    disconnect() { this.disconnectCalled = true; }
+  }
+
+  const captureDoc = {
+    addEventListener() {},
+    querySelectorAll: () => [],
+    readyState: 'complete', // else-branch runs synchronously: injectTableToggles() + observe()
+    body: { appendChild() {} },
+  };
+  const captureChrome = {
+    runtime: { onMessage: { addListener() {} }, sendMessage() {} },
+  };
+  const saved = {
+    document: global.document, chrome: global.chrome, window: global.window,
+    MutationObserver: global.MutationObserver, ResizeObserver: global.ResizeObserver,
+    Node: global.Node, NodeFilter: global.NodeFilter,
+  };
+  global.document = captureDoc;
+  global.chrome = captureChrome;
+  global.window = { addEventListener() {}, getComputedStyle: () => ({ display: 'block', visibility: 'visible' }) };
+  global.MutationObserver = CapturingTableObserverMO;
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+  global.Node = { ELEMENT_NODE: 1 };
+  global.NodeFilter = { SHOW_TEXT: 4 };
+
+  try {
+    // Expose this eval's own DR_STORE/tableToggles/trackedTables bindings
+    // (distinct instances from the file-level ones the rest of the suite
+    // uses) onto globalThis so this function can drive and inspect them
+    // after eval() returns — same trick the top-of-file eval already uses.
+    eval(contentScriptBundle + `
+      globalThis.__rt_DR_STORE = DR_STORE;
+      globalThis.__rt_tableToggles = tableToggles;
+      globalThis.__rt_trackedTables = trackedTables;
+    `);
+
+    eq('ancestor removal: exactly one MutationObserver constructed (the _tableObserver watching document.body)',
+      capturedInstances.length, 1);
+    const tableObserver = capturedInstances[0];
+    eq('ancestor removal: _tableObserver.observe was called with document.body',
+      tableObserver._target === captureDoc.body, true);
+
+    const freshDR_STORE = global.__rt_DR_STORE;
+    const freshTableToggles = global.__rt_tableToggles;
+    const freshTrackedTables = global.__rt_trackedTables;
+
+    // A table nested under a container — the removedNodes record will carry
+    // the CONTAINER, never the table directly (e.g. a host page detaching a
+    // wrapping <div> that happens to hold the table, not the table itself).
+    const table = { tagName: 'TABLE', nodeType: 1 };
+    const removedButtons = [];
+    const button = { parentElement: { removeChild(b) { removedButtons.push(b); } } };
+    freshTableToggles.set(table, button);
+    freshTrackedTables.add(table);
+    freshDR_STORE.registerTable(table);
+
+    eq('ancestor removal (pre): table is registered before the removal fires',
+      freshDR_STORE.hasTable(table), true);
+
+    const container = {
+      nodeType: 1,
+      // The only DOM relationship the real removal loop consults: does this
+      // removed node CONTAIN the tracked table (a real Node.contains check
+      // on a real ancestor, stubbed here to report the containment we set up).
+      contains(el) { return el === table; },
+    };
+
+    // Fire the REAL captured callback — table itself is absent from
+    // removedNodes; only its ancestor container is.
+    tableObserver._cb([{ addedNodes: [], removedNodes: [container] }]);
+
+    eq('ancestor removal: DR_STORE.hasTable is false after the ancestor-only removal record',
+      freshDR_STORE.hasTable(table), false);
+    eq('ancestor removal: trackedTables no longer has the table',
+      freshTrackedTables.has(table), false);
+    eq('ancestor removal: the table\'s toggle button was removed from its parent',
+      removedButtons.includes(button), true);
+
+    // A DIRECT removedNodes entry (the table itself, not an ancestor) must
+    // also still work — the `table === node` half of the containment check.
+    const table2 = { tagName: 'TABLE', nodeType: 1 };
+    freshTableToggles.set(table2, { parentElement: { removeChild() {} } });
+    freshTrackedTables.add(table2);
+    freshDR_STORE.registerTable(table2);
+    tableObserver._cb([{ addedNodes: [], removedNodes: [table2] }]);
+    eq('direct removal: DR_STORE.hasTable is false when the table itself is the removedNodes entry',
+      freshDR_STORE.hasTable(table2), false);
+  } finally {
+    global.document = saved.document; global.chrome = saved.chrome; global.window = saved.window;
+    global.MutationObserver = saved.MutationObserver; global.ResizeObserver = saved.ResizeObserver;
+    global.Node = saved.Node; global.NodeFilter = saved.NodeFilter;
+  }
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -2877,7 +2877,7 @@ function makeMockButton() {
   const clickHandlers = buttonEl._listeners['click'] || [];
   clickHandlers.forEach(fn => fn({ stopPropagation() {}, type: 'click' }));
 
-  // After click: table shows originals (drShowingOriginal='true'), aria-pressed='false'
+  // After click: table shows originals (appliedFlag 'original' in DR_STORE), aria-pressed='false'
   eq('accessibility AC3: button click (mouse, was-rounded) sets aria-pressed="false"',
     buttonEl.getAttribute('aria-pressed'), 'false');
 })();
@@ -16103,21 +16103,15 @@ const LADDER_OPTS = {
   eq('recycling: the surviving cell also re-rounds correctly on peek-back',
     cellSurvivor.classList.contains('dr-ext-rounded'), true);
 
-  // REGRESSION vs parent (non-blocking, flagged for reviewer judgment):
-  // the registry's per-table `originals` map (app/store.js) is a plain Map
-  // keyed by cell element, not a WeakMap, and restoreTable/resetTable only
-  // ever iterate table.querySelectorAll('.dr-ext-rounded') — a recycled-away
-  // cell that no longer matches that selector is never visited, so its
-  // DR_STORE.deleteTableOriginal call never happens. cellA's entry survives
-  // in that Map for the life of the table's registration even though cellA
-  // itself is permanently unreachable. The parent's dataset-attribute design
-  // had no equivalent structure: a detached element's dataset simply went
-  // away with the node, with nothing left to accumulate. Under heavy
-  // virtualized-grid scroll churn (many cells recycled over a long session)
-  // this Map grows unboundedly until the table itself is unregistered — a
-  // memory-growth characteristic the parent did not have. Not a visible
-  // correctness bug (nothing renders wrong), so not blocking on its own.
-  eq('recycling REGRESSION (non-blocking): cellA\'s registry original is STILL present after it is unreachable — the per-table Map leaks recycled-away cells, unlike the parent\'s dataset-attribute design',
+  // The registry's per-table `originals` is a WeakMap keyed by cell element
+  // (app/store.js). A recycled-away cell that no longer matches the rounded
+  // selector is never visited by restoreTable, so its entry is never deleted
+  // explicitly — the WeakMap makes that safe: once nothing references the
+  // cell, the entry is collectible. This test holds cellA alive by
+  // reference, so its original stays retrievable; a genuinely unreachable
+  // cell's entry is garbage, matching the parent's dataset design where a
+  // detached element's data went away with the node.
+  eq('recycling: a live-referenced recycled cell\'s registry original stays retrievable (WeakMap keeps it while referenced, collects it when not)',
     DR_STORE.hasTableOriginal(grid.wrapperEl, cellA), true);
 })();
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -172,6 +172,14 @@ globalThis.OFFSCREEN_LEFT_PX_THRESHOLD = OFFSCREEN_LEFT_PX_THRESHOLD;
 // Expose content.js's badge/marker call-site wrapper (sprint extract-dr-table)
 // for direct unit testing.
 globalThis.markAndToggleIfNewGrid = markAndToggleIfNewGrid;
+// Expose the DR_STORE-backed originals port (app-model-registry sprint) so
+// grid-adapter tests can build an adapter the same way roundTable/
+// collectNumericCells/computeGridRoundedValues do in production — a plain
+// makeAdapter(el) with no opts uses lib/dr-table's private default port
+// instead, which is invisible to DR_STORE and would make a test's setup
+// silently diverge from what the real call sites do.
+globalThis.registryOriginalsPort = registryOriginalsPort;
+globalThis.restoreTable = restoreTable;
 `);
 
 let passed = 0;
@@ -4593,8 +4601,8 @@ function withReactiveCreateTreeWalker(fn) {
     const cell = makeReactiveCell(segsFor());
     const table = { rows: [{ cells: [cell, otherCell()] }], dataset: {} };
     roundTable(table, opts);
-    eq('sup-stale regression: cell was actually rounded (dataset.originalValue set)',
-      cell.dataset.originalValue, '1234.5678 kg9');
+    eq('sup-stale regression: cell was actually rounded (registry original.value set)',
+      DR_STORE.getTableOriginal(table, cell).value, '1234.5678 kg9');
 
     const after = collectNumericCells(table, opts);
     eq('sup-stale regression: preview sample set is unchanged after rounding',
@@ -4628,8 +4636,8 @@ function withReactiveCreateTreeWalker(fn) {
     const cell = makeReactiveCell(segsFor());
     const table = { rows: [{ cells: [cell, otherCell()] }], dataset: {} };
     roundTable(table, opts);
-    eq('linked-number-post-round regression: cell was actually rounded (dataset.originalValue set)',
-      cell.dataset.originalValue, 'Total 1234.5678 see also 51234.5678');
+    eq('linked-number-post-round regression: cell was actually rounded (registry original.value set)',
+      DR_STORE.getTableOriginal(table, cell).value, 'Total 1234.5678 see also 51234.5678');
 
     const after = collectNumericCells(table, opts);
     eq('linked-number-post-round regression: preview sample set is unchanged after rounding',
@@ -7245,32 +7253,30 @@ function withFindTargetEnv(elements, fn) {
   });
 })();
 
-// FT5: findTargetTable — returns already-tagged ancestor (.dr-ext-grid) without re-walking
-// If an ancestor already carries `dr-ext-grid`, it must be returned immediately
-// via closest('.dr-ext-grid') without calling looksLikeGrid again.
+// FT5: findTargetTable — returns already-found ancestor without re-walking
+// If an ancestor is already known per opts.isSeen (app-model-registry sprint
+// replaced the closest('.dr-ext-grid') read with an injected isSeen check —
+// see lib/dr-table/detect.js), it must be returned immediately without
+// calling looksLikeGrid again.
 (function findTargetTable_returnsAlreadyTaggedGrid() {
   withFindTargetEnv([], function() {
     const existingGrid = makeWalkEl({ display: 'flex' });
-    existingGrid.classList.add('dr-ext-grid');
 
     const clickTarget = {
       tagName: 'DIV',
       nodeType: 1,
       parentElement: existingGrid,
       parentNode: existingGrid,
-      closest: function(sel) {
-        if (sel === 'table') return null;
-        if (sel === '.dr-ext-grid') return existingGrid;
-        return null;
-      },
+      closest: function(sel) { return null; },
     };
 
-    const result = findTargetTable(clickTarget);
+    const seen = new Set([existingGrid]);
+    const result = findTargetTable(clickTarget, { isSeen: (el) => seen.has(el) });
 
-    eq('findTargetTable: returns already-tagged .dr-ext-grid ancestor immediately',
+    eq('findTargetTable: returns already-found ancestor immediately',
       result.handle, existingGrid);
-    // Already marked — the caller has already handled this one; isNew is false.
-    eq('findTargetTable: already-tagged .dr-ext-grid ancestor reports isNew: false',
+    // Already found — the caller has already handled this one; isNew is false.
+    eq('findTargetTable: already-found ancestor reports isNew: false',
       result.isNew, false);
   });
 })();
@@ -7878,7 +7884,7 @@ function makeGridWrapper(rowData, opts) {
     ['1234567', '99'],
   ]);
 
-  const adapter = makeAdapter(grid.wrapperEl);
+  const adapter = makeAdapter(grid.wrapperEl, { originalsPort: registryOriginalsPort(grid.wrapperEl) });
   const rows = adapter.getRows();
 
   // Round all cells
@@ -7888,11 +7894,11 @@ function makeGridWrapper(rowData, opts) {
     });
   });
 
-  // All cells should carry dr-ext-rounded and drOriginal
+  // All cells should carry dr-ext-rounded and a registry original
   eq('GR4 (setup): cell 0 is rounded',
     grid.cellEls[0].classList.contains('dr-ext-rounded'), true);
-  eq('GR4 (setup): cell 0 drOriginal is stored original value',
-    grid.cellEls[0].dataset.drOriginal, '8584629');
+  eq('GR4 (setup): cell 0 registry original is stored original value',
+    DR_STORE.getTableOriginal(grid.wrapperEl, grid.cellEls[0]), '8584629');
 
   // Simulate a recycled row: cell has NO .dr-ext-rounded (framework removed+readded it)
   // We model this by creating a fresh cell that was never rounded by us.
@@ -7928,8 +7934,8 @@ function makeGridWrapper(rowData, opts) {
   eq('GR4: cell 0 no longer carries dr-ext-rounded',
     grid.cellEls[0].classList.contains('dr-ext-rounded'), false);
 
-  eq('GR4: cell 0 drOriginal cleared after reset',
-    grid.cellEls[0].dataset.drOriginal, undefined);
+  eq('GR4: cell 0 registry original cleared after reset',
+    DR_STORE.getTableOriginal(grid.wrapperEl, grid.cellEls[0]), undefined);
 
   // The recycled cell was never touched by us and must not be modified
   eq('GR4: recycled cell text node untouched (framework text preserved)',
@@ -8066,22 +8072,22 @@ function makeGridWrapper(rowData, opts) {
     emptyCell.classList.contains('dr-ext-rounded'), false);
 })();
 
-// GR6e: dataset.drOriginal is stored ONCE and NOT overwritten on a second setText call
+// GR6e: the registry original is stored ONCE and NOT overwritten on a second setText call
 (function gr6e_drOriginal_storedOnce() {
   const grid = makeGridWrapper([['12345']]);
-  const adapter = makeAdapter(grid.wrapperEl);
+  const adapter = makeAdapter(grid.wrapperEl, { originalsPort: registryOriginalsPort(grid.wrapperEl) });
   const cellObj = adapter.getRows()[0].getCells()[0];
 
   // First setText: original should be stored
   cellObj.setText('12000');
-  const storedOriginal = grid.cellEls[0].dataset.drOriginal;
-  eq('GR6e: drOriginal stored on first setText',
+  const storedOriginal = DR_STORE.getTableOriginal(grid.wrapperEl, grid.cellEls[0]);
+  eq('GR6e: registry original stored on first setText',
     storedOriginal, '12345');
 
-  // Second setText (e.g. rounding again): drOriginal must NOT change
+  // Second setText (e.g. rounding again): the registry original must NOT change
   cellObj.setText('10000');
-  eq('GR6e: drOriginal NOT overwritten on second setText',
-    grid.cellEls[0].dataset.drOriginal, '12345');
+  eq('GR6e: registry original NOT overwritten on second setText',
+    DR_STORE.getTableOriginal(grid.wrapperEl, grid.cellEls[0]), '12345');
 
   // But the nodeValue IS updated
   eq('GR6e: nodeValue updated to second setText value',
@@ -8282,11 +8288,12 @@ function makeE2EGridWrapper(rowData) {
   eq('E2E-GR1: cell[0] childNodes.length unchanged after roundTable',
     cell0.childNodes.length, childCountBefore);
 
-  // drOriginal must be set on the cell element (nodeValue path).
-  eq('E2E-GR1: cell[0] dataset.drOriginal is set to original text',
-    cell0.dataset.drOriginal, originalValue);
+  // The registry original must be recorded for the cell (nodeValue path).
+  eq('E2E-GR1: cell[0] registry original is set to original text',
+    DR_STORE.getTableOriginal(grid.wrapperEl, cell0), originalValue);
 
-  // originalHtml must NOT be set (that is the native-table / extracted path).
+  // originalHtml must NOT be set (that is the native-table / extracted path,
+  // which records a { html, value, ... } record instead of a plain string).
   eq('E2E-GR1: cell[0] dataset.originalHtml is NOT set on a grid cell',
     cell0.dataset.originalHtml, undefined);
 })();
@@ -8329,9 +8336,9 @@ function makeE2EGridWrapper(rowData) {
   eq('E2E-GR2: dr-ext-rounded removed after resetTable',
     cell0.classList.contains('dr-ext-rounded'), false);
 
-  // drOriginal must be cleared.
-  eq('E2E-GR2: dataset.drOriginal cleared after resetTable',
-    cell0.dataset.drOriginal, undefined);
+  // The registry original must be cleared.
+  eq('E2E-GR2: registry original cleared after resetTable',
+    DR_STORE.getTableOriginal(grid.wrapperEl, cell0), undefined);
 
   // childNodes.length still unchanged (no innerHTML write at any point).
   eq('E2E-GR2: childNodes.length unchanged throughout (no innerHTML write)',
@@ -8401,12 +8408,12 @@ function makeE2EGridWrapper(rowData) {
   eq('E2E-GR4: pure-numeric cell text changed from original',
     numericCell.childNodes[0].nodeValue !== numericTextBefore, true);
 
-  // drOriginal set on numeric, not on mixed.
-  eq('E2E-GR4: drOriginal set on pure-numeric cell',
-    numericCell.dataset.drOriginal, numericTextBefore);
+  // Registry original set on numeric, not on mixed.
+  eq('E2E-GR4: registry original set on pure-numeric cell',
+    DR_STORE.getTableOriginal(grid.wrapperEl, numericCell), numericTextBefore);
 
-  eq('E2E-GR4: drOriginal NOT set on mixed-text cell',
-    mixedCell.dataset.drOriginal, undefined);
+  eq('E2E-GR4: registry original NOT set on mixed-text cell',
+    DR_STORE.getTableOriginal(grid.wrapperEl, mixedCell), undefined);
 })();
 
 // =============================================================================
@@ -8599,7 +8606,7 @@ function flushTimers(pendingTimers) {
 
     const tn0 = cell0.childNodes[0];
     const roundedValue = tn0.nodeValue;   // e.g. '8600000'
-    const originalValue = cell0.dataset.drOriginal;  // e.g. '8584629'
+    const originalValue = DR_STORE.getTableOriginal(grid.wrapperEl, cell0);  // e.g. '8584629'
 
     eq('GV2 (pre): roundedValue differs from original',
       roundedValue !== originalValue, true);
@@ -8809,8 +8816,8 @@ function flushTimers(pendingTimers) {
     toggleOriginalValues(grid.wrapperEl);
 
     // Flag must be set and originals restored.
-    eq('GV5b: drShowingOriginal is "true" after toggleOriginalValues',
-      grid.wrapperEl.dataset.drShowingOriginal, 'true');
+    eq('GV5b: appliedFlag is "original" after toggleOriginalValues',
+      DR_STORE.getTableAppliedFlag(grid.wrapperEl), 'original');
     eq('GV5b: cell[0] text node restored to original',
       grid.cellEls[0].childNodes[0].nodeValue, '8584629');
 
@@ -8828,8 +8835,8 @@ function flushTimers(pendingTimers) {
 
     // Toggling back on must re-round (resetTable + roundTable path).
     toggleOriginalValues(grid.wrapperEl);
-    eq('GV5b: drShowingOriginal cleared after toggling back on',
-      grid.wrapperEl.dataset.drShowingOriginal, undefined);
+    eq('GV5b: appliedFlag is "simplified" after toggling back on',
+      DR_STORE.getTableAppliedFlag(grid.wrapperEl), 'simplified');
     eq('GV5b: cell[0] re-rounded after toggling back on',
       grid.cellEls[0].childNodes[0].nodeValue !== '8584629', true);
 
@@ -9022,7 +9029,7 @@ function flushTimers(pendingTimers) {
     // Capture the rounded value so we can verify re-apply restores it.
     const tn_r1c1 = cell_r1c1.childNodes[0];
     const roundedValue_r1c1 = tn_r1c1.nodeValue;
-    const originalValue_r1c1 = cell_r1c1.dataset.drOriginal;  // '87654321'
+    const originalValue_r1c1 = DR_STORE.getTableOriginal(grid.wrapperEl, cell_r1c1);  // '87654321'
 
     eq('GV8 (pre): row-1 col-1 rounded value differs from original',
       roundedValue_r1c1 !== originalValue_r1c1, true);
@@ -9128,7 +9135,7 @@ function flushTimers(pendingTimers) {
     // Capture the rounded value for re-apply verification.
     const tn_r1c0 = cell_r1c0.childNodes[0];
     const roundedValue_r1c0 = tn_r1c0.nodeValue;
-    const originalValue_r1c0 = cell_r1c0.dataset.drOriginal;
+    const originalValue_r1c0 = DR_STORE.getTableOriginal(grid.wrapperEl, cell_r1c0);
 
     eq('GV9 (pre): row-1 col-0 rounded value differs from original',
       roundedValue_r1c0 !== originalValue_r1c0, true);
@@ -10131,7 +10138,8 @@ function withToggleDocumentMock(fn) {
 // ---------------------------------------------------------------------------
 (function pass2aria_adversarial_alreadyTagged_skipped() {
   const grid = makeAriaGrid([]);
-  grid.classList.add('dr-ext-grid'); // pre-tag it
+  grid.classList.add('dr-ext-grid'); // pre-tag it (style hook only, no longer read as state)
+  DR_STORE.registerTable(grid); // the actual "already found" signal pass 2 now checks
 
   withToggleDocumentMock(function() {
     global.document.querySelectorAll = function(sel) {
@@ -12889,31 +12897,36 @@ function fireMouseClick(buttonEl, fn) {
 
 // -------------------------------------------------------------------------
 // Issue #2: when a native table is already simplified, collectNumericCells
-// reads the stored original (dataset.originalValue) rather than the rounded
+// reads the stored original (DR_STORE's table registry, app-model-registry
+// sprint — this used to be dataset.originalValue) rather than the rounded
 // text now showing in the cell.
 // -------------------------------------------------------------------------
 (function originalValueOnSimplifiedTable() {
   // A rounded native cell: innerText shows the rounded "3,000,000" but the true
-  // original "2,794,356" is stashed on dataset.originalValue.
+  // original "2,794,356" is recorded in the registry.
   const roundedCell = {
     tagName: 'TD',
     innerText: '3,000,000',
     textContent: '3,000,000',
-    dataset: { originalValue: '2,794,356' },
+    dataset: {},
   };
   // A header row + label column keep the cell off row 0 / column 0
   // (DR_DEFAULTS excludes both by default; see the merge-ladder divergence
-  // tests below) so this stays a test of the dataset.originalValue read path,
+  // tests below) so this stays a test of the registry original read path,
   // not an incidental first-row/first-column exclusion.
   const labelCell = { tagName: 'TH', innerText: '', textContent: '' };
   const headerCell = { tagName: 'TH', innerText: 'A', textContent: 'A' };
   const rowLabelCell = { tagName: 'TH', innerText: 'Row', textContent: 'Row' };
-  const cells = collectNumericCells({
+  const mockTable = {
     rows: [
       { cells: [labelCell, headerCell] },
       { cells: [rowLabelCell, roundedCell] },
     ],
+  };
+  DR_STORE.setTableOriginal(mockTable, roundedCell, {
+    html: '2,794,356', value: '2,794,356', supRanges: null, linkFilteredIdx: null,
   });
+  const cells = collectNumericCells(mockTable);
   eq('orig-value: reads original text, not rounded',
     cells[0].text, '2,794,356');
   eq('orig-value: parses num from original, not rounded',

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -16114,6 +16114,135 @@ const LADDER_OPTS = {
     DR_STORE.hasTableOriginal(grid.wrapperEl, cellA), true);
 })();
 
+// --- (j) Content-script re-injection: DR_STORE lives in the content script's
+// JS heap, which a re-injection (extension reload/update while a tab stays
+// open) throws away and rebuilds from scratch — the live PAGE DOM survives
+// untouched (classes, text, everything the OLD script instance wrote stay
+// exactly as they were). The bundle is eval'd TWICE here against the SAME
+// fixture table/document, each eval producing its own independent DR_STORE
+// (direct eval gives let/const their own lexical environment per call — the
+// same mechanism runContextmenuFixture above already relies on), to model
+// exactly that: instance 1 rounds the table; instance 2 (fresh registry,
+// same already-rounded DOM) is what a real re-injected script would face.
+//
+// CONFIRMED via parent source (chrome-extension/content.js on
+// refactor/app-model-settings): the parent read/wrote cell.dataset.
+// originalValue/originalHtml directly on the DOM element. Because dataset
+// lives on the element, it survives re-injection the same way the rounded
+// text does — the parent's second instance recovers the true original
+// cleanly. HEAD's registry does not: this test demonstrates the true
+// original becomes UNRECOVERABLE through the UI once a second instance
+// touches the table — a reachable, non-blocking-to-notice but data-losing
+// regression, flagged prominently per the sprint's own "KNOWN ACCEPTED
+// COST" comment on restoreTable (content.js) for the reviewer's judgment. ---
+(function registrySprint_reinjectionLosesOriginalsParentRecovers() {
+  function makeReinjectionFixtureTable() {
+    const table = makeToggleTable([
+      [{ tag: 'td', text: 'Label' }, { tag: 'td', text: 'Values' }],
+      [{ tag: 'td', text: 'Row' },   { tag: 'td', text: '12,345' }],
+    ]);
+    // Link innerHTML/innerText/textContent to one backing value on the data
+    // cell, matching a real <td>'s single-node-tree-backed semantics (same
+    // fix angle (f)'s test needed, for the same reason: restoreTable writes
+    // innerHTML only, and getText()/the fake tree walker below read innerText).
+    const dataCell = table._cells[3];
+    let _text = dataCell.innerHTML;
+    Object.defineProperties(dataCell, {
+      innerHTML: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+      innerText: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+      textContent: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+    });
+    return { table, dataCell };
+  }
+
+  const { table, dataCell } = makeReinjectionFixtureTable();
+  const trueOriginal = '12,345';
+
+  // A minimal document shared by BOTH eval'd instances — this is the "live
+  // page" that persists across the simulated re-injection. createTreeWalker
+  // mirrors withCreateTreeWalker's single-fake-text-node approach, reading
+  // and writing through the SAME linked innerText/innerHTML property.
+  const sharedDoc = {
+    addEventListener() {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: { appendChild() {} },
+    createTreeWalker(cell) {
+      let done = false;
+      return {
+        nextNode() {
+          if (done) return null;
+          done = true;
+          return {
+            get nodeValue() { return cell.innerText; },
+            set nodeValue(v) { cell.innerText = v; cell.textContent = v; },
+          };
+        },
+      };
+    },
+  };
+  const saved = {
+    document: global.document, chrome: global.chrome, window: global.window,
+    MutationObserver: global.MutationObserver, ResizeObserver: global.ResizeObserver,
+    Node: global.Node, NodeFilter: global.NodeFilter,
+  };
+  global.document = sharedDoc;
+  global.chrome = { runtime: { onMessage: { addListener() {} }, sendMessage() {} } };
+  global.window = { addEventListener() {}, getComputedStyle: () => ({ display: 'block', visibility: 'visible' }) };
+  global.MutationObserver = class { observe() {} disconnect() {} };
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+  global.Node = { ELEMENT_NODE: 1 };
+  global.NodeFilter = { SHOW_TEXT: 4 };
+
+  try {
+    // --- Instance 1: the content script as originally injected. Rounds the
+    // table directly (bypassing detection/UI wiring, irrelevant to this
+    // mechanism) with DR_DEFAULTS, same as runToggleAction's fresh-round path. ---
+    eval(contentScriptBundle + `
+      globalThis.__ri1_roundTable = roundTable;
+      globalThis.__ri1_isTableRounded = isTableRounded;
+    `);
+    global.__ri1_roundTable(table, DR_DEFAULTS);
+    const roundedText = dataCell.innerText;
+
+    eq('re-injection (pre): instance 1 actually rounded the cell away from the true original',
+      roundedText !== trueOriginal, true);
+    eq('re-injection (pre): instance 1 reports the table as rounded',
+      global.__ri1_isTableRounded(table), true);
+
+    // --- Instance 2: simulates re-injection. The DOM is untouched (dataCell
+    // still shows roundedText, still carries dr-ext-rounded) but this eval's
+    // DR_STORE is BRAND NEW — instance 1's registry (and its stored true
+    // original) is unreachable garbage now, exactly as a real content-script
+    // reload would leave it. ---
+    eval(contentScriptBundle + `
+      globalThis.__ri2_isTableRounded = isTableRounded;
+      globalThis.__ri2_resetTable = resetTable;
+      globalThis.__ri2_DR_STORE = DR_STORE;
+    `);
+
+    eq('re-injection: a fresh instance reports the table as NOT rounded, despite the DOM still showing rounded text — a state/display mismatch the moment re-injection happens',
+      global.__ri2_isTableRounded(table), false);
+
+    // The user's most natural recovery action is "reset" (or an equivalent
+    // toggle-to-original click). Drive the SAME production primitive
+    // (resetTable) the sprint's own restoreTable KNOWN ACCEPTED COST comment
+    // discusses.
+    global.__ri2_resetTable(table);
+
+    eq('re-injection: after reset, the dr-ext-rounded marker IS cleared (the UI looks "back to normal")',
+      dataCell.classList.contains('dr-ext-rounded'), false);
+    eq('re-injection REGRESSION (reachable, non-blocking to notice, DATA-LOSING — reviewer judgment requested): the displayed text after "reset" is STILL the rounded value, not the true original — the true original is unrecoverable through the UI from this point on',
+      dataCell.innerText, roundedText);
+    eq('re-injection REGRESSION corollary: the value is provably NOT the true original',
+      dataCell.innerText !== trueOriginal, true);
+  } finally {
+    global.document = saved.document; global.chrome = saved.chrome; global.window = saved.window;
+    global.MutationObserver = saved.MutationObserver; global.ResizeObserver = saved.ResizeObserver;
+    global.Node = saved.Node; global.NodeFilter = saved.NodeFilter;
+  }
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1939,11 +1939,21 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
   eq('unified: data-rounded-value attribute no longer written',
     /data-rounded-value|dataset\.roundedValue/.test(contentSrc), false);
 
-  eq('unified: data-original-html attribute is written',
-    /dataset\.originalHtml\s*=/.test(contentSrc), true);
+  // app-model-registry sprint: native-table originals (html/value/supRanges/
+  // linkFilteredIdx) and the per-table round options moved off page
+  // attributes / a file-level WeakMap into DR_STORE's table registry — see
+  // the "table registry" test section below for the full replacement suite.
+  eq('unified (superseded by app-model-registry): dataset.originalHtml is no longer written',
+    /dataset\.originalHtml\s*=/.test(contentSrc), false);
 
-  eq('unified: per-table options WeakMap declared',
-    /const\s+tableOptions\s*=\s*new\s+WeakMap/.test(contentSrc), true);
+  eq('registry: native-table originals are recorded via DR_STORE.setTableOriginal',
+    /DR_STORE\.setTableOriginal\(\s*table\s*,\s*cell\s*,\s*\{\s*html:/.test(contentSrc), true);
+
+  eq('unified (superseded by app-model-registry): tableOptions WeakMap no longer declared',
+    /const\s+tableOptions\s*=\s*new\s+WeakMap/.test(contentSrc), false);
+
+  eq('registry: round options are recorded via DR_STORE.setTableRoundOptions',
+    /DR_STORE\.setTableRoundOptions\(table,\s*opts\)/.test(contentSrc), true);
 
   eq('unified: toggleOriginalValues calls roundTable for original→rounded path',
     /function toggleOriginalValues[\s\S]{0,500}roundTable\(/.test(contentSrc), true);
@@ -2173,23 +2183,26 @@ function makeMockButton() {
 // --- AC5: isTableRounded returns true after roundTable marks cells ---
 
 (function atToggle_isTableRounded_afterRound() {
-  // Directly inject the rounded class to simulate a rounded table (don't run
-  // the full roundTable pipeline which requires tree walkers etc.)
+  // Directly inject the rounded class AND set the registry's appliedFlag to
+  // simulate a rounded table (don't run the full roundTable pipeline which
+  // requires tree walkers etc.) — isTableRounded reads DR_STORE's appliedFlag
+  // (app-model-registry sprint), not the class, so both are set here the way
+  // roundTable itself would leave them.
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
-  // Manually mark the cell as rounded — this is what roundTable does.
   table._cells[0].classList.add('dr-ext-rounded');
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
   eq('auto-table-toggle: isTableRounded(table with .dr-ext-rounded cell) is true',
     isTableRounded(table), true);
 })();
 
-// --- AC5: isTableRounded returns false when drShowingOriginal === 'true' ---
+// --- AC5: isTableRounded returns false when appliedFlag !== 'simplified' ---
 // (toggleOriginalValues sets this; the table still has rounded cells but is showing originals)
 
 (function atToggle_isTableRounded_showingOriginal() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   table._cells[0].classList.add('dr-ext-rounded');
-  table.dataset.drShowingOriginal = 'true';
-  eq('auto-table-toggle: isTableRounded is false when drShowingOriginal===true',
+  DR_STORE.setTableAppliedFlag(table, 'original');
+  eq('auto-table-toggle: isTableRounded is false when appliedFlag is "original"',
     isTableRounded(table), false);
 })();
 
@@ -2198,10 +2211,15 @@ function makeMockButton() {
 
 (function atToggle_isTableRounded_afterToggleOff() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
-  // Simulate a post-roundTable state: cell has rounded class + originalHtml
+  // Simulate a post-roundTable state: cell has rounded class + a registry
+  // original record (app-model-registry sprint — this used to be
+  // cell.dataset.originalHtml), and the registry's appliedFlag is
+  // 'simplified' so toggleOriginalValues reads it as currently-rounded and
+  // takes the "hide" branch.
   const cell = table._cells[0];
   cell.classList.add('dr-ext-rounded');
-  cell.dataset.originalHtml = '1,000';
+  DR_STORE.setTableOriginal(table, cell, { html: '1,000', value: '1,000', supRanges: null, linkFilteredIdx: null });
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
   cell.innerHTML = '1,000';
   // Also need to stub innerHTML setter so toggleOriginalValues can restore it
   Object.defineProperty(cell, 'innerHTML', {
@@ -2213,13 +2231,13 @@ function makeMockButton() {
   // Inject toggle entry (proper button stub) so syncSwitchForTable doesn't crash
   injectToggleEntry(table);
 
-  // Calling toggleOriginalValues (showingOriginal=false path) sets drShowingOriginal='true'
+  // Calling toggleOriginalValues (showingOriginal=false path) sets appliedFlag='original'
   toggleOriginalValues(table);
 
   eq('auto-table-toggle: after toggleOriginalValues, isTableRounded is false',
     isTableRounded(table), false);
-  eq('auto-table-toggle: after toggleOriginalValues, drShowingOriginal is "true"',
-    table.dataset.drShowingOriginal, 'true');
+  eq('auto-table-toggle: after toggleOriginalValues, appliedFlag is "original"',
+    DR_STORE.getTableAppliedFlag(table), 'original');
 })();
 
 // --- AC6: syncSwitchForTable sets aria-pressed on the button to match isTableRounded ---
@@ -2241,6 +2259,7 @@ function makeMockButton() {
 
   // Mark table as rounded
   table._cells[0].classList.add('dr-ext-rounded');
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
 
   syncSwitchForTable(table);
   eq('auto-table-toggle: syncSwitchForTable sets aria-pressed="true" on rounded table',
@@ -2251,7 +2270,7 @@ function makeMockButton() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   const button = injectToggleEntry(table);
   table._cells[0].classList.add('dr-ext-rounded');
-  table.dataset.drShowingOriginal = 'true';
+  DR_STORE.setTableAppliedFlag(table, 'original');
   button.setAttribute('aria-pressed', 'true');
 
   syncSwitchForTable(table);
@@ -2519,7 +2538,8 @@ function makeMockButton() {
   const table = makeToggleTable([{ tag: 'td', text: '8,500,000' }]);
   const cell = table._cells[0];
   cell.classList.add('dr-ext-rounded');
-  cell.dataset.originalHtml = '8,584,629';
+  DR_STORE.setTableOriginal(table, cell, { html: '8,584,629', value: '8,584,629', supRanges: null, linkFilteredIdx: null });
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
 
   // The cell's innerHTML property needs to be writable
   let htmlVal = cell.innerHTML;
@@ -2533,9 +2553,9 @@ function makeMockButton() {
 
   runToggleAction(table);
 
-  // After toggling off: drShowingOriginal must be 'true' (AC4)
-  eq('auto-table-toggle: runToggleAction on rounded table sets drShowingOriginal=true (AC4)',
-    table.dataset.drShowingOriginal, 'true');
+  // After toggling off: appliedFlag must be 'original' (AC4)
+  eq('auto-table-toggle: runToggleAction on rounded table sets appliedFlag=original (AC4)',
+    DR_STORE.getTableAppliedFlag(table), 'original');
   // aria-pressed should be "false" — table is now showing originals, not rounded
   eq('auto-table-toggle: aria-pressed="false" after toggle-off via runToggleAction',
     input.getAttribute('aria-pressed'), 'false');
@@ -3590,6 +3610,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 (function morphAC_syncSwitch_roundedTable() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   table._cells[0].classList.add('dr-ext-rounded');
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
   const button = injectToggleEntry(table);
   syncSwitchForTable(table);
   eq('expanding-toggle: syncSwitchForTable rounded table → aria-pressed="true"',
@@ -14377,7 +14398,7 @@ const LADDER_OPTS = {
   };
   const contentTopLevelNames = topLevelBindingNames(contentSrcForScan);
   eq('static scan: content.js still declares its usual top-level bindings (sanity check on the scan itself)',
-    contentTopLevelNames.includes('lastRightClickedElement') && contentTopLevelNames.includes('tableOptions'),
+    contentTopLevelNames.includes('lastRightClickedElement') && contentTopLevelNames.includes('gridObservers'),
     true);
   eq('static scan: content.js no longer declares lastRightClickedTable or sidebarOpen at top level',
     contentTopLevelNames.includes('lastRightClickedTable') || contentTopLevelNames.includes('sidebarOpen'),
@@ -14397,11 +14418,18 @@ const LADDER_OPTS = {
   // anti-pattern this sprint removed) would slip through undetected. Close
   // that gap by scanning for writes to DR_STORE's own private field names,
   // read directly from app/store.js rather than from content.js.
-  const storeFieldNames = Array.from(storeSrc.matchAll(/\b(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g))
+  //
+  // The field declarations sit one level inside the IIFE (2-space indent);
+  // anchoring on that indentation (rather than a bare \b(?:let|const) scan
+  // anywhere in the file) is what keeps this from also matching the `const
+  // entry = ...` locals declared inside the table-registry getters/setters
+  // (app-model-registry sprint) — those are per-call temporaries, not fields.
+  const storeFieldNames = Array.from(storeSrc.matchAll(/^ {2}(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)/gm))
     .map((m) => m[1])
     .filter((name) => name !== 'DR_STORE');
-  eq('static scan: app/store.js declares its three private fields (sanity check on the scan itself)',
-    storeFieldNames.slice().sort(), ['selectedTable', 'sidebarOpen', 'settings'].sort());
+  eq('static scan: app/store.js declares its five private fields (sanity check on the scan itself)',
+    storeFieldNames.slice().sort(),
+    ['registeredTables', 'selectedTable', 'settings', 'sidebarOpen', 'tableRegistry'].sort());
   const storeFieldWrites = storeFieldNames.filter((name) => {
     const assignRe = new RegExp('\\b' + name + '\\s*=[^=]');
     return assignRe.test(uiToggleSrcForScan) || assignRe.test(contentSrcForScan);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -3635,10 +3635,10 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 (function morphAC_syncSwitch_showingOriginal() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   table._cells[0].classList.add('dr-ext-rounded');
-  table.dataset.drShowingOriginal = 'true';
+  DR_STORE.setTableAppliedFlag(table, 'original');
   const button = injectToggleEntry(table);
   syncSwitchForTable(table);
-  eq('expanding-toggle: syncSwitchForTable drShowingOriginal=true → aria-pressed="false"',
+  eq('expanding-toggle: syncSwitchForTable appliedFlag=\'original\' (showing originals) with a rounded cell present → aria-pressed="false"',
     button.getAttribute('aria-pressed'), 'false');
 })();
 

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -15716,6 +15716,109 @@ const LADDER_OPTS = {
   });
 })();
 
+// --- (f) Grid magnitude basis freeze: DELIBERATE BEHAVIOR CHANGE from the
+// parent branch (refactor/app-model-settings), where computeGridRoundedValues
+// took no frozenMaxMag parameter and reapplyGridRounding recomputed max_mag
+// from whatever was visible on every scroll re-apply. HEAD's roundTable
+// freezes max_mag on first sight into DR_STORE.setTableMaxMagnitude and every
+// later reapplyGridRounding reuses that frozen value (see content.js's
+// frozenMaxMag doc on computeGridRoundedValues). offsetTop/offsetOther are
+// deliberately set apart so a magnitude-driven bucket flip is visible in the
+// formatted output, not just in the stored number. ---
+(function registrySprint_gridMagnitudeFrozenAtFirstSight() {
+  let ctx;
+  try {
+    const opts = { offsetTop: -1, offsetOther: 0, numTop: 1 };
+    // Sole visible row at first sight: magnitude 2 (555) — freezes max_mag at 2.
+    ctx = setupVirtGrid([['555']], opts);
+    const { grid, pendingTimers } = ctx;
+    const cell555 = grid.cellEls[0];
+
+    eq('magnitude freeze: 555 rounds via offsetTop (max_mag=2, within numTop of itself)',
+      cell555.childNodes[0].nodeValue, '560');
+    eq('magnitude freeze: DR_STORE freezes maxMagnitude at 2 on first sight',
+      DR_STORE.getTableMaxMagnitude(grid.wrapperEl), 2);
+
+    // Simulate scroll bringing a magnitude-9 row into view alongside the
+    // still-visible 555 row — appended to the wrapper's children, the
+    // fallback _getRowEls path this unlabelled-grid shape uses.
+    const hugeCell = makeGridCellWithTextNode('5000000000');
+    const hugeRow = makeElementNode('row', [hugeCell]);
+    hugeRow.dataset = { row: '1' };
+    hugeRow.children = [hugeCell];
+    grid.wrapperEl.children.push(hugeRow);
+
+    const obs = ctx.capturedObserver;
+    obs.trigger([{ type: 'characterData', target: cell555.childNodes[0] }]);
+    flushTimers(pendingTimers);
+
+    // If the basis recomputed from the now-visible magnitude-9 row (the
+    // parent's behavior), 555 would fall out of the top bucket and round to
+    // "600" (offsetOther) instead. HEAD must keep "560".
+    eq('magnitude freeze: after a scroll-triggered reapply exposing a magnitude-9 row, 555 KEEPS the magnitude-2 basis ("560"), not a recomputed magnitude-9 basis ("600")',
+      cell555.childNodes[0].nodeValue, '560');
+    eq('magnitude freeze: DR_STORE.getTableMaxMagnitude never shifts off the frozen value',
+      DR_STORE.getTableMaxMagnitude(grid.wrapperEl), 2);
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
+// --- (f) continued: a peek-to-original-and-back round trip goes through
+// toggleOriginalValues' resetTable()+roundTable() path, which clears the
+// frozen basis (resetTable sets maxMagnitude back to null) and re-freezes
+// fresh from whatever is visible at the moment of toggling back — it does
+// NOT preserve the basis established by the original round. This is the
+// registry's actual behavior, documented here so a reviewer can judge
+// whether "frozen at first sight" was meant to survive a peek round trip. ---
+(function registrySprint_toggleRoundTripReFreezesRatherThanPreserving() {
+  let ctx;
+  try {
+    const opts = { offsetTop: -1, offsetOther: 0, numTop: 1 };
+    ctx = setupVirtGrid([['555']], opts);
+    const { grid } = ctx;
+    const cell555 = grid.cellEls[0];
+
+    eq('toggle round trip: initial freeze is at max_mag=2 ("560")',
+      cell555.childNodes[0].nodeValue, '560');
+    eq('toggle round trip: DR_STORE holds the frozen basis before any toggle',
+      DR_STORE.getTableMaxMagnitude(grid.wrapperEl), 2);
+
+    // Scroll in a magnitude-9 row BEFORE peeking, so the "first sight" the
+    // re-round sees on toggle-back is the magnitude-9 view, not the original
+    // magnitude-2 view.
+    const hugeCell = makeGridCellWithTextNode('5000000000');
+    const hugeRow = makeElementNode('row', [hugeCell]);
+    hugeRow.dataset = { row: '1' };
+    hugeRow.children = [hugeCell];
+    grid.wrapperEl.children.push(hugeRow);
+
+    toggleOriginalValues(grid.wrapperEl); // peek at originals
+    eq('toggle round trip: peeking to original clears the display back to "555"',
+      cell555.childNodes[0].nodeValue, '555');
+
+    toggleOriginalValues(grid.wrapperEl); // peek back to rounded
+    eq('toggle round trip: DR_STORE re-freezes from the now-visible magnitude-9 row (9), not the original magnitude-2 basis',
+      DR_STORE.getTableMaxMagnitude(grid.wrapperEl), 9);
+    // Under the re-frozen (9) basis, current_mag(555)=2, max_mag-current_mag=7
+    // >= numTop(1), so 555 now takes offsetOther ("600") — a DIFFERENT
+    // rendered value than the original round produced ("560"), purely
+    // because of what happened to be visible at toggle-back time.
+    eq('toggle round trip: 555 renders differently after the round trip than its original round ("600", not "560")',
+      cell555.childNodes[0].nodeValue, '600');
+  } finally {
+    if (ctx) {
+      global.MutationObserver = ctx.origMO;
+      global.setTimeout = ctx.origSetTimeout;
+      global.clearTimeout = ctx.origClearTimeout;
+    }
+  }
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -15819,6 +15819,68 @@ const LADDER_OPTS = {
   }
 })();
 
+// --- (g) TABLE_TOGGLE_STATE sequence: isTableRounded (claim 4 — now reading
+// DR_STORE's appliedFlag instead of a dr-ext-rounded/dataset.drShowingOriginal
+// pair) must report correctly to the sidebar across a full round -> peek-
+// original -> peek-back cycle, not just a single toggle. The pillbox-sprint
+// AC1 test above pins one click; the toggle-split parent-equivalence guard
+// matrix pins one intent:toggleTable dispatch. Neither exercises the 3-step
+// peek cycle this sprint's registry model actually has to get right. ---
+(function registrySprint_tableToggleStateAcrossPeekCycle() {
+  const savedSelected = DR_STORE.getSelectedTable();
+  const savedOpen = DR_STORE.isSidebarOpen();
+  const sent = [];
+  const origSend = global.chrome.runtime.sendMessage;
+  global.chrome.runtime.sendMessage = (msg) => { sent.push(msg); };
+
+  try {
+    const table = makeToggleTable([
+      [{ tag: 'td', text: 'Label' }, { tag: 'td', text: 'Values' }],
+      [{ tag: 'td', text: 'Row' },   { tag: 'td', text: '12,345' }],
+    ]);
+    injectToggleEntry(table);
+    DR_STORE.setSelectedTable(table);
+    DR_STORE.setSidebarOpen(true);
+
+    // makeToggleTableCell gives innerHTML/innerText/textContent as three
+    // INDEPENDENT properties. A real <td>'s innerHTML/innerText/textContent
+    // all derive from the same child-node tree, so writing one (restoreTable's
+    // `cell.innerHTML = original.html`) is immediately visible through the
+    // others (roundTable's re-classification reads getText() -> innerText).
+    // Without this link the mock desyncs after the peek-original restore:
+    // innerHTML goes back to '12,345' but innerText stays on the stale
+    // rounded string, so the round-trip's re-round misclassifies the cell as
+    // already-rounded and skips it — a fixture artifact, not a product bug
+    // (see the identical link in registrySprint_originalsSurviveToggleCycle
+    // above, needed for the same reason on the 2-toggle case).
+    const dataCell = table._cells[3]; // row1/col1: 'Row' | '12,345'
+    let _text = dataCell.innerHTML;
+    Object.defineProperties(dataCell, {
+      innerHTML: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+      innerText: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+      textContent: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
+    });
+
+    withCreateTreeWalker(function () {
+      DR_BUS.publish('intent:toggleTable', { table }); // round
+      DR_BUS.publish('intent:toggleTable', { table }); // peek original
+      DR_BUS.publish('intent:toggleTable', { table }); // peek back
+    });
+
+    const toggleMsgs = sent.filter(m => m.action === 'TABLE_TOGGLE_STATE');
+    eq('toggle-state cycle: exactly one TABLE_TOGGLE_STATE per dispatch (3 total)',
+      toggleMsgs.length, 3);
+    eq('toggle-state cycle: enabled sequence is true (rounded), false (peek original), true (peek back)',
+      toggleMsgs.map(m => m.enabled), [true, false, true]);
+    eq('toggle-state cycle: isTableRounded agrees with the last reported state',
+      isTableRounded(table), true);
+  } finally {
+    global.chrome.runtime.sendMessage = origSend;
+    DR_STORE.setSelectedTable(savedSelected);
+    DR_STORE.setSidebarOpen(savedOpen);
+  }
+})();
+
 // --- Report ---
 console.log(`Passed: ${passed}`);
 console.log(`Failed: ${failed}`);

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1964,7 +1964,7 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     /DR_STORE\.setTableRoundOptions\(table,\s*opts\)/.test(contentSrc), true);
 
   eq('unified: toggleOriginalValues calls roundTable for original→rounded path',
-    /function toggleOriginalValues[\s\S]{0,500}roundTable\(/.test(contentSrc), true);
+    /function toggleOriginalValues[\s\S]{0,1500}roundTable\(/.test(contentSrc), true);
 
   // --- Display simplification: "35.0" → "35" when value unchanged but format would ---
 
@@ -2864,7 +2864,14 @@ function makeMockButton() {
   Object.defineProperty(cell, 'innerHTML', {
     get(){return htmlVal;}, set(v){htmlVal=v;}, configurable: true
   });
-  cell.dataset.originalHtml = '50000';
+  // Registry-backed setup (app-model-registry sprint): restoreTable reads
+  // the pre-round original from DR_STORE, not a dataset attribute, so the
+  // fixture must register one for the cell to be genuinely restorable — a
+  // dr-ext-rounded class with no registry entry is the unrestorable case
+  // (see the content-script re-injection tests), which is a different
+  // scenario than the one this test means to exercise.
+  DR_STORE.setTableOriginal(table, cell, { html: '50000', value: '50000', supRanges: null, linkFilteredIdx: null });
+  DR_STORE.setTableAppliedFlag(table, 'simplified');
 
   // Fire click via handlers
   const clickHandlers = buttonEl._listeners['click'] || [];
@@ -16119,27 +16126,28 @@ const LADDER_OPTS = {
 // open) throws away and rebuilds from scratch — the live PAGE DOM survives
 // untouched (classes, text, everything the OLD script instance wrote stay
 // exactly as they were). The bundle is eval'd TWICE here against the SAME
-// fixture table/document, each eval producing its own independent DR_STORE
+// fixture tables/document, each eval producing its own independent DR_STORE
 // (direct eval gives let/const their own lexical environment per call — the
 // same mechanism runContextmenuFixture above already relies on), to model
-// exactly that: instance 1 rounds the table; instance 2 (fresh registry,
+// exactly that: instance 1 rounds the tables; instance 2 (fresh registry,
 // same already-rounded DOM) is what a real re-injected script would face.
 //
-// CONFIRMED via parent source (chrome-extension/content.js on
-// refactor/app-model-settings): the parent read/wrote cell.dataset.
-// originalValue/originalHtml directly on the DOM element. Because dataset
-// lives on the element, it survives re-injection the same way the rounded
-// text does — the parent's second instance recovers the true original
-// cleanly. HEAD's registry does not: this test demonstrates the true
-// original becomes UNRECOVERABLE through the UI once a second instance
-// touches the table — a reachable, non-blocking-to-notice but data-losing
-// regression, flagged prominently per the sprint's own "KNOWN ACCEPTED
-// COST" comment on restoreTable (content.js) for the reviewer's judgment. ---
-(function registrySprint_reinjectionLosesOriginalsParentRecovers() {
-  function makeReinjectionFixtureTable() {
+// A re-injected instance still cannot recover the true original from its
+// own (empty) registry — that half of the KNOWN ACCEPTED COST comment on
+// restoreTable (content.js) holds. What this test pins is the consequence
+// the sprint did NOT accept: an unrestorable cell must be left exactly as
+// found — marker, title, and text untouched — instead of resetTable
+// stripping the marker and title off a cell it could not actually restore,
+// and instead of toggleOriginalValues then re-running roundTable over
+// already-rounded text and stamping a FALSE "Original: ..." title over the
+// one attribute that still held the truth. Scenario A drives resetTable
+// directly (the "reset" recovery action); scenario B drives the actual
+// toggle-click wiring end to end. ---
+(function registrySprint_reinjectionUnrestorableResetStaysTruthful() {
+  function makeReinjectionFixtureTable(dataText) {
     const table = makeToggleTable([
       [{ tag: 'td', text: 'Label' }, { tag: 'td', text: 'Values' }],
-      [{ tag: 'td', text: 'Row' },   { tag: 'td', text: '12,345' }],
+      [{ tag: 'td', text: 'Row' },   { tag: 'td', text: dataText }],
     ]);
     // Link innerHTML/innerText/textContent to one backing value on the data
     // cell, matching a real <td>'s single-node-tree-backed semantics (same
@@ -16152,21 +16160,34 @@ const LADDER_OPTS = {
       innerText: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
       textContent: { get() { return _text; }, set(v) { _text = v; }, configurable: true },
     });
+    // A real removeAttribute('title') clears the title. makeToggleTableCell's
+    // default stub is a no-op, which would hide exactly the bug this test
+    // exists to catch — an implementation that unconditionally strips the
+    // title would otherwise leave dataCell.title looking untouched.
+    dataCell.removeAttribute = function (name) {
+      if (name === 'title') this.title = '';
+    };
     return { table, dataCell };
   }
 
-  const { table, dataCell } = makeReinjectionFixtureTable();
-  const trueOriginal = '12,345';
+  const { table: table1, dataCell: dataCell1 } = makeReinjectionFixtureTable('12,345');
+  const { table: table2, dataCell: dataCell2 } = makeReinjectionFixtureTable('67,890');
+  const trueOriginal1 = '12,345';
+  const trueOriginal2 = '67,890';
 
-  // A minimal document shared by BOTH eval'd instances — this is the "live
-  // page" that persists across the simulated re-injection. createTreeWalker
-  // mirrors withCreateTreeWalker's single-fake-text-node approach, reading
-  // and writing through the SAME linked innerText/innerHTML property.
+  // A minimal document shared by every eval'd instance below — this is the
+  // "live page" that persists across the simulated re-injection.
+  // createTreeWalker mirrors withCreateTreeWalker's single-fake-text-node
+  // approach, reading and writing through the SAME linked innerText/
+  // innerHTML property. createElement/head back ensureHighlightStyleInjected,
+  // which scenario B (the real click path) exercises for real.
   const sharedDoc = {
     addEventListener() {},
     querySelectorAll: () => [],
     readyState: 'complete',
     body: { appendChild() {} },
+    head: { appendChild() {} },
+    createElement() { return { textContent: '' }; },
     createTreeWalker(cell) {
       let done = false;
       return {
@@ -16195,47 +16216,75 @@ const LADDER_OPTS = {
   global.NodeFilter = { SHOW_TEXT: 4 };
 
   try {
-    // --- Instance 1: the content script as originally injected. Rounds the
-    // table directly (bypassing detection/UI wiring, irrelevant to this
-    // mechanism) with DR_DEFAULTS, same as runToggleAction's fresh-round path. ---
+    // --- Instance 1: the content script as originally injected. Rounds
+    // both fixture tables directly (bypassing detection/UI wiring,
+    // irrelevant to this mechanism) with DR_DEFAULTS, same as
+    // runToggleAction's fresh-round path. ---
     eval(contentScriptBundle + `
       globalThis.__ri1_roundTable = roundTable;
       globalThis.__ri1_isTableRounded = isTableRounded;
     `);
-    global.__ri1_roundTable(table, DR_DEFAULTS);
-    const roundedText = dataCell.innerText;
+    global.__ri1_roundTable(table1, DR_DEFAULTS);
+    global.__ri1_roundTable(table2, DR_DEFAULTS);
+    const roundedText1 = dataCell1.innerText;
+    const roundedTitle1 = dataCell1.title;
+    const roundedText2 = dataCell2.innerText;
+    const roundedTitle2 = dataCell2.title;
 
     eq('re-injection (pre): instance 1 actually rounded the cell away from the true original',
-      roundedText !== trueOriginal, true);
+      roundedText1 !== trueOriginal1, true);
     eq('re-injection (pre): instance 1 reports the table as rounded',
-      global.__ri1_isTableRounded(table), true);
+      global.__ri1_isTableRounded(table1), true);
+    eq('re-injection (pre): the title attribute holds the true original',
+      roundedTitle1, `Original: ${trueOriginal1}`);
 
-    // --- Instance 2: simulates re-injection. The DOM is untouched (dataCell
-    // still shows roundedText, still carries dr-ext-rounded) but this eval's
-    // DR_STORE is BRAND NEW — instance 1's registry (and its stored true
-    // original) is unreachable garbage now, exactly as a real content-script
-    // reload would leave it. ---
+    // --- Instance 2: simulates re-injection. The DOM is untouched (both
+    // data cells still show their rounded text, still carry
+    // dr-ext-rounded) but this eval's DR_STORE is BRAND NEW — instance 1's
+    // registry (and its stored true originals) is unreachable garbage now,
+    // exactly as a real content-script reload would leave it. ---
     eval(contentScriptBundle + `
       globalThis.__ri2_isTableRounded = isTableRounded;
       globalThis.__ri2_resetTable = resetTable;
       globalThis.__ri2_DR_STORE = DR_STORE;
+      globalThis.__ri2_DR_BUS = DR_BUS;
     `);
 
     eq('re-injection: a fresh instance reports the table as NOT rounded, despite the DOM still showing rounded text — a state/display mismatch the moment re-injection happens',
-      global.__ri2_isTableRounded(table), false);
+      global.__ri2_isTableRounded(table1), false);
 
-    // The user's most natural recovery action is "reset" (or an equivalent
-    // toggle-to-original click). Drive the SAME production primitive
-    // (resetTable) the sprint's own restoreTable KNOWN ACCEPTED COST comment
-    // discusses.
-    global.__ri2_resetTable(table);
+    // --- Scenario A: the user's most natural recovery action is "reset"
+    // (or an equivalent toggle-to-original click). Drive the SAME
+    // production primitive (resetTable) the sprint's own restoreTable
+    // KNOWN ACCEPTED COST comment discusses. ---
+    const unrestorableCount = global.__ri2_resetTable(table1);
 
-    eq('re-injection: after reset, the dr-ext-rounded marker IS cleared (the UI looks "back to normal")',
-      dataCell.classList.contains('dr-ext-rounded'), false);
-    eq('re-injection REGRESSION (reachable, non-blocking to notice, DATA-LOSING — reviewer judgment requested): the displayed text after "reset" is STILL the rounded value, not the true original — the true original is unrecoverable through the UI from this point on',
-      dataCell.innerText, roundedText);
-    eq('re-injection REGRESSION corollary: the value is provably NOT the true original',
-      dataCell.innerText !== trueOriginal, true);
+    eq('re-injection reset: resetTable reports the one cell it could not restore',
+      unrestorableCount, 1);
+    eq('re-injection reset: the dr-ext-rounded marker SURVIVES — the screen still shows rounded text, so the marker must stay truthful instead of claiming a clean reset that did not happen',
+      dataCell1.classList.contains('dr-ext-rounded'), true);
+    eq('re-injection reset: the title attribute SURVIVES — it is the last remaining copy of the true original and must not be stripped when nothing was actually restored',
+      dataCell1.title, roundedTitle1);
+    eq('re-injection reset: the displayed text is unchanged — not falsely "restored"',
+      dataCell1.innerText, roundedText1);
+    eq('re-injection reset: appliedFlag stays \'simplified\' — the truthful state, since the screen still shows rounded text',
+      global.__ri2_DR_STORE.getTableAppliedFlag(table1), 'simplified');
+
+    // --- Scenario B: the toggle-click path (not covered before this fix) —
+    // drives the exact wiring a real click on the toggle switch uses
+    // (ui-toggle.js's click handler publishes this same intent), end to
+    // end through content.js's intent:toggleTable subscriber,
+    // runToggleAction, and toggleOriginalValues. One click on a
+    // re-injected, already-rounded table must not double-round the text or
+    // stamp a false title over it. ---
+    global.__ri2_DR_BUS.publish('intent:toggleTable', { table: table2 });
+
+    eq('re-injection click path: one click after re-injection does not strip the dr-ext-rounded marker',
+      dataCell2.classList.contains('dr-ext-rounded'), true);
+    eq('re-injection click path: one click does not rewrite the title with a false original (no double-round)',
+      dataCell2.title, roundedTitle2);
+    eq('re-injection click path: one click leaves the displayed text unchanged',
+      dataCell2.innerText, roundedText2);
   } finally {
     global.document = saved.document; global.chrome = saved.chrome; global.window = saved.window;
     global.MutationObserver = saved.MutationObserver; global.ResizeObserver = saved.ResizeObserver;

--- a/chrome-extension/ui-toggle.js
+++ b/chrome-extension/ui-toggle.js
@@ -12,13 +12,20 @@
  * highlight/flash affordances, and the detection predicates (looksLikeGrid,
  * findTargetTable, isDataTable) that decide what counts as a roundable table.
  * Module-level state here is view-transient only — DOM/timer bookkeeping
- * (tableToggles, trackedTables, the resize-observer map, the style-injected
- * flags, the per-button auto-collapse timer) — never selection or sidebar
- * state, which live in DR_STORE (app/store.js). A user action (click/tap)
- * reports an intent on DR_BUS instead of calling a content.js function
- * directly; content.js is the sole subscriber and owns what happens next.
- * All load-time-executing wiring (observers, listeners) stays in content.js.
- * Loaded before content.js.
+ * (tableToggles: table → its button element; trackedTables: the
+ * reposition-on-scroll list; the resize-observer map; the style-injected
+ * flags; the per-button auto-collapse timer) — never selection, sidebar, or
+ * "have I found this table" state, which live in DR_STORE (app/store.js).
+ * Before the app-model-registry sprint, tableToggles/trackedTables and the
+ * dr-ext-grid marker class doubled as three separate "tables found" stores;
+ * createToggleForTable now also registers the table with DR_STORE, and
+ * every "have I already handled this element" check reads DR_STORE.hasTable
+ * instead. tableToggles/trackedTables keep their narrower remaining job: a
+ * DOM reference to each table's button, for aria-pressed updates and
+ * scroll/resize repositioning. A user action (click/tap) reports an intent
+ * on DR_BUS instead of calling a content.js function directly; content.js
+ * is the sole subscriber and owns what happens next. All load-time-executing
+ * wiring (observers, listeners) stays in content.js. Loaded before content.js.
  */
 
 // Toggle geometry constants
@@ -46,8 +53,13 @@ const trackedTables = new Set();
 /** WeakMap from HTMLTableElement → ResizeObserver for the toggle */
 const tableResizeObservers = new WeakMap();
 
+// isTableRounded used to read two page states directly: whether any cell
+// carried the dr-ext-rounded class, and whether table.dataset.drShowingOriginal
+// was 'true' (issue #245). Both now live in DR_STORE's per-table registry
+// entry as a single appliedFlag — 'simplified' only when roundTable actually
+// changed a cell and the table isn't currently showing originals.
 function isTableRounded(table) {
-  return table.querySelector('.dr-ext-rounded') !== null && table.dataset.drShowingOriginal !== 'true';
+  return DR_STORE.getTableAppliedFlag(table) === 'simplified';
 }
 
 function syncSwitchForTable(table) {
@@ -242,9 +254,13 @@ function createToggleForTable(table) {
   // Stop mousedown propagation to avoid triggering host-page handlers
   button.addEventListener('mousedown', (e) => e.stopPropagation());
 
-  // Store button in WeakMap and table in tracked set
+  // Store button in WeakMap and table in tracked set (view-only bookkeeping —
+  // the button element itself, and the reposition-on-scroll list). The
+  // "found" registration these two used to also stand in for now goes
+  // through DR_STORE's table registry, the one place that concept lives.
   tableToggles.set(table, button);
   trackedTables.add(table);
+  DR_STORE.registerTable(table);
 
   // Set up ResizeObserver for repositioning
   const ro = new ResizeObserver(() => {
@@ -272,15 +288,15 @@ function injectTableToggles() {
   // Pass 1: native <table> elements; phantom a11y tables are skipped.
   document.querySelectorAll('table').forEach(table => {
     if (isPhantomA11yTable(table)) return;
-    if (!tableToggles.has(table)) {
+    if (!DR_STORE.hasTable(table)) {
       createToggleForTable(table);
     }
   });
   // Pass 2: cheap ARIA pass — [role="grid"] and [role="table"].
-  // Skip elements already carrying dr-ext-grid (already handled) or that
+  // Skip elements already found (DR_STORE's table registry) or that
   // contain / are a <table> already handled by pass 1.
   document.querySelectorAll(GRID_ARIA_SELECTOR).forEach(el => {
-    if (el.classList.contains('dr-ext-grid')) return;
+    if (DR_STORE.hasTable(el)) return;
     if (el.tagName === 'TABLE') return; // handled by pass 1
     if (Array.from(el.querySelectorAll('table')).some(t => !isPhantomA11yTable(t))) return; // contains a real native table — let pass 1 own it
     el.classList.add('dr-ext-grid');


### PR DESCRIPTION
Sprint 10 of [docs/sprint-plans/decoupling-migration.md](https://github.com/ArieFisher/dynamic-rounding/blob/main/docs/sprint-plans/decoupling-migration.md) — the final sprint. The page stops being the application's memory.

## What

`DR_STORE` gains the table registry: per-table entries (a WeakMap with an enumerable companion set) holding the original cell values, the simplified/original flag, the last round options, and the frozen magnitude basis. The three parallel "tables found" stores collapse into registry reads; the marker class is still written but no production code reads it as state (statically locked, mutation-tested). The six page attributes that held originals and the applied flag are gone; grid originals flow through an `originalsPort` on the adapter. One `restoreTable(table, keepEntry)` serves native tables and grids; the re-apply observer runs entirely from model state; the nine-line guard comment is deleted because the shared page attribute it guarded is gone. `isTableRounded` reads the model, closing #245.

Two deliberate behavior changes, both pinned: the grid magnitude basis is now genuinely frozen at first sight (it previously recomputed on every scroll re-apply, silently changing rounding), and an unrestorable reset now keeps the truthful state. That second one came from review: after a content-script re-injection, model-held originals are gone (the design's accepted cost), and the first implementation let a reset or toggle strip markers, destroy the surviving `title` original, and stamp a false one. Now a cell with no registry original is left untouched, `resetTable` reports the unrestorable count and keeps the flag at simplified, and the toggle path declines to re-round — proven by inverting the re-injection test and driving the real click path.

## Acceptance criteria

- [x] No production read of the marker class as state (static lock, mutation-tested)
- [x] One restore path for both table kinds
- [x] The re-apply observer runs from model state
- [x] The guard comment is gone because the sharing is gone
- [x] All three suites pass (extension 1,868; js 256; python 214); every message pin unmodified

## Reviewer notes

- Follow-up issues: #254 (the sidebar apply path ignores the unrestorable count — highest priority, needs a policy call), #255 (widen the marker-read lock), #256 (`dr-ext-grid` is written by four sites and read by nothing), #257 (the freeze does not survive a peek round-trip, consistent with the documented contract).
- Accepted cost, stated in code: registry-held originals do not survive content-script re-injection; the extension now degrades honestly instead of corrupting.
- The originals map is a WeakMap: recycled-away grid cells' entries are collectible instead of accumulating.
