### PR TITLE
fix: refuse sidebar apply on tables with unrestorable originals (#254)

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -230,7 +230,22 @@ window.addEventListener('pagehide', () => {
 function applySidebarRounding(table, options) {
   const opts = Object.assign({}, DR_DEFAULTS, options || {});
   ensureHighlightStyleInjected();
-  resetTable(table);
+  const unrestorableCount = resetTable(table);
+  if (unrestorableCount > 0) {
+    // Same refusal as toggleOriginalValues' guard: at least one cell's
+    // registry original is gone (a content-script re-injection — see
+    // restoreTable's KNOWN ACCEPTED COST doc). Running roundTable now would
+    // round the already-rounded text, stamp a false "Original: ..." title
+    // over the one attribute that still holds the truth, and record the
+    // rounded value as the registry original of record. resetTable already
+    // left every such cell untouched and the appliedFlag truthful; tell the
+    // sidebar why nothing changed and stop. APPLY_OK below clears the
+    // notice once an apply works again (a table switch, or the site
+    // re-rendered the table with fresh cells).
+    chrome.runtime.sendMessage({ action: 'APPLY_BLOCKED', count: unrestorableCount });
+    return;
+  }
+  chrome.runtime.sendMessage({ action: 'APPLY_OK' });
   if (opts.enabled !== false) {
     sendRangeStatusMessage(roundTable(table, opts));
     if (table.querySelector('.dr-ext-rounded')) {

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -11,6 +11,10 @@ const statusEl = document.getElementById('status');
 
 const NO_TABLE_CLASS = 'no-table';
 const NO_TABLE_STATUS_MSG = 'Right-click a table to connect it here.';
+// Shown when the content script refuses an apply because the table's
+// registry originals did not survive a content-script re-injection (the
+// APPLY_BLOCKED message — see content.js's applySidebarRounding guard).
+const APPLY_BLOCKED_STATUS_MSG = 'This table\'s original values are no longer available. Reload the page, then apply settings again.';
 
 function setTableBound(isBound) {
   document.body.classList.toggle(NO_TABLE_CLASS, !isBound);
@@ -500,7 +504,12 @@ function applyNow() {
     onDelivery: function () {
       if (chrome.runtime.lastError) {
         setTableBound(false);
-      } else {
+      } else if (!statusEl.dataset.source) {
+        // Clear only an unsourced stale message (the no-table reminder).
+        // Sourced messages — a range error, an apply-blocked notice — are
+        // cleared by their own OK messages and must survive this callback:
+        // Chrome does not guarantee whether this response callback or the
+        // content script's status message is delivered first.
         statusEl.textContent = '';
       }
     }
@@ -556,6 +565,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   } else if (request.action === 'RANGE_OK') {
     if (rangeExprEl) rangeExprEl.classList.remove('invalid');
     if (statusEl.dataset.source === 'range') {
+      statusEl.textContent = '';
+      delete statusEl.dataset.source;
+    }
+  } else if (request.action === 'APPLY_BLOCKED') {
+    statusEl.textContent = APPLY_BLOCKED_STATUS_MSG;
+    statusEl.dataset.source = 'blocked';
+  } else if (request.action === 'APPLY_OK') {
+    if (statusEl.dataset.source === 'blocked') {
       statusEl.textContent = '';
       delete statusEl.dataset.source;
     }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -15013,6 +15013,155 @@ const LADDER_OPTS = {
 })();
 
 // ---------------------------------------------------------------------------
+// Issue #254 (sidebar side): the APPLY_BLOCKED / APPLY_OK notice lifecycle.
+// The content script refuses a sidebar apply on a table whose registry
+// originals did not survive re-injection (see the re-injection suite's
+// scenario C) and sends APPLY_BLOCKED; every non-refused apply sends
+// APPLY_OK. This drives sidebar.js's real onMessage handler and applyNow's
+// real delivery callback, in the same eval harness as the delivery-feedback
+// test above, and pins:
+//   - APPLY_BLOCKED shows the user-visible notice in #status (source-tagged);
+//   - the notice survives applyNow's delivery-success clear — Chrome does
+//     not guarantee whether the response callback or the content script's
+//     status message lands first, so the clear must skip sourced messages;
+//   - APPLY_OK clears the notice, and ONLY the notice (a range error's
+//     source tag is not its to clear), mirroring RANGE_OK;
+//   - an unsourced stale status still clears on delivery success (the
+//     behavior the delivery-feedback test above pins is preserved).
+// ---------------------------------------------------------------------------
+(function sidebarApplyBlocked_noticeLifecycle() {
+  const defaultsSrc = sourceByName('defaults.js');
+  const roundingSrc = sourceByName('lib/dr-number/rounding.js');
+  const coreSrc = sourceByName('lib/dr-number/core.js');
+  if (defaultsSrc === null || roundingSrc === null || coreSrc === null || messagingCode === null) {
+    eq('apply-blocked notice: source files (defaults/rounding/core/messaging) present in manifest',
+      false, true);
+    return;
+  }
+
+  function makeEl() {
+    return {
+      addEventListener() {}, removeEventListener() {},
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      style: {}, value: '', checked: false, disabled: false, textContent: '', innerHTML: '',
+      appendChild() {}, querySelector() { return makeEl(); }, querySelectorAll() { return []; },
+      getBoundingClientRect() { return { top: 0, left: 0, width: 0, height: 0, bottom: 0, right: 0 }; },
+      matches() { return false; }, closest() { return null; }, dataset: {},
+    };
+  }
+
+  const statusEl = makeEl();
+  const enabledEl = makeEl();
+  enabledEl.checked = true;
+  let enabledChangeHandler = null;
+  enabledEl.addEventListener = function (type, fn) { if (type === 'change') enabledChangeHandler = fn; };
+
+  const captureDoc = {
+    addEventListener() {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: { classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} }, addEventListener() {}, get offsetWidth() { return 0; } },
+    getElementById(id) {
+      if (id === 'status') return statusEl;
+      if (id === 'enabled') return enabledEl;
+      return makeEl();
+    },
+    createElement() { return makeEl(); },
+  };
+
+  let onMessageHandler = null;
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener(fn) { onMessageHandler = fn; } },
+      sendMessage() {},
+      get lastError() { return null; },
+    },
+    tabs: {
+      query(q, cb) { cb([{ id: 42 }]); },
+      sendMessage(tabId, msg, cb) { if (typeof cb === 'function') cb(); },
+    },
+  };
+
+  const savedDoc = global.document;
+  const savedChrome = global.chrome;
+  const savedWindow = global.window;
+  global.document = captureDoc;
+  global.chrome = captureChrome;
+  global.window = { addEventListener() {}, close() {}, getComputedStyle: () => ({ display: 'block' }) };
+
+  try {
+    try {
+      eval(
+        defaultsSrc + '\n' +
+        roundingSrc + '\n' +
+        coreSrc + '\n' +
+        messagingCode + '\n' +
+        fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8')
+      );
+    } catch (e) {
+      // sidebar.js's module-level settings/preview pull can throw past this
+      // point in this stub environment — both the onMessage listener and the
+      // 'change' listener register before that runs.
+    }
+
+    eq('apply-blocked notice: sidebar onMessage handler was captured',
+      typeof onMessageHandler, 'function');
+    eq('apply-blocked notice: sidebar\'s enabled-checkbox change handler was captured',
+      typeof enabledChangeHandler, 'function');
+    if (typeof onMessageHandler !== 'function' || typeof enabledChangeHandler !== 'function') return;
+
+    // --- APPLY_BLOCKED shows the notice, tagged with its source. ---
+    statusEl.textContent = '';
+    delete statusEl.dataset.source;
+    onMessageHandler({ action: 'APPLY_BLOCKED', count: 3 }, {}, () => {});
+    eq('apply-blocked notice: APPLY_BLOCKED sets the user-visible notice in #status',
+      statusEl.textContent,
+      'This table\'s original values are no longer available. Reload the page, then apply settings again.');
+    eq('apply-blocked notice: the notice is tagged with its source',
+      statusEl.dataset.source, 'blocked');
+
+    // --- The notice survives applyNow's delivery-success clear. ---
+    enabledChangeHandler();
+    eq('apply-blocked notice: a delivery-success clear does NOT wipe the notice (message/response ordering is not guaranteed)',
+      statusEl.textContent,
+      'This table\'s original values are no longer available. Reload the page, then apply settings again.');
+
+    // --- RANGE_OK does not clear it either (source mismatch). ---
+    onMessageHandler({ action: 'RANGE_OK' }, {}, () => {});
+    eq('apply-blocked notice: RANGE_OK leaves the blocked notice alone',
+      statusEl.textContent,
+      'This table\'s original values are no longer available. Reload the page, then apply settings again.');
+
+    // --- APPLY_OK clears it. ---
+    onMessageHandler({ action: 'APPLY_OK' }, {}, () => {});
+    eq('apply-blocked notice: APPLY_OK clears the notice',
+      statusEl.textContent, '');
+    eq('apply-blocked notice: APPLY_OK removes the source tag',
+      statusEl.dataset.source, undefined);
+
+    // --- APPLY_OK leaves a range error alone (source mismatch, mirroring
+    // RANGE_OK's own guard). ---
+    onMessageHandler({ action: 'RANGE_ERROR', error: 'Invalid range expression.' }, {}, () => {});
+    onMessageHandler({ action: 'APPLY_OK' }, {}, () => {});
+    eq('apply-blocked notice: APPLY_OK leaves a range error alone',
+      statusEl.textContent, 'Invalid range expression.');
+    onMessageHandler({ action: 'RANGE_OK' }, {}, () => {});
+
+    // --- An unsourced stale status still clears on delivery success — the
+    // delivery-feedback behavior pinned above is preserved. ---
+    statusEl.textContent = 'a stale status message';
+    delete statusEl.dataset.source;
+    enabledChangeHandler();
+    eq('apply-blocked notice: an unsourced stale status still clears on delivery success',
+      statusEl.textContent, '');
+  } finally {
+    global.document = savedDoc;
+    global.chrome = savedChrome;
+    global.window = savedWindow;
+  }
+})();
+
+// ---------------------------------------------------------------------------
 // Sprint app-model-settings: settings live in DR_STORE, sourced from
 // DR_DEFAULTS at init, changed only through setSettings (publishing the
 // whole new value), and read back through getSettings().
@@ -16166,8 +16315,10 @@ const LADDER_OPTS = {
 
   const { table: table1, dataCell: dataCell1 } = makeReinjectionFixtureTable('12,345');
   const { table: table2, dataCell: dataCell2 } = makeReinjectionFixtureTable('67,890');
+  const { table: table3, dataCell: dataCell3 } = makeReinjectionFixtureTable('54,321');
   const trueOriginal1 = '12,345';
   const trueOriginal2 = '67,890';
+  const trueOriginal3 = '54,321';
 
   // A minimal document shared by every eval'd instance below — this is the
   // "live page" that persists across the simulated re-injection.
@@ -16220,10 +16371,18 @@ const LADDER_OPTS = {
     `);
     global.__ri1_roundTable(table1, DR_DEFAULTS);
     global.__ri1_roundTable(table2, DR_DEFAULTS);
+    global.__ri1_roundTable(table3, DR_DEFAULTS);
     const roundedText1 = dataCell1.innerText;
     const roundedTitle1 = dataCell1.title;
     const roundedText2 = dataCell2.innerText;
     const roundedTitle2 = dataCell2.title;
+    const roundedText3 = dataCell3.innerText;
+    const roundedTitle3 = dataCell3.title;
+
+    eq('re-injection (pre): instance 1 actually rounded the sidebar-scenario cell away from the true original',
+      roundedText3 !== trueOriginal3, true);
+    eq('re-injection (pre): the sidebar-scenario cell\'s title holds the true original',
+      roundedTitle3, `Original: ${trueOriginal3}`);
 
     eq('re-injection (pre): instance 1 actually rounded the cell away from the true original',
       roundedText1 !== trueOriginal1, true);
@@ -16279,6 +16438,45 @@ const LADDER_OPTS = {
       dataCell2.title, roundedTitle2);
     eq('re-injection click path: one click leaves the displayed text unchanged',
       dataCell2.innerText, roundedText2);
+
+    // --- Scenario C (issue #254): the sidebar apply path — the one other
+    // resetTable caller. Drives the real wiring end to end: a sidebar
+    // settings change lands as DR_STORE.setSettings (the
+    // APPLY_SIDEBAR_SETTINGS listener), whose state:settingsChanged
+    // subscriber calls applySidebarRounding on the selected table. Before
+    // the fix this ran roundTable over the already-rounded text — stamping
+    // a false "Original: <rounded value>" title over the surviving truth
+    // and recording the rounded value as the registry original of record.
+    // It must refuse instead, and tell the sidebar why nothing changed.
+    //
+    // The new settings must DIFFER from the ones instance 1 rounded with:
+    // re-rounding under identical settings is a value-preserving no-op the
+    // engine skips, which would hide the title-stamping this test exists
+    // to catch. offsetTop 1 re-rounds instance 1's '55,000' to '100,000',
+    // so an unguarded apply visibly rewrites the cell and its title. ---
+    const sentMessages = [];
+    global.chrome.runtime.sendMessage = (msg) => { sentMessages.push(msg); };
+    global.__ri2_DR_STORE.setSelectedTable(table3);
+    global.__ri2_DR_STORE.setSettings(Object.assign({}, DR_DEFAULTS, { offsetTop: 1 }));
+
+    eq('re-injection sidebar apply: the dr-ext-rounded marker survives',
+      dataCell3.classList.contains('dr-ext-rounded'), true);
+    eq('re-injection sidebar apply: the title still holds the TRUE original — not a re-stamped "Original: <rounded value>"',
+      dataCell3.title, roundedTitle3);
+    eq('re-injection sidebar apply: the displayed text is unchanged (no double-round)',
+      dataCell3.innerText, roundedText3);
+    eq('re-injection sidebar apply: appliedFlag stays \'simplified\' — the screen still shows rounded text',
+      global.__ri2_DR_STORE.getTableAppliedFlag(table3), 'simplified');
+    eq('re-injection sidebar apply: the registry records NO original for the unrestorable cell — a rounded value must not become the original of record',
+      global.__ri2_DR_STORE.getTableOriginal(table3, dataCell3), undefined);
+    eq('re-injection sidebar apply: exactly one APPLY_BLOCKED notice is sent',
+      sentMessages.filter((m) => m.action === 'APPLY_BLOCKED').length, 1);
+    eq('re-injection sidebar apply: the APPLY_BLOCKED notice carries the unrestorable-cell count',
+      (sentMessages.find((m) => m.action === 'APPLY_BLOCKED') || {}).count, 1);
+    eq('re-injection sidebar apply: no APPLY_OK — the apply was refused',
+      sentMessages.some((m) => m.action === 'APPLY_OK'), false);
+    eq('re-injection sidebar apply: no RANGE_OK/RANGE_ERROR — roundTable never ran',
+      sentMessages.some((m) => m.action === 'RANGE_OK' || m.action === 'RANGE_ERROR'), false);
   } finally {
     global.document = saved.document; global.chrome = saved.chrome; global.window = saved.window;
     global.MutationObserver = saved.MutationObserver; global.ResizeObserver = saved.ResizeObserver;


### PR DESCRIPTION
Closes #254.

## What changed

**Product.** If the extension restarted while a simplified page stayed open (an update, or a manual reload), its internal state (holding the table's original values) would be lost.  One implication is that the extension could never restore the original values.  The second is that the user could be misled into thinking the values they see *are* the original values.  This is especially true if they invoked the 'simplify' behaviour and were now able to apply/restore, without realizing they were double-applying/restoring to the singly simplified values.
Now, if the extension loses its memory of the original values, it will refuse to work on an already-simplified table (and notifies the user in the sidebar). 

**Engineering.** `applySidebarRounding` (content.js) was the one `resetTable` caller that ignored the unrestorable-reset count. On a re-injected table it ran `roundTable` over already-rounded text: the cell double-rounded, the title lost the true original to a re-stamped "Original: &lt;rounded value&gt;", and the registry recorded the rounded value as the original of record. Reachable by right-click select after a re-injection, then any sidebar apply — including the automatic apply on sidebar reopen. The policy is refuse-and-notify, matching the toggle and reset guards: when `resetTable` reports unrestorable cells, `applySidebarRounding` sends `APPLY_BLOCKED` with the cell count and returns; every non-refused apply sends `APPLY_OK`. `restoreTable` already leaves such cells untouched, so the screen keeps the rounded text and the title keeps the true original. sidebar.js shows the notice in `#status`, tagged `dataset.source = 'blocked'`, and clears it on `APPLY_OK` — the same lifecycle as the `RANGE_ERROR`/`RANGE_OK` pair. `applyNow`'s delivery-success callback now clears only unsourced status text: Chrome does not guarantee whether the response callback or the content script's status message lands first, so sourced notices (apply-blocked, range errors) must survive it in either order. Rejected alternative: re-rounding from the surviving title value would rebuild the text but not the registry's HTML snapshot, superscript ranges, or link-filter indices, so a later reset would still destroy markup.

## Cost

**Product.** On an affected table, the sidebar's controls change nothing until the page reloads, and the notice says so. No other user-visible cost.

**Engineering.** Each sidebar apply sends one extra message (`APPLY_OK` or `APPLY_BLOCKED`).

## Tested

**Product.** An automated test reproduces the exact damage scenario — restart, then apply from the sidebar — and proves the table and its tooltips now survive untouched with the notice shown. It fails without the fix. All suites pass.

**Engineering.**
- `node chrome-extension/tests.js` — 1889 passed, 0 failed. 21 new assertions: re-injection scenario C drives the real wiring (`setSettings` → `state:settingsChanged` → `applySidebarRounding`) with coarser settings, since a same-settings re-round is a no-op the engine skips; a sidebar eval-harness test pins the notice lifecycle, including survival of the delivery-success clear and `RANGE_OK`/`APPLY_OK` source isolation.
- `node js/tests.js` — 256 passed.
- `scripts/check-files.sh --staged` — clean.
- Python suite untouched by the diff; CI runs it.

## Manual tests

- Round a table, reload the extension (chrome://extensions → Reload), right-click the table, change a sidebar setting: the table must not change and the sidebar status must show the blocked notice.
- Right-click a fresh table and apply: the notice must clear.

## Reviewer notes

- Follow-up #262 (from product review): on a stuck table, the on-page pill and the sidebar toggle can still misreport state; lock them at selected. Out of scope here.

