### PR TITLE
fix: lock the rounding controls on tables with unrestorable originals (#262)

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1181,6 +1181,17 @@ function toggleOriginalValues(table) {
   const roundedCells = table.querySelectorAll('.dr-ext-rounded');
   if (roundedCells.length === 0) return;
 
+  if (tableHasUnrestorableCells(table)) {
+    // Locked table (issue #262): rounded markers with no registry originals
+    // behind them. Both branches below no-op on such cells while flipping
+    // appliedFlag, which made the pill oscillate between states the screen
+    // never leaves. Pin the flag to the truthful state — the screen shows
+    // simplified text — and re-render the (locked) pill instead.
+    DR_STORE.setTableAppliedFlag(table, 'simplified');
+    syncSwitchForTable(table);
+    return;
+  }
+
   const showingOriginal = DR_STORE.getTableAppliedFlag(table) !== 'simplified';
 
   if (showingOriginal) {

--- a/chrome-extension/sidebar.html
+++ b/chrome-extension/sidebar.html
@@ -244,6 +244,20 @@
       font-weight: 500;
       color: #5f6368;
     }
+    /* Locked table (issue #262): the connected table is stuck showing
+       simplified values (see content.js's APPLY_BLOCKED). The settings area
+       and the main toggle dim and stop accepting input; #status carries the
+       explanation. */
+    body.table-locked #optionsSection,
+    body.table-locked .title-row .switch {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+    body.table-locked #status {
+      font-size: 13px;
+      font-weight: 500;
+      color: #5f6368;
+    }
     .divider {
       border: none;
       border-top: 1px solid #e8eaed;

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -21,6 +21,12 @@ function setTableBound(isBound) {
   if (!isBound) {
     // No active table: there is nothing for rounding to act on, so flip the
     // main toggle to its off state rather than dimming the whole sidebar.
+    // Any lock belonged to the table that just went away (issue #262), and
+    // the message written below is unsourced — drop a stale source tag so
+    // applyNow's delivery-success clear can still collect it.
+    document.body.classList.remove('table-locked');
+    enabledEl.disabled = false;
+    delete statusEl.dataset.source;
     enabledEl.checked = false;
     statusEl.textContent = NO_TABLE_STATUS_MSG;
   } else {
@@ -571,14 +577,27 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   } else if (request.action === 'APPLY_BLOCKED') {
     statusEl.textContent = APPLY_BLOCKED_STATUS_MSG;
     statusEl.dataset.source = 'blocked';
+    // Issue #262: the connected table is stuck showing simplified values.
+    // Show that truth and stop accepting input: main toggle ON and
+    // disabled, settings area dimmed via body.table-locked (sidebar.html).
+    document.body.classList.add('table-locked');
+    enabledEl.checked = true;
+    enabledEl.disabled = true;
+    updateDisabledState();
   } else if (request.action === 'APPLY_OK') {
     if (statusEl.dataset.source === 'blocked') {
       statusEl.textContent = '';
       delete statusEl.dataset.source;
     }
+    document.body.classList.remove('table-locked');
+    enabledEl.disabled = false;
   } else if (request.action === 'PREVIEW_SAMPLES_CHANGED') {
     fetchPreviewSamples();
   } else if (request.action === 'RESET_SIDEBAR_TO_DEFAULTS') {
+    // A table switch: the lock, if any, belonged to the previous table. The
+    // new table's own reconnect apply re-locks if it must (APPLY_BLOCKED).
+    document.body.classList.remove('table-locked');
+    enabledEl.disabled = false;
     try {
       applyDefaultsToUI();
       fetchPreviewSamples();

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1964,7 +1964,9 @@ eq('formatExtractedNumber: |rounded|>=10 short-circuit overrides floorDecimals',
     /DR_STORE\.setTableRoundOptions\(table,\s*opts\)/.test(contentSrc), true);
 
   eq('unified: toggleOriginalValues calls roundTable for original→rounded path',
-    /function toggleOriginalValues[\s\S]{0,1500}roundTable\(/.test(contentSrc), true);
+    // Window sized for the locked-table guard (issue #262) that now sits
+    // between the function head and the re-round call.
+    /function toggleOriginalValues[\s\S]{0,2200}roundTable\(/.test(contentSrc), true);
 
   // --- Display simplification: "35.0" → "35" when value unchanged but format would ---
 
@@ -2154,6 +2156,7 @@ function makeMockButton() {
     classList,
     setAttribute(name, value) { attrs[name] = value; },
     getAttribute(name) { return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null; },
+    removeAttribute(name) { delete attrs[name]; },
     addEventListener(evt, fn) {
       if (!listeners[evt]) listeners[evt] = [];
       listeners[evt].push(fn);
@@ -2265,8 +2268,13 @@ function makeMockButton() {
   const button = injectToggleEntry(table);
   button.setAttribute('aria-pressed', 'false'); // pre-set to false to confirm it gets corrected
 
-  // Mark table as rounded
+  // Mark table as rounded. A registry record accompanies the marker:
+  // production rounded/showing-original states always carry one (roundTable
+  // writes it; the keepEntry restore preserves it). A marker WITHOUT a
+  // record is the locked re-injection state (issue #262), tested in the
+  // re-injection suite.
   table._cells[0].classList.add('dr-ext-rounded');
+  DR_STORE.setTableOriginal(table, table._cells[0], { html: '1,000', value: '1,000', supRanges: null, linkFilteredIdx: null });
   DR_STORE.setTableAppliedFlag(table, 'simplified');
 
   syncSwitchForTable(table);
@@ -2278,6 +2286,8 @@ function makeMockButton() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   const button = injectToggleEntry(table);
   table._cells[0].classList.add('dr-ext-rounded');
+  // Registry record present — see atToggle_syncSwitch_ariaTrueWhenRounded.
+  DR_STORE.setTableOriginal(table, table._cells[0], { html: '1,000', value: '1,000', supRanges: null, linkFilteredIdx: null });
   DR_STORE.setTableAppliedFlag(table, 'original');
   button.setAttribute('aria-pressed', 'true');
 
@@ -2336,6 +2346,7 @@ function makeMockButton() {
       getAttribute(name) {
         return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
       },
+      removeAttribute(name) { delete attrs[name]; },
       classList: (() => {
         const c = [];
         return {
@@ -2714,6 +2725,7 @@ function makeMockButton() {
       getAttribute(name) {
         return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
       },
+      removeAttribute(name) { delete attrs[name]; },
       contains() { return false; },
     };
     createdElements.push(el);
@@ -2814,7 +2826,7 @@ function makeMockButton() {
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -3625,6 +3637,8 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 (function morphAC_syncSwitch_roundedTable() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   table._cells[0].classList.add('dr-ext-rounded');
+  // Registry record present — see atToggle_syncSwitch_ariaTrueWhenRounded.
+  DR_STORE.setTableOriginal(table, table._cells[0], { html: '1,000', value: '1,000', supRanges: null, linkFilteredIdx: null });
   DR_STORE.setTableAppliedFlag(table, 'simplified');
   const button = injectToggleEntry(table);
   syncSwitchForTable(table);
@@ -3635,6 +3649,8 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
 (function morphAC_syncSwitch_showingOriginal() {
   const table = makeToggleTable([{ tag: 'td', text: '1,000' }]);
   table._cells[0].classList.add('dr-ext-rounded');
+  // Registry record present — see atToggle_syncSwitch_ariaTrueWhenRounded.
+  DR_STORE.setTableOriginal(table, table._cells[0], { html: '1,000', value: '1,000', supRanges: null, linkFilteredIdx: null });
   DR_STORE.setTableAppliedFlag(table, 'original');
   const button = injectToggleEntry(table);
   syncSwitchForTable(table);
@@ -3668,7 +3684,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -3749,7 +3765,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -3833,7 +3849,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -3922,7 +3938,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -4000,7 +4016,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -4104,7 +4120,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(node){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -4204,7 +4220,7 @@ eq('formatExtractedNumber: whole number with floorDecimals=2 still trimmed',
       })(),
       appendChild(ch){this._children.push(ch);ch.parentElement=this;return ch;},
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
-      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      setAttribute(n,v){attrs[n]=v;}, getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;}, removeAttribute(n){delete attrs[n];},
       contains(node){return node === this || (this._children && this._children.includes(node));},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -4963,6 +4979,7 @@ function createToggleWithSpies(table) {
       addEventListener(evt,fn){if(!listeners[evt])listeners[evt]=[];listeners[evt].push(fn);},
       setAttribute(n,v){attrs[n]=v;},
       getAttribute(n){return Object.prototype.hasOwnProperty.call(attrs,n)?attrs[n]:null;},
+      removeAttribute(n){delete attrs[n];},
       contains(){return false;},
       dispatchEvent(evt){(listeners[evt.type]||[]).forEach(fn=>fn(evt));},
     };
@@ -5382,13 +5399,14 @@ function fireTouchSecondTap(buttonEl) {
     /\blastRightClickedTable\s*=[^=]/.test(sourceByName('content.js') || ''),
     false);
 
-  // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler calls applyDefaultsToUI
+  // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler calls applyDefaultsToUI.
+  // Window sized for the unlock lines (issue #262) at the handler's top.
   eq('rebind source: sidebar.js RESET_SIDEBAR_TO_DEFAULTS handler calls applyDefaultsToUI()',
-    /RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,200}applyDefaultsToUI\(\)/.test(sidebarSrc), true);
+    /RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,400}applyDefaultsToUI\(\)/.test(sidebarSrc), true);
 
   // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler calls fetchPreviewSamples
   eq('rebind source: sidebar.js RESET_SIDEBAR_TO_DEFAULTS handler calls fetchPreviewSamples()',
-    /RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,200}fetchPreviewSamples\(\)/.test(sidebarSrc), true);
+    /RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,400}fetchPreviewSamples\(\)/.test(sidebarSrc), true);
 
   // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler does NOT auto-apply settings
   // (must NOT call applyNow() or applySidebarRounding() inside the handler)
@@ -7077,6 +7095,7 @@ function withFindTargetEnv(elements, fn) {
     dataset: {},
     setAttribute: () => {},
     getAttribute: () => null,
+    removeAttribute: () => {},
     addEventListener: () => {},
     classList: { _c: [], add(c){ this._c.push(c); }, remove(c){ this._c=this._c.filter(x=>x!==c); }, contains(c){ return this._c.includes(c); } },
     appendChild: () => {},
@@ -9579,6 +9598,7 @@ function runPass1WithTables(tables) {
       addEventListener(evt, fn) { if (!listeners[evt]) listeners[evt]=[]; listeners[evt].push(fn); },
       setAttribute(name, val) { attrs[name] = val; },
       getAttribute(name) { return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null; },
+      removeAttribute(name) { delete attrs[name]; },
     };
   };
 
@@ -9992,6 +10012,7 @@ function withToggleDocumentMock(fn) {
       getAttribute(name) {
         return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
       },
+      removeAttribute(name) { delete attrs[name]; },
       classList: (() => {
         const c = [];
         return {
@@ -10451,6 +10472,7 @@ function makeRealToggleButton(tableSpec, docMock) {
       getAttribute(n) {
         return Object.prototype.hasOwnProperty.call(attrs, n) ? attrs[n] : null;
       },
+      removeAttribute(n) { delete attrs[n]; },
       contains() { return false; },
       dispatchEvent(evt) { (listeners[evt.type] || []).forEach(fn => fn(evt)); },
     };
@@ -11050,8 +11072,11 @@ function fireMouseClick(buttonEl, fn) {
     nodeType: 1, tagName: 'DIV', className: 'grid-wrapper', children: rows,
     classList: gridClassList, parentElement: null, parentNode: null,
     // runToggleAction calls table.querySelector(...) directly, with no `&&`
-    // guard, so this must exist (returning "not already rounded").
+    // guard, so this must exist (returning "not already rounded"), and
+    // syncSwitchForTable's lock check scans querySelectorAll the same way
+    // (returning "no rounded cells").
     querySelector() { return null; },
+    querySelectorAll() { return []; },
     getBoundingClientRect() { return { top: 10, right: 100, bottom: 50, left: 10, width: 90, height: 40 }; },
   };
   const clickTarget = {
@@ -11066,7 +11091,7 @@ function fireMouseClick(buttonEl, fn) {
       return {
         type: '', className: '', style: {}, dataset: {},
         classList: { add() {}, remove() {}, contains() { return false; } },
-        setAttribute() {}, getAttribute() { return null; },
+        setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
         addEventListener() {}, appendChild() {}, parentElement: null,
       };
     }
@@ -12304,8 +12329,8 @@ function fireMouseClick(buttonEl, fn) {
     // Build stub environment for each sub-test.
     function makeEnv(initialStatus, initialChecked) {
       const classList = makeClassList();
-      const statusEl = { textContent: initialStatus !== undefined ? initialStatus : '' };
-      const enabledEl = { checked: initialChecked !== undefined ? initialChecked : true };
+      const statusEl = { textContent: initialStatus !== undefined ? initialStatus : '', dataset: {} };
+      const enabledEl = { checked: initialChecked !== undefined ? initialChecked : true, disabled: false };
       const fakeDoc = { body: { classList } };
       const DR_DEFAULTS = { enabled: true };
       let updateDisabledCalls = 0;
@@ -12314,12 +12339,16 @@ function fireMouseClick(buttonEl, fn) {
       // Extract constants + function from sidebar source, then eval in closure.
       // We pull the relevant declarations and avoid running the rest of
       // sidebar.js (which needs getElementById, chrome.tabs, etc.).
+      // Keep this copy in step with the real setTableBound in sidebar.js.
       const snippet = `
         const NO_TABLE_CLASS = 'no-table';
         const NO_TABLE_STATUS_MSG = 'Right-click a table to connect it here.';
         function setTableBound(isBound) {
           document.body.classList.toggle(NO_TABLE_CLASS, !isBound);
           if (!isBound) {
+            document.body.classList.remove('table-locked');
+            enabledEl.disabled = false;
+            delete statusEl.dataset.source;
             enabledEl.checked = false;
             statusEl.textContent = NO_TABLE_STATUS_MSG;
           } else {
@@ -15056,11 +15085,27 @@ const LADDER_OPTS = {
   let enabledChangeHandler = null;
   enabledEl.addEventListener = function (type, fn) { if (type === 'change') enabledChangeHandler = fn; };
 
+  const bodyClasses = new Set();
+  const captureBody = {
+    classList: {
+      add(cls) { bodyClasses.add(cls); },
+      remove(cls) { bodyClasses.delete(cls); },
+      contains(cls) { return bodyClasses.has(cls); },
+      toggle(cls, force) {
+        if (force === undefined) {
+          if (bodyClasses.has(cls)) bodyClasses.delete(cls); else bodyClasses.add(cls);
+        } else if (force) bodyClasses.add(cls); else bodyClasses.delete(cls);
+      },
+    },
+    addEventListener() {},
+    get offsetWidth() { return 0; },
+  };
+
   const captureDoc = {
     addEventListener() {},
     querySelectorAll: () => [],
     readyState: 'complete',
-    body: { classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} }, addEventListener() {}, get offsetWidth() { return 0; } },
+    body: captureBody,
     getElementById(id) {
       if (id === 'status') return statusEl;
       if (id === 'enabled') return enabledEl;
@@ -15070,11 +15115,12 @@ const LADDER_OPTS = {
   };
 
   let onMessageHandler = null;
+  let queuedLastError = null;
   const captureChrome = {
     runtime: {
       onMessage: { addListener(fn) { onMessageHandler = fn; } },
       sendMessage() {},
-      get lastError() { return null; },
+      get lastError() { return queuedLastError; },
     },
     tabs: {
       query(q, cb) { cb([{ id: 42 }]); },
@@ -15154,11 +15200,69 @@ const LADDER_OPTS = {
     enabledChangeHandler();
     eq('apply-blocked notice: an unsourced stale status still clears on delivery success',
       statusEl.textContent, '');
+
+    // --- Issue #262: APPLY_BLOCKED also locks the panel. The connected
+    // table is stuck showing simplified values, so the main toggle must
+    // show ON (the truth) and stop accepting input, and the settings area
+    // dims via body.table-locked. APPLY_OK, a table switch
+    // (RESET_SIDEBAR_TO_DEFAULTS), and unbinding (delivery failure →
+    // setTableBound(false)) each lift the lock. ---
+    enabledEl.checked = false;
+    enabledEl.disabled = false;
+    onMessageHandler({ action: 'APPLY_BLOCKED', count: 1 }, {}, () => {});
+    eq('sidebar lock: APPLY_BLOCKED adds body.table-locked',
+      bodyClasses.has('table-locked'), true);
+    eq('sidebar lock: APPLY_BLOCKED forces the main toggle ON — the table IS simplified',
+      enabledEl.checked, true);
+    eq('sidebar lock: APPLY_BLOCKED disables the main toggle',
+      enabledEl.disabled, true);
+
+    onMessageHandler({ action: 'APPLY_OK' }, {}, () => {});
+    eq('sidebar lock: APPLY_OK lifts the lock',
+      bodyClasses.has('table-locked'), false);
+    eq('sidebar lock: APPLY_OK re-enables the main toggle',
+      enabledEl.disabled, false);
+
+    onMessageHandler({ action: 'APPLY_BLOCKED', count: 1 }, {}, () => {});
+    onMessageHandler({ action: 'RESET_SIDEBAR_TO_DEFAULTS' }, {}, () => {});
+    eq('sidebar lock: a table switch (RESET_SIDEBAR_TO_DEFAULTS) lifts the lock',
+      bodyClasses.has('table-locked'), false);
+    eq('sidebar lock: a table switch re-enables the main toggle',
+      enabledEl.disabled, false);
+
+    onMessageHandler({ action: 'APPLY_BLOCKED', count: 1 }, {}, () => {});
+    queuedLastError = { message: 'Could not establish connection.' };
+    enabledChangeHandler();
+    queuedLastError = null;
+    eq('sidebar lock: unbinding (delivery failure) lifts the lock',
+      bodyClasses.has('table-locked'), false);
+    eq('sidebar lock: unbinding re-enables the main toggle for the no-table state',
+      enabledEl.disabled, false);
+    eq('sidebar lock: unbinding drops the stale source tag — the no-table message it writes is unsourced',
+      statusEl.dataset.source, undefined);
   } finally {
     global.document = savedDoc;
     global.chrome = savedChrome;
     global.window = savedWindow;
   }
+})();
+
+// ---------------------------------------------------------------------------
+// Issue #262 (static): the locked presentation exists in the stylesheets.
+// body.table-locked must dim and mute the settings area and the title-row
+// switch in sidebar.html; the on-page pill's locked look lives in
+// ui-toggle.js's injected style.
+// ---------------------------------------------------------------------------
+(function lockedPresentation_stylesExist() {
+  const sidebarHtmlSrc = fs.readFileSync(path.join(__dirname, 'sidebar.html'), 'utf8');
+  eq('locked styles: sidebar.html styles body.table-locked',
+    sidebarHtmlSrc.includes('body.table-locked'), true);
+  eq('locked styles: the locked sidebar blocks pointer input (pointer-events: none present in the table-locked block)',
+    /body\.table-locked[^}]*\{[^}]*pointer-events:\s*none/.test(sidebarHtmlSrc), true);
+  eq('locked styles: ui-toggle.js styles the locked pill class',
+    uiToggleCode !== null && uiToggleCode.includes('.dr-ext-morph-locked'), true);
+  eq('locked styles: the locked pill shows a not-allowed cursor',
+    uiToggleCode !== null && /\.dr-ext-morph-locked[^}]*\{[^}]*cursor:\s*not-allowed/.test(uiToggleCode), true);
 })();
 
 // ---------------------------------------------------------------------------
@@ -16316,6 +16420,12 @@ const LADDER_OPTS = {
   const { table: table1, dataCell: dataCell1 } = makeReinjectionFixtureTable('12,345');
   const { table: table2, dataCell: dataCell2 } = makeReinjectionFixtureTable('67,890');
   const { table: table3, dataCell: dataCell3 } = makeReinjectionFixtureTable('54,321');
+  // Scenario D fixtures (issue #262): table5 is rounded by instance 1 and
+  // then untouched — the pill's wrong-on-arrival case. table6 starts
+  // unrounded and is later rounded BY instance 2 itself — the sanity case
+  // proving the lock keys on missing registry records, not on "rounded".
+  const { table: table5, dataCell: dataCell5 } = makeReinjectionFixtureTable('9,876');
+  const { table: table6 } = makeReinjectionFixtureTable('8,765');
   const trueOriginal1 = '12,345';
   const trueOriginal2 = '67,890';
   const trueOriginal3 = '54,321';
@@ -16372,6 +16482,7 @@ const LADDER_OPTS = {
     global.__ri1_roundTable(table1, DR_DEFAULTS);
     global.__ri1_roundTable(table2, DR_DEFAULTS);
     global.__ri1_roundTable(table3, DR_DEFAULTS);
+    global.__ri1_roundTable(table5, DR_DEFAULTS);
     const roundedText1 = dataCell1.innerText;
     const roundedTitle1 = dataCell1.title;
     const roundedText2 = dataCell2.innerText;
@@ -16401,6 +16512,9 @@ const LADDER_OPTS = {
       globalThis.__ri2_resetTable = resetTable;
       globalThis.__ri2_DR_STORE = DR_STORE;
       globalThis.__ri2_DR_BUS = DR_BUS;
+      globalThis.__ri2_roundTable = roundTable;
+      globalThis.__ri2_syncSwitchForTable = syncSwitchForTable;
+      globalThis.__ri2_tableToggles = tableToggles;
     `);
 
     eq('re-injection: a fresh instance reports the table as NOT rounded, despite the DOM still showing rounded text — a state/display mismatch the moment re-injection happens',
@@ -16477,6 +16591,79 @@ const LADDER_OPTS = {
       sentMessages.some((m) => m.action === 'APPLY_OK'), false);
     eq('re-injection sidebar apply: no RANGE_OK/RANGE_ERROR — roundTable never ran',
       sentMessages.some((m) => m.action === 'RANGE_OK' || m.action === 'RANGE_ERROR'), false);
+
+    // --- Scenario D (issue #262): the on-page pill on a locked table. A
+    // table is locked when it shows cells wearing dr-ext-rounded that the
+    // registry has no record for — the post-re-injection state. The pill
+    // must render selected AND locked on arrival (before any interaction):
+    // aria-pressed 'true' because the screen shows simplified text,
+    // aria-disabled 'true' plus a hover title because nothing here can
+    // change it. A table instance 2 rounded ITSELF (registry records
+    // present) must stay a normal, unlocked pill — the lock keys on
+    // missing records, not on "rounded". ---
+    const stub5 = makeMockButton();
+    global.__ri2_tableToggles.set(table5, stub5);
+    global.__ri2_syncSwitchForTable(table5);
+
+    eq('re-injection pill: locked table renders selected on arrival (screen shows simplified text)',
+      stub5.getAttribute('aria-pressed'), 'true');
+    eq('re-injection pill: locked table renders aria-disabled',
+      stub5.getAttribute('aria-disabled'), 'true');
+    eq('re-injection pill: locked table carries the locked marker class',
+      stub5.classList.contains('dr-ext-morph-locked'), true);
+    eq('re-injection pill: locked table explains itself on hover',
+      typeof stub5.title === 'string' && stub5.title.includes('Reload the page'), true);
+
+    const stub6 = makeMockButton();
+    global.__ri2_tableToggles.set(table6, stub6);
+    global.__ri2_syncSwitchForTable(table6);
+    eq('re-injection pill: an unrounded table renders unselected',
+      stub6.getAttribute('aria-pressed'), 'false');
+    eq('re-injection pill: an unrounded table is not locked',
+      stub6.getAttribute('aria-disabled'), null);
+
+    global.__ri2_roundTable(table6, DR_DEFAULTS);
+    global.__ri2_syncSwitchForTable(table6);
+    eq('re-injection pill: a table THIS instance rounded renders selected',
+      stub6.getAttribute('aria-pressed'), 'true');
+    eq('re-injection pill: a table THIS instance rounded is NOT locked — its registry records exist',
+      stub6.getAttribute('aria-disabled'), null);
+    eq('re-injection pill: a table THIS instance rounded carries no locked class',
+      stub6.classList.contains('dr-ext-morph-locked'), false);
+
+    // --- Scenario E (issue #262): toggle clicks on a locked table must not
+    // oscillate the pill. Before the fix, alternating clicks flipped
+    // appliedFlag between 'simplified' and 'original' (both
+    // toggleOriginalValues branches no-op on cells without registry
+    // records), so the pill toggled visually while the table never changed,
+    // and TABLE_TOGGLE_STATE reported enabled:false to the sidebar under a
+    // visibly simplified table. ---
+    const stub2 = makeMockButton();
+    global.__ri2_tableToggles.set(table2, stub2);
+    global.__ri2_DR_STORE.setSidebarOpen(true);
+    sentMessages.length = 0;
+
+    global.__ri2_DR_BUS.publish('intent:toggleTable', { table: table2 });
+    eq('re-injection toggle click 1: appliedFlag stays \'simplified\' — the truthful state',
+      global.__ri2_DR_STORE.getTableAppliedFlag(table2), 'simplified');
+    eq('re-injection toggle click 1: the pill stays selected',
+      stub2.getAttribute('aria-pressed'), 'true');
+
+    global.__ri2_DR_BUS.publish('intent:toggleTable', { table: table2 });
+    eq('re-injection toggle click 2: appliedFlag still \'simplified\' — no oscillation',
+      global.__ri2_DR_STORE.getTableAppliedFlag(table2), 'simplified');
+    eq('re-injection toggle click 2: the pill still selected — no oscillation',
+      stub2.getAttribute('aria-pressed'), 'true');
+    eq('re-injection toggle clicks: the pill is locked',
+      stub2.getAttribute('aria-disabled'), 'true');
+    eq('re-injection toggle clicks: displayed text never changed',
+      dataCell2.innerText, roundedText2);
+    eq('re-injection toggle clicks: the title still holds the true original',
+      dataCell2.title, roundedTitle2);
+
+    const toggleStates = sentMessages.filter((m) => m.action === 'TABLE_TOGGLE_STATE');
+    eq('re-injection toggle clicks: every TABLE_TOGGLE_STATE reports enabled:true — the sidebar toggle must not flip off under a simplified table',
+      toggleStates.length > 0 && toggleStates.every((m) => m.enabled === true), true);
   } finally {
     global.document = saved.document; global.chrome = saved.chrome; global.window = saved.window;
     global.MutationObserver = saved.MutationObserver; global.ResizeObserver = saved.ResizeObserver;

--- a/chrome-extension/ui-toggle.js
+++ b/chrome-extension/ui-toggle.js
@@ -41,6 +41,9 @@ const TOGGLE_DOT_OVERHANG_PX = 2;
 const TOGGLE_COLOR_ON = '#3d85c6';
 const TOGGLE_COLOR_OFF = '#cccccc';
 const TOUCH_AUTOCOLLAPSE_MS = 3000;
+// Hover text for a locked pill — see tableHasUnrestorableCells. Wording
+// mirrors sidebar.js's APPLY_BLOCKED_STATUS_MSG.
+const LOCKED_TOGGLE_TITLE = 'This table\'s original values are no longer available. Reload the page to change it.';
 
 // --- Per-table toggle switch infrastructure ---
 
@@ -62,11 +65,38 @@ function isTableRounded(table) {
   return DR_STORE.getTableAppliedFlag(table) === 'simplified';
 }
 
+// A locked table (issue #262) shows cells wearing dr-ext-rounded that
+// DR_STORE has no original for. Only a content-script re-injection produces
+// that pairing (see restoreTable's KNOWN ACCEPTED COST comment in
+// content.js): the class survives in the page, the registry did not. Such a
+// table is stuck showing simplified text — nothing in this instance can
+// restore it, and re-rounding would destroy the title attribute's surviving
+// originals — so every control over it renders locked. Evaluated live on
+// each sync: if the site re-renders the table with fresh cells, the marker
+// class disappears with the old cells and the lock lifts by itself.
+function tableHasUnrestorableCells(table) {
+  for (const cell of table.querySelectorAll('.dr-ext-rounded')) {
+    if (DR_STORE.getTableOriginal(table, cell) === undefined) return true;
+  }
+  return false;
+}
+
 function syncSwitchForTable(table) {
   const button = tableToggles.get(table);
-  if (button) {
-    button.setAttribute('aria-pressed', isTableRounded(table) ? 'true' : 'false');
+  if (!button) return;
+  if (tableHasUnrestorableCells(table)) {
+    // The screen shows simplified text (pressed) and no control here can
+    // change that (disabled) — see tableHasUnrestorableCells.
+    button.setAttribute('aria-pressed', 'true');
+    button.setAttribute('aria-disabled', 'true');
+    button.classList.add('dr-ext-morph-locked');
+    button.title = LOCKED_TOGGLE_TITLE;
+    return;
   }
+  button.removeAttribute('aria-disabled');
+  button.classList.remove('dr-ext-morph-locked');
+  button.removeAttribute('title');
+  button.setAttribute('aria-pressed', isTableRounded(table) ? 'true' : 'false');
 }
 
 let toggleStyleInjected = false;
@@ -140,6 +170,17 @@ function ensureToggleStyleInjected() {
       }
     }
     .dr-ext-morph:focus-visible { outline: 2px solid ${TOGGLE_COLOR_ON}!important; outline-offset: 2px; }
+    /* Locked pill (issue #262): dimmed dot, no expand, no knob, explaining
+       cursor. These rules sit last so they win the equal-specificity race
+       against the hover/expanded/focus-visible rules above. */
+    .dr-ext-morph.dr-ext-morph-locked { cursor: not-allowed; }
+    .dr-ext-morph.dr-ext-morph-locked .dr-ext-morph-visible {
+      width: ${TOGGLE_DOT_PX}px;
+      height: ${TOGGLE_DOT_PX}px;
+      border-radius: 50%;
+      opacity: .55;
+    }
+    .dr-ext-morph.dr-ext-morph-locked .dr-ext-morph-knob { opacity: 0; }
   `;
   (document.head || document.documentElement).appendChild(style);
   toggleStyleInjected = true;
@@ -229,6 +270,11 @@ function createToggleForTable(table) {
   // the toggle logic.
   button.addEventListener('click', (e) => {
     e.stopPropagation();
+    // A locked pill (aria-disabled — see syncSwitchForTable) reports
+    // nothing: no expand, no intent. The controller guards the intent too
+    // (toggleOriginalValues), but the view must not animate an interaction
+    // it will not honor.
+    if (button.getAttribute('aria-disabled') === 'true') return;
     const pType = button.dataset.pointerType;
     if (pType === 'touch' || pType === 'pen') {
       if (!button.classList.contains('expanded')) {
@@ -261,6 +307,13 @@ function createToggleForTable(table) {
   tableToggles.set(table, button);
   trackedTables.add(table);
   DR_STORE.registerTable(table);
+
+  // Render the initial state through the same sync every later state change
+  // uses. On a fresh table this keeps aria-pressed 'false' exactly as set
+  // above; on a re-injected page whose table still wears rounded markers
+  // (see tableHasUnrestorableCells) the pill must arrive locked-and-selected
+  // instead of claiming an unrounded table.
+  syncSwitchForTable(table);
 
   // Set up ResizeObserver for repositioning
   const ro = new ResizeObserver(() => {


### PR DESCRIPTION
Closes #262. Follow-up to #261.

## What changed

**Product.** When the extension restarts while a simplified page stays open, its internal state (holding each table's original values) is lost, and such a table can no longer be changed — but the controls did not say so. The on-page pill arrived deselected under visibly simplified figures; clicking it flipped it back and forth while the table never changed; the sidebar's main toggle could rest at off under a simplified table. The user could be misled twice: about whether the figures they see are simplified, and about whether they can change them. Now every control states the truth. The pill arrives selected and visibly locked (dimmed, no press animation), hovering it explains why and names the recovery, and clicks change nothing. The sidebar's main toggle locks at on, the settings area dims and stops accepting input, and the notice from #261 stays pinned. If the site redraws the table with fresh cells, the lock lifts by itself. Reloading the page fully recovers.

**Engineering.** `tableHasUnrestorableCells` (ui-toggle.js) names the state — a `dr-ext-rounded` cell with no `DR_STORE.getTableOriginal` record — and is evaluated live at each sync so a site re-render lifts the lock without bookkeeping. `syncSwitchForTable` renders the locked pill: `aria-pressed` and `aria-disabled` true, `dr-ext-morph-locked` (dimmed dot, suppressed expand and knob, `not-allowed` cursor; the block sits last in the injected stylesheet to win equal-specificity races), hover title naming the page reload. `createToggleForTable` syncs at creation, so re-created pills arrive locked-and-selected instead of claiming an unrounded table. The pill's click handler goes inert when locked (no expand, no intent, both mouse and touch two-tap). `toggleOriginalValues` (content.js) refuses on locked tables and pins `appliedFlag` to `'simplified'`, killing the oscillation and making `TABLE_TOGGLE_STATE` report `enabled: true`. sidebar.js locks the panel on `APPLY_BLOCKED` (main toggle forced on and disabled, `body.table-locked` dims the settings area per sidebar.html's new CSS); `APPLY_OK`, a table switch, and unbinding lift it. `setTableBound(false)` also drops the stale status source tag, since the no-table message it writes is unsourced.

## Cost

**Product.** None visible beyond the intended locking. A locked table's controls stay inert until the page reloads or the site redraws the table.

**Engineering.** The lock check adds one pass of registry map lookups over a table's rounded cells at each sync point (toggle click, round, reset, sidebar apply) — no DOM writes. Review noted this as LOW: negligible next to the DOM-mutation pass each of those actions already performs; only a future profiling pass on huge non-virtualized tables would revisit it.

## Tested

**Product.** Automated tests reproduce the restart scenario and prove: the pill arrives locked-and-selected, clicks no longer flip it while the table stands still, a table the fresh extension simplifies itself stays unlocked, and the sidebar locks on refusal and unlocks on recovery, table switch, and disconnect. All suites pass.

**Engineering.**
- `node chrome-extension/tests.js` — 1920 passed, 0 failed. New: re-injection scenarios D (locked pill on arrival; instance-rounded table stays unlocked) and E (no oscillation; truthful `TABLE_TOGGLE_STATE`), sidebar lock lifecycle in the notice harness, static pins for both stylesheets. Harness: element stubs gained `removeAttribute`; fixtures modeling rounded/showing-original states now carry the registry record production always has; two source-regex windows widened for the grown handlers.
- `node js/tests.js` — 256 passed.
- `scripts/check-files.sh --staged` — clean.
- Python suite untouched by the diff; CI runs it.
- Independent review (worktree red/green verification): APPROVE, no CRITICAL/HIGH/MEDIUM findings; the LOW note is recorded under Cost.

## Manual tests

- Round a table, reload the extension (chrome://extensions → Reload): the pill on the table must render selected and dimmed; hovering shows the explanation; clicking does nothing.
- Right-click that table with the sidebar open: the sidebar must show the notice, force the main toggle on, and dim the settings.
- Right-click a fresh table: the sidebar must unlock and behave normally.
- Reload the page: everything recovers.
