### PR TITLE
fix: sidebar mirrors the model's settings on any table switch

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -63,13 +63,24 @@ DR_BUS.subscribe('intent:toggleTable', ({ table }) => {
     // even when a second intent (toggle) is what triggered it.
     DR_BUS.publish('intent:selectTable', { table });
     try {
-      // One message per switch. The sidebar's handler re-reads the model's
-      // settings (issue #251) and that pull chain ends in the preview
-      // fetch, so no separate PREVIEW_SAMPLES_CHANGED send is needed here.
+      // TABLE_SWITCHED goes out before the apply below, so the sidebar
+      // lifts the PREVIOUS table's lock before this table's own
+      // APPLY_BLOCKED/APPLY_OK lands. The sidebar's handler re-reads the
+      // model's settings, and that pull chain ends in the preview fetch,
+      // so no separate PREVIEW_SAMPLES_CHANGED send is needed.
       chrome.runtime.sendMessage({ action: 'TABLE_SWITCHED' });
     } catch (e) {
       // sidebar may be torn down; harmless
     }
+    // With the sidebar open, a click on a different table connects that
+    // table and syncs it to the model — the same apply a sidebar reopen
+    // runs (see SIDEBAR_OPENED) — instead of toggling it with the shipped
+    // defaults, so the table always matches what the panel is about to
+    // show (issue #251). applySidebarRounding sends the apply and range
+    // messages and syncs the on-page toggle itself. No TABLE_TOGGLE_STATE
+    // here: the panel redraws from the model pull.
+    applySidebarRounding(table, DR_STORE.getSettings());
+    return;
   }
   runToggleAction(table);
   syncSwitchForTable(table);

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -53,9 +53,9 @@ DR_BUS.subscribe('state:settingsChanged', ({ settings }) => {
 // (an immediate mouse/keyboard click, or the second tap of a touch/pen
 // two-tap) as this one intent instead of calling runToggleAction or
 // toggleOriginalValues itself. This is where that intent turns into: the
-// select-if-different rebind (and the sidebar-reset messaging it implies),
-// the toggle action, and the sidebar's live toggle-state messaging — all
-// controller decisions that used to live inline in the view's click handler.
+// select-if-different rebind (and its TABLE_SWITCHED message), the toggle
+// action, and the sidebar's live toggle-state messaging — all controller
+// decisions that used to live inline in the view's click handler.
 DR_BUS.subscribe('intent:toggleTable', ({ table }) => {
   if (DR_STORE.isSidebarOpen() && DR_STORE.getSelectedTable() && table !== DR_STORE.getSelectedTable()) {
     // Report the intent instead of writing DR_STORE directly here — one
@@ -63,12 +63,10 @@ DR_BUS.subscribe('intent:toggleTable', ({ table }) => {
     // even when a second intent (toggle) is what triggered it.
     DR_BUS.publish('intent:selectTable', { table });
     try {
-      chrome.runtime.sendMessage({ action: 'RESET_SIDEBAR_TO_DEFAULTS' });
-    } catch (e) {
-      // sidebar may be torn down; harmless
-    }
-    try {
-      chrome.runtime.sendMessage({ action: 'PREVIEW_SAMPLES_CHANGED' });
+      // One message per switch. The sidebar's handler re-reads the model's
+      // settings (issue #251) and that pull chain ends in the preview
+      // fetch, so no separate PREVIEW_SAMPLES_CHANGED send is needed here.
+      chrome.runtime.sendMessage({ action: 'TABLE_SWITCHED' });
     } catch (e) {
       // sidebar may be torn down; harmless
     }
@@ -176,8 +174,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     const selected = DR_STORE.getSelectedTable();
     if (selected) {
       applySidebarRounding(selected, DR_STORE.getSettings());
-      // Tell the sidebar its cached preview samples are stale; it will re-pull
-      // GET_PREVIEW_SAMPLES against the now-current targeted table.
+      // Tell the sidebar its view is stale; it re-reads the model's settings
+      // and re-pulls GET_PREVIEW_SAMPLES against the now-current targeted
+      // table.
       try {
         chrome.runtime.sendMessage({ action: 'PREVIEW_SAMPLES_CHANGED' });
       } catch (e) {

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -52,10 +52,12 @@ DR_BUS.subscribe('state:settingsChanged', ({ settings }) => {
 // ui-toggle.js's click handler reports every committed toggle activation
 // (an immediate mouse/keyboard click, or the second tap of a touch/pen
 // two-tap) as this one intent instead of calling runToggleAction or
-// toggleOriginalValues itself. This is where that intent turns into: the
-// select-if-different rebind (and its TABLE_SWITCHED message), the toggle
-// action, and the sidebar's live toggle-state messaging — all controller
-// decisions that used to live inline in the view's click handler.
+// toggleOriginalValues itself. This is where that intent turns into one of
+// two controller actions: a click on a DIFFERENT table while the sidebar
+// is open connects that table and syncs it to the model (the rebind
+// branch, with its TABLE_SWITCHED message); every other click runs the
+// plain toggle with the sidebar's live toggle-state messaging. All of it
+// used to live inline in the view's click handler.
 DR_BUS.subscribe('intent:toggleTable', ({ table }) => {
   if (DR_STORE.isSidebarOpen() && DR_STORE.getSelectedTable() && table !== DR_STORE.getSelectedTable()) {
     // Report the intent instead of writing DR_STORE directly here — one

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -592,8 +592,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // reset the main toggle to the shipped default (issue #251).
     pullSettingsAndApplyToUI();
   } else if (request.action === 'TABLE_SWITCHED') {
-    // A table switch: the lock, if any, belonged to the previous table. The
-    // new table's own reconnect apply re-locks if it must (APPLY_BLOCKED).
+    // A table switch: the lock, if any, belonged to the previous table.
+    // The switch apply on the content side runs after this message is
+    // sent, so its APPLY_BLOCKED re-locks the panel right after this lift
+    // when the new table is stuck.
     document.body.classList.remove('table-locked');
     enabledEl.disabled = false;
     // The panel mirrors the model's settings on any switch (issue #251); it
@@ -622,7 +624,14 @@ window.addEventListener('unload', () => {
 // can never drift apart no matter which one supplied the values.
 function applySettingsToUI(settings) {
   const s = Object.assign({}, DR_DEFAULTS, settings || {});
-  enabledEl.checked = s.enabled !== false;
+  // The #262 lock forces the main toggle ON + disabled while the bound
+  // table is stuck simplified. A pull resolving under the lock — a
+  // reconnect refresh whose apply just re-blocked — must not write the
+  // model's enabled over that forced ON; every other control still
+  // mirrors the model.
+  if (!document.body.classList.contains('table-locked')) {
+    enabledEl.checked = s.enabled !== false;
+  }
   for (const id in CHECKBOX_TO_SETTING) {
     const el = document.getElementById(id);
     if (el) el.checked = !!s[CHECKBOX_TO_SETTING[id]];

--- a/chrome-extension/sidebar.js
+++ b/chrome-extension/sidebar.js
@@ -30,9 +30,10 @@ function setTableBound(isBound) {
     enabledEl.checked = false;
     statusEl.textContent = NO_TABLE_STATUS_MSG;
   } else {
-    // A table is now bound: restore the toggle to the shared default (the
-    // per-table state then arrives via TABLE_TOGGLE_STATE / reset).
-    enabledEl.checked = DR_DEFAULTS.enabled !== false;
+    // A table is now bound. The main toggle is not touched here: the model
+    // is its source (issue #251) — applySettingsToUI on a pull, or
+    // applyDefaultsToUI on the pull's fallback, has already set it, and a
+    // bind must not reset it to the shipped default.
     if (statusEl.textContent === NO_TABLE_STATUS_MSG) {
       statusEl.textContent = '';
     }
@@ -344,14 +345,12 @@ function renderPreviewBands() {
   renderBotBand(botBandEl, cachedSamples.bottom, botVal, cachedMaxMag);
 }
 
-// pulledSettings is optional: when this call is the tail end of
-// pullSettingsAndApplyToUI (sidebar reopen), it carries the settings object
-// just pulled from the model. setTableBound(true) below resets enabledEl to
-// the shared default on every bind, which is correct for a live rebind
-// (PREVIEW_SAMPLES_CHANGED) but would clobber a pulled enabled:false with a
-// bound table — so when pulledSettings is present, its enabled value wins
-// back over that default once the bind has resolved.
-function fetchPreviewSamples(pulledSettings) {
+// Refreshes the preview bands from the selected table; the bound/unbound
+// state is a side effect of the response (samples !== null means bound).
+// The main toggle is not written on the bound path: setTableBound(true)
+// leaves it to the settings apply that ran before this call (issue #251),
+// so no pulled value needs threading back in after the bind resolves.
+function fetchPreviewSamples() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (!tabs[0]) return;
     chrome.tabs.sendMessage(tabs[0].id, { action: 'GET_PREVIEW_SAMPLES' }, (response) => {
@@ -363,10 +362,6 @@ function fetchPreviewSamples(pulledSettings) {
         cachedSamples = response.samples;
         cachedMaxMag = response.maxMag;
         setTableBound(response.samples !== null);
-        if (response.samples !== null && pulledSettings) {
-          enabledEl.checked = pulledSettings.enabled !== false;
-          updateDisabledState();
-        }
       }
       renderPreviewBands();
     });
@@ -592,15 +587,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     document.body.classList.remove('table-locked');
     enabledEl.disabled = false;
   } else if (request.action === 'PREVIEW_SAMPLES_CHANGED') {
-    fetchPreviewSamples();
-  } else if (request.action === 'RESET_SIDEBAR_TO_DEFAULTS') {
+    // Stale view: re-read the model's settings, then the previews (the pull
+    // chain ends in fetchPreviewSamples). A bare preview fetch here used to
+    // reset the main toggle to the shipped default (issue #251).
+    pullSettingsAndApplyToUI();
+  } else if (request.action === 'TABLE_SWITCHED') {
     // A table switch: the lock, if any, belonged to the previous table. The
     // new table's own reconnect apply re-locks if it must (APPLY_BLOCKED).
     document.body.classList.remove('table-locked');
     enabledEl.disabled = false;
+    // The panel mirrors the model's settings on any switch (issue #251); it
+    // does not reset to the shipped defaults.
     try {
-      applyDefaultsToUI();
-      fetchPreviewSamples();
+      pullSettingsAndApplyToUI();
     } catch (e) {
       // sidebar may be in teardown; harmless
     }
@@ -642,26 +641,24 @@ function applySettingsToUI(settings) {
 }
 
 // Seed the UI from the shared defaults so the sidebar and content.js never
-// drift apart even before a table has ever been selected (RESET_SIDEBAR_TO_
-// DEFAULTS, and this file's own fallback when the live pull below fails).
+// drift apart even before a table has ever been selected (this file's own
+// fallback when the live pull below fails).
 function applyDefaultsToUI() {
   applySettingsToUI(DR_DEFAULTS);
 }
 
-// Reconnect: pull the model's current settings from content.js (the
-// settings' sole owner) rather than resetting to shipped defaults on every
-// sidebar open — a close/reopen must not lose what the user configured. No
-// active tab, no content script yet, or no response at all falls back to
-// defaults, same as before this pull existed.
+// Reconnect, table switch, or stale-view refresh: pull the model's current
+// settings from content.js (the settings' sole owner) rather than resetting
+// to shipped defaults — neither a close/reopen nor a switch may lose what
+// the user configured (issue #251). No active tab, no content script yet,
+// or no response at all falls back to defaults, same as before this pull
+// existed.
 //
 // fetchPreviewSamples runs only after the pull settles (success or fallback),
 // never in parallel with it: fetchPreviewSamples's own setTableBound call is
 // what forces enabledEl back off when no table is bound, and that must stay
 // the last word — racing it against this pull could let a pulled "enabled:
-// true" win the UI over an actual no-table state. When the pull DID resolve a
-// settings object, that same object is threaded into fetchPreviewSamples so
-// it can restore a pulled "enabled: false" after its own bound branch resets
-// enabledEl to the shared default (see fetchPreviewSamples above).
+// true" win the UI over an actual no-table state.
 function pullSettingsAndApplyToUI() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (!tabs[0]) {
@@ -675,7 +672,7 @@ function pullSettingsAndApplyToUI() {
         fetchPreviewSamples();
       } else {
         applySettingsToUI(response.settings);
-        fetchPreviewSamples(response.settings);
+        fetchPreviewSamples();
       }
     });
   });

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -5101,8 +5101,8 @@ function fireTouchSecondTap(buttonEl) {
   eq('rebind AC1 mouse: PREVIEW_SAMPLES_CHANGED not dispatched on a switch',
     previewCalls.length, 0);
 
-  // 1d. Toggle still runs (cells get rounded, since table has numbers)
-  eq('rebind AC1 mouse: toggle action ran against tableB (cells rounded)',
+  // 1d. The switch apply rounds tableB (the model's enabled is on)
+  eq('rebind AC1 mouse: the switch apply rounded tableB',
     hasRounded_mouse, true);
 })();
 
@@ -5152,7 +5152,7 @@ function fireTouchSecondTap(buttonEl) {
   eq('rebind AC1 touch: PREVIEW_SAMPLES_CHANGED not dispatched on a switch',
     previewCalls.length, 0);
 
-  eq('rebind AC1 touch: toggle action ran against tableB (cells rounded)',
+  eq('rebind AC1 touch: the switch apply rounded tableB',
     hasRounded_touch, true);
 })();
 
@@ -5427,6 +5427,51 @@ function fireTouchSecondTap(buttonEl) {
     rounded, false);
   eq('sync-on-switch: the clicked table\'s applied flag stays original under enabled:false',
     flag, 'original');
+})();
+
+// Switching onto a LOCKED table (issue #262): the clicked table carries a
+// dr-ext-rounded cell with no registry original, so the switch apply's
+// resetTable refuses. The pin here is the ORDER — TABLE_SWITCHED must leave
+// before APPLY_BLOCKED, because the sidebar lifts the PREVIOUS table's lock
+// on TABLE_SWITCHED and the new table's APPLY_BLOCKED must land after that
+// lift to re-lock the panel. A send moved after the apply would leave a
+// stuck table showing an unlocked panel with nothing failing.
+//
+// The intent is published straight onto the bus: the view refuses clicks on
+// a locked pill (issue #263's aria-disabled guard), but a table can become
+// unrestorable between pill syncs, so the controller's own entry point must
+// hold the order on its own.
+(function issue251_switchOntoLockedTablePinsMessageOrder() {
+  const tableA = makeToggleTable([
+    [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
+    [{ tag: 'td', text: '8,584,629' }, { tag: 'td', text: '286' }],
+  ]);
+  tableA._cells.forEach(c => { c.querySelectorAll = () => []; });
+  const tableB = makeToggleTable([
+    [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
+    [{ tag: 'td', text: '8,584,629' }, { tag: 'td', text: '286' }],
+  ]);
+  tableB._cells.forEach(c => { c.querySelectorAll = () => []; });
+  // The unrestorable pairing: rounded class, no DR_STORE original.
+  tableB._cells[2].classList.add('dr-ext-rounded');
+
+  const sentMessages = [];
+  const origSendMessage = global.chrome.runtime.sendMessage;
+  global.chrome.runtime.sendMessage = (msg) => { sentMessages.push(msg); };
+
+  sidebarOpen = true;
+  lastRightClickedTable = tableA;
+
+  DR_BUS.publish('intent:toggleTable', { table: tableB });
+
+  global.chrome.runtime.sendMessage = origSendMessage;
+  sidebarOpen = false;
+  lastRightClickedTable = null;
+
+  eq('locked-switch: the sequence is TABLE_SWITCHED then APPLY_BLOCKED, nothing else',
+    sentMessages.map(m => m.action), ['TABLE_SWITCHED', 'APPLY_BLOCKED']);
+  eq('locked-switch: APPLY_BLOCKED carries the unrestorable-cell count',
+    sentMessages[1] && sentMessages[1].count, 1);
 })();
 
 // ---------------------------------------------------------------------------

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -5339,6 +5339,97 @@ function fireTouchSecondTap(buttonEl) {
 })();
 
 // ---------------------------------------------------------------------------
+// Issue #251 (sync-on-switch): a switch with the sidebar open applies the
+// MODEL's settings to the clicked table — the panel then mirrors the model,
+// and the table matches what the panel shows. Two cells: a non-default
+// offset reaches the new table's rounding pass, and a model holding
+// enabled:false leaves the new table unrounded.
+// ---------------------------------------------------------------------------
+
+(function issue251_switchAppliesModelToNewTable() {
+  const savedSettings = DR_STORE.getSettings();
+  DR_STORE.setSettings(Object.assign({}, DR_DEFAULTS, { offsetTop: -2, offsetOther: -2 }));
+
+  const tableA = makeToggleTable([
+    [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
+    [{ tag: 'td', text: '8,584,629' }, { tag: 'td', text: '286' }],
+  ]);
+  tableA._cells.forEach(c => { c.querySelectorAll = () => []; });
+  // The value that must visibly round under offsetTop -2 sits in the SECOND
+  // column: the shipped defaults leave the first column alone, and 286 at
+  // offset -2 rounds to itself, so a first-column 8,584,629 would let a
+  // defaults-run pass hide.
+  const tableB = makeToggleTable([
+    [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
+    [{ tag: 'td', text: '286' }, { tag: 'td', text: '8,584,629' }],
+  ]);
+  tableB._cells.forEach(c => { c.querySelectorAll = () => []; });
+
+  const origSendMessage = global.chrome.runtime.sendMessage;
+  global.chrome.runtime.sendMessage = () => {};
+
+  sidebarOpen = true;
+  lastRightClickedTable = tableA;
+
+  const buttonB = createToggleWithSpies(tableB);
+  fireMouseClick(buttonB);
+
+  const rounded = tableB._cells.some(c => c.classList.contains('dr-ext-rounded'));
+  const usedOpts = DR_STORE.getTableRoundOptions(tableB);
+
+  global.chrome.runtime.sendMessage = origSendMessage;
+  sidebarOpen = false;
+  lastRightClickedTable = null;
+  DR_STORE.setSettings(savedSettings);
+
+  eq('sync-on-switch: the clicked table is rounded (model enabled is on)',
+    rounded, true);
+  eq('sync-on-switch: the rounding pass ran with the model\'s offset, not the shipped default',
+    usedOpts && usedOpts.offsetTop, -2);
+})();
+
+(function issue251_switchRespectsModelEnabledOff() {
+  const savedSettings = DR_STORE.getSettings();
+  DR_STORE.setSettings(Object.assign({}, DR_DEFAULTS, { enabled: false }));
+
+  const tableA = makeToggleTable([
+    [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
+    [{ tag: 'td', text: '8,584,629' }, { tag: 'td', text: '286' }],
+  ]);
+  tableA._cells.forEach(c => { c.querySelectorAll = () => []; });
+  // Values that visibly change under the shipped default offset (see the
+  // wire-message test's note: 1,000,000-style values round to themselves
+  // and would let a wrongly-run rounding pass hide).
+  const tableB = makeToggleTable([
+    [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
+    [{ tag: 'td', text: '8,584,629' }, { tag: 'td', text: '286' }],
+  ]);
+  tableB._cells.forEach(c => { c.querySelectorAll = () => []; });
+
+  const origSendMessage = global.chrome.runtime.sendMessage;
+  global.chrome.runtime.sendMessage = () => {};
+
+  sidebarOpen = true;
+  lastRightClickedTable = tableA;
+
+  const buttonB = createToggleWithSpies(tableB);
+  fireMouseClick(buttonB);
+
+  const rounded = tableB._cells.some(c => c.classList.contains('dr-ext-rounded'));
+  const flag = DR_STORE.getTableAppliedFlag(tableB);
+
+  global.chrome.runtime.sendMessage = origSendMessage;
+  sidebarOpen = false;
+  lastRightClickedTable = null;
+  DR_STORE.setSettings(savedSettings);
+
+  eq('sync-on-switch: a model holding enabled:false leaves the clicked table unrounded',
+    rounded, false);
+  eq('sync-on-switch: the clicked table\'s applied flag stays original under enabled:false',
+    flag, 'original');
+})();
+
+// ---------------------------------------------------------------------------
 // Source-level assertions (supplementary): verify structural invariants that
 // cover both click branches and the sidebar.js handler in a single pass.
 // These complement the live tests above and are an accepted fallback pattern
@@ -5407,20 +5498,23 @@ function fireTouchSecondTap(buttonEl) {
     false);
 
   // sidebar.js: TABLE_SWITCHED handler re-reads the model's settings (issue
-  // #251) instead of resetting the controls to the shipped defaults. Window
-  // sized for the unlock lines (issue #262) at the handler's top.
+  // #251) instead of resetting the controls to the shipped defaults. The
+  // handler block is isolated up to the next `} else if` so the negative
+  // pins below cover the whole handler, not a fixed character window.
+  const switchHandlerMatch = sidebarSrc.match(/=== 'TABLE_SWITCHED'\)\s*\{([\s\S]*?)\n  \} else if/);
+  const switchHandlerBlock = switchHandlerMatch ? switchHandlerMatch[1] : '';
+  eq('rebind source: sidebar.js TABLE_SWITCHED handler block was isolated (sanity check on the scan itself)',
+    switchHandlerBlock.length > 0, true);
   eq('rebind source: sidebar.js TABLE_SWITCHED handler calls pullSettingsAndApplyToUI()',
-    /TABLE_SWITCHED[\s\S]{0,400}pullSettingsAndApplyToUI\(\)/.test(sidebarSrc), true);
+    /pullSettingsAndApplyToUI\(\)/.test(switchHandlerBlock), true);
 
   // sidebar.js: TABLE_SWITCHED handler does NOT reset the controls to the
   // shipped defaults — that reset is what desynced the panel from the model.
-  const switchHandlerMatch = sidebarSrc.match(/TABLE_SWITCHED[\s\S]{0,400}/);
-  const switchHandlerBlock = switchHandlerMatch ? switchHandlerMatch[0] : '';
   eq('rebind source: sidebar.js TABLE_SWITCHED handler does NOT call applyDefaultsToUI()',
     /applyDefaultsToUI\s*\(\)/.test(switchHandlerBlock), false);
 
   // sidebar.js: TABLE_SWITCHED handler does NOT auto-apply settings
-  // (must NOT call applyNow() or applySidebarRounding() inside the handler)
+  // (must NOT call applyNow() inside the handler)
   eq('rebind source: sidebar.js TABLE_SWITCHED handler does NOT call applyNow()',
     /applyNow\s*\(\)/.test(switchHandlerBlock), false);
 })();
@@ -10687,13 +10781,13 @@ function fireMouseClick(buttonEl, fn) {
   eq('AC3 impl: clicking non-lastRightClickedTable sends TABLE_SWITCHED',
     switchMsgs.length >= 1, true);
 
-  // GAP (spec vs impl): spec says TABLE_TOGGLE_STATE must NOT be sent for a
-  // non-matching table, but the implementation DOES send it (after reassignment).
-  // This test documents the actual behaviour; the reviewer should determine
-  // whether this is intentional (the sidebar auto-redirects to the new table)
-  // or a spec violation.
-  eq('AC3 GAP: implementation sends TABLE_TOGGLE_STATE even for non-lastRightClickedTable (after reassignment)',
-    toggleMsgs.length >= 1, true);
+  // The AC3 spec ("toggling a non-selected table sends no TABLE_TOGGLE_STATE")
+  // is satisfied since issue #251's sync-on-switch: the switch path applies
+  // the model to the new table and returns before the same-table
+  // TABLE_TOGGLE_STATE send, and the panel redraws from the model pull that
+  // TABLE_SWITCHED triggers instead.
+  eq('AC3: clicking non-lastRightClickedTable sends NO TABLE_TOGGLE_STATE (panel redraws from the model pull)',
+    toggleMsgs.length, 0);
 })();
 
 // AC3 guard that DOES hold: when lastRightClickedTable is null,
@@ -12489,7 +12583,7 @@ function fireMouseClick(buttonEl, fn) {
     // Issue #251: the bound branch must not reset the pill to the shipped
     // default — the model (or the pull's explicit defaults fallback) is the
     // pill's only source once a table is bound.
-    eq('no-table toggle: sidebar.js setTableBound bound branch no longer references DR_DEFAULTS (issue #251)',
+    eq('no-table toggle: sidebar.js setTableBound no longer references DR_DEFAULTS anywhere (issue #251)',
       /DR_DEFAULTS/.test(setTableBoundFnBody), false);
 
     // AC2 gap — ADVERSARIAL: verify that the sidebar does NOT have a runtime
@@ -14662,17 +14756,21 @@ const LADDER_OPTS = {
       { action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' },
       { action: 'TABLE_TOGGLE_STATE', enabled: true },
     ],
-    // Issue #251 changed this cell's contract deliberately: the switch
-    // message was renamed to TABLE_SWITCHED (its sidebar handler pulls the
-    // model's settings instead of resetting to defaults), and the separate
-    // PREVIEW_SAMPLES_CHANGED send was dropped — the pull chain already ends
-    // in the preview fetch. The other three cells stay byte-identical to the
-    // frozen parent capture.
+    // Issue #251 changed this cell's contract deliberately. A switch with
+    // the sidebar open now syncs the clicked table to the model — the same
+    // applySidebarRounding a sidebar reopen runs — instead of toggling it
+    // with the shipped defaults. TABLE_SWITCHED goes out first so the
+    // sidebar lifts the previous table's lock before the apply's own
+    // APPLY_BLOCKED/APPLY_OK lands; the apply then emits its usual
+    // messages. No PREVIEW_SAMPLES_CHANGED (the sidebar's pull chain ends
+    // in the preview fetch) and no TABLE_TOGGLE_STATE (the panel redraws
+    // from the model pull). The other three cells stay byte-identical to
+    // the frozen parent capture.
     'true:false': [
       { action: 'TABLE_SWITCHED' },
+      { action: 'APPLY_OK' },
       { action: 'RANGE_OK' },
       { action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' },
-      { action: 'TABLE_TOGGLE_STATE', enabled: true },
     ],
     'false:true': [
       { action: 'RANGE_OK' },
@@ -15779,6 +15877,40 @@ function makeIssue251SidebarHarness() {
     h.dispatch({ action: 'PREVIEW_SAMPLES_CHANGED' });
     eq('refresh-pull: the main toggle mirrors the model\'s enabled:false after a preview refresh',
       h.enabledEl.checked, false);
+  } finally {
+    h.restore();
+  }
+})();
+
+(function issue251_lockOutlivesAPullResolvingUnderIt() {
+  const h = makeIssue251SidebarHarness();
+  if (!h) {
+    eq('lock-vs-pull: source files (defaults/rounding/core/messaging) present in manifest',
+      false, true);
+    return;
+  }
+  try {
+    eq('lock-vs-pull: sidebar.js loaded with no stub gaps', h.evalError, null);
+    eq('lock-vs-pull: sidebar onMessage handler was captured', h.hasHandler(), true);
+    if (h.evalError !== null || !h.hasHandler()) return;
+
+    // Issue #262's lock forces the main toggle ON + disabled (the bound
+    // table is stuck simplified). A settings pull that resolves while the
+    // lock is displayed — a reconnect refresh whose apply just re-blocked —
+    // must not write the model's enabled:false over the lock's forced ON.
+    // Ordering here mirrors the wire: APPLY_BLOCKED lands, then the
+    // stale-view refresh runs its pull.
+    h.dispatch({ action: 'APPLY_BLOCKED', count: 1 });
+    eq('lock-vs-pull: precondition — APPLY_BLOCKED locked the panel',
+      h.bodyClasses.has('table-locked'), true);
+
+    h.dispatch({ action: 'PREVIEW_SAMPLES_CHANGED' });
+    eq('lock-vs-pull: the pull leaves the locked toggle ON — the table IS simplified',
+      h.enabledEl.checked, true);
+    eq('lock-vs-pull: the pull leaves the locked toggle disabled',
+      h.enabledEl.disabled, true);
+    eq('lock-vs-pull: the lock itself survives the pull',
+      h.bodyClasses.has('table-locked'), true);
   } finally {
     h.restore();
   }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -5086,15 +5086,20 @@ function fireTouchSecondTap(buttonEl) {
   eq('rebind AC1 mouse: lastRightClickedTable rebound to tableB',
     reboundToB_mouse, true);
 
-  // 1b. RESET_SIDEBAR_TO_DEFAULTS dispatched exactly once
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC1 mouse: RESET_SIDEBAR_TO_DEFAULTS dispatched exactly once',
-    resetCalls.length, 1);
+  // 1b. TABLE_SWITCHED dispatched exactly once. Issue #251 renamed the
+  // switch message from RESET_SIDEBAR_TO_DEFAULTS: the sidebar's handler now
+  // pulls the model's settings, and the old name described the defaults
+  // reset that fix removed.
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC1 mouse: TABLE_SWITCHED dispatched exactly once',
+    switchCalls.length, 1);
 
-  // 1c. PREVIEW_SAMPLES_CHANGED also dispatched
+  // 1c. PREVIEW_SAMPLES_CHANGED NOT dispatched — the TABLE_SWITCHED pull
+  // chain already ends in the preview fetch; a second trigger would be a
+  // duplicate round-trip.
   const previewCalls = sentMessages.filter(m => m.action === 'PREVIEW_SAMPLES_CHANGED');
-  eq('rebind AC1 mouse: PREVIEW_SAMPLES_CHANGED dispatched',
-    previewCalls.length >= 1, true);
+  eq('rebind AC1 mouse: PREVIEW_SAMPLES_CHANGED not dispatched on a switch',
+    previewCalls.length, 0);
 
   // 1d. Toggle still runs (cells get rounded, since table has numbers)
   eq('rebind AC1 mouse: toggle action ran against tableB (cells rounded)',
@@ -5139,13 +5144,13 @@ function fireTouchSecondTap(buttonEl) {
   eq('rebind AC1 touch: lastRightClickedTable rebound to tableB',
     reboundToB_touch, true);
 
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC1 touch: RESET_SIDEBAR_TO_DEFAULTS dispatched exactly once',
-    resetCalls.length, 1);
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC1 touch: TABLE_SWITCHED dispatched exactly once',
+    switchCalls.length, 1);
 
   const previewCalls = sentMessages.filter(m => m.action === 'PREVIEW_SAMPLES_CHANGED');
-  eq('rebind AC1 touch: PREVIEW_SAMPLES_CHANGED dispatched',
-    previewCalls.length >= 1, true);
+  eq('rebind AC1 touch: PREVIEW_SAMPLES_CHANGED not dispatched on a switch',
+    previewCalls.length, 0);
 
   eq('rebind AC1 touch: toggle action ran against tableB (cells rounded)',
     hasRounded_touch, true);
@@ -5176,10 +5181,10 @@ function fireTouchSecondTap(buttonEl) {
   sidebarOpen = false;
   lastRightClickedTable = null;
 
-  // Same-table guard: RESET must NOT be dispatched
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC2 mouse: RESET_SIDEBAR_TO_DEFAULTS NOT dispatched for same-table click',
-    resetCalls.length, 0);
+  // Same-table guard: the switch message must NOT be dispatched
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC2 mouse: TABLE_SWITCHED NOT dispatched for same-table click',
+    switchCalls.length, 0);
 })();
 
 // ---------------------------------------------------------------------------
@@ -5207,9 +5212,9 @@ function fireTouchSecondTap(buttonEl) {
   sidebarOpen = false;
   lastRightClickedTable = null;
 
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC2 touch: RESET_SIDEBAR_TO_DEFAULTS NOT dispatched for same-table click',
-    resetCalls.length, 0);
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC2 touch: TABLE_SWITCHED NOT dispatched for same-table click',
+    switchCalls.length, 0);
 })();
 
 // ---------------------------------------------------------------------------
@@ -5243,9 +5248,9 @@ function fireTouchSecondTap(buttonEl) {
   global.chrome.runtime.sendMessage = origSendMessage;
   lastRightClickedTable = null;
 
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC3 mouse: RESET_SIDEBAR_TO_DEFAULTS NOT dispatched when sidebar closed',
-    resetCalls.length, 0);
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC3 mouse: TABLE_SWITCHED NOT dispatched when sidebar closed',
+    switchCalls.length, 0);
 })();
 
 // ---------------------------------------------------------------------------
@@ -5278,14 +5283,14 @@ function fireTouchSecondTap(buttonEl) {
   global.chrome.runtime.sendMessage = origSendMessage;
   lastRightClickedTable = null;
 
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC3 touch: RESET_SIDEBAR_TO_DEFAULTS NOT dispatched when sidebar closed',
-    resetCalls.length, 0);
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC3 touch: TABLE_SWITCHED NOT dispatched when sidebar closed',
+    switchCalls.length, 0);
 })();
 
 // ---------------------------------------------------------------------------
 // AC4: CLOSE_SIDEBAR flips sidebarOpen back to false; subsequent different-table
-//      click does NOT dispatch RESET_SIDEBAR_TO_DEFAULTS.
+//      click does NOT dispatch TABLE_SWITCHED.
 //
 // Because chrome.runtime.onMessage.addListener is a no-op stub, we deliver
 // SIDEBAR_OPENED / CLOSE_SIDEBAR by setting sidebarOpen directly via the
@@ -5328,9 +5333,9 @@ function fireTouchSecondTap(buttonEl) {
   global.chrome.runtime.sendMessage = origSendMessage;
   lastRightClickedTable = null;
 
-  const resetCalls = sentMessages.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
-  eq('rebind AC4: after CLOSE_SIDEBAR, different-table click does NOT dispatch RESET',
-    resetCalls.length, 0);
+  const switchCalls = sentMessages.filter(m => m.action === 'TABLE_SWITCHED');
+  eq('rebind AC4: after CLOSE_SIDEBAR, different-table click does NOT dispatch TABLE_SWITCHED',
+    switchCalls.length, 0);
 })();
 
 // ---------------------------------------------------------------------------
@@ -5377,14 +5382,16 @@ function fireTouchSecondTap(buttonEl) {
     true);
 
   // content.js: sprint toggle-split consolidated the mouse and touch click
-  // branches' controller logic (which used to each carry their own
-  // RESET_SIDEBAR_TO_DEFAULTS send) into one intent:toggleTable subscriber
-  // in content.js, so the literal now appears once, not per branch. The
-  // occurrence-count check below was written when each branch sent it
-  // separately; it now checks the single, shared dispatch site still exists.
-  const resetCount = (contentSrc.match(/RESET_SIDEBAR_TO_DEFAULTS/g) || []).length;
-  eq('rebind source: RESET_SIDEBAR_TO_DEFAULTS is dispatched from the shared intent:toggleTable handler (>= 1 occurrence)',
-    resetCount >= 1, true);
+  // branches' controller logic (which used to each carry their own switch
+  // send) into one intent:toggleTable subscriber in content.js, so the
+  // literal now appears once, not per branch. Issue #251 renamed the switch
+  // message from RESET_SIDEBAR_TO_DEFAULTS to TABLE_SWITCHED — the sidebar's
+  // handler pulls the model's settings instead of resetting to defaults.
+  const switchCount = (contentSrc.match(/TABLE_SWITCHED/g) || []).length;
+  eq('rebind source: TABLE_SWITCHED is dispatched from the shared intent:toggleTable handler (>= 1 occurrence)',
+    switchCount >= 1, true);
+  eq('rebind source: the RESET_SIDEBAR_TO_DEFAULTS message is gone from the content-script source',
+    /RESET_SIDEBAR_TO_DEFAULTS/.test(contentSrc), false);
 
   // content.js: the intent:toggleTable handler's rebind branch publishes the
   // select-table intent instead of assigning DR_STORE's field directly —
@@ -5399,21 +5406,23 @@ function fireTouchSecondTap(buttonEl) {
     /\blastRightClickedTable\s*=[^=]/.test(sourceByName('content.js') || ''),
     false);
 
-  // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler calls applyDefaultsToUI.
-  // Window sized for the unlock lines (issue #262) at the handler's top.
-  eq('rebind source: sidebar.js RESET_SIDEBAR_TO_DEFAULTS handler calls applyDefaultsToUI()',
-    /RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,400}applyDefaultsToUI\(\)/.test(sidebarSrc), true);
+  // sidebar.js: TABLE_SWITCHED handler re-reads the model's settings (issue
+  // #251) instead of resetting the controls to the shipped defaults. Window
+  // sized for the unlock lines (issue #262) at the handler's top.
+  eq('rebind source: sidebar.js TABLE_SWITCHED handler calls pullSettingsAndApplyToUI()',
+    /TABLE_SWITCHED[\s\S]{0,400}pullSettingsAndApplyToUI\(\)/.test(sidebarSrc), true);
 
-  // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler calls fetchPreviewSamples
-  eq('rebind source: sidebar.js RESET_SIDEBAR_TO_DEFAULTS handler calls fetchPreviewSamples()',
-    /RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,400}fetchPreviewSamples\(\)/.test(sidebarSrc), true);
+  // sidebar.js: TABLE_SWITCHED handler does NOT reset the controls to the
+  // shipped defaults — that reset is what desynced the panel from the model.
+  const switchHandlerMatch = sidebarSrc.match(/TABLE_SWITCHED[\s\S]{0,400}/);
+  const switchHandlerBlock = switchHandlerMatch ? switchHandlerMatch[0] : '';
+  eq('rebind source: sidebar.js TABLE_SWITCHED handler does NOT call applyDefaultsToUI()',
+    /applyDefaultsToUI\s*\(\)/.test(switchHandlerBlock), false);
 
-  // sidebar.js: RESET_SIDEBAR_TO_DEFAULTS handler does NOT auto-apply settings
+  // sidebar.js: TABLE_SWITCHED handler does NOT auto-apply settings
   // (must NOT call applyNow() or applySidebarRounding() inside the handler)
-  const resetHandlerMatch = sidebarSrc.match(/RESET_SIDEBAR_TO_DEFAULTS[\s\S]{0,400}/);
-  const resetHandlerBlock = resetHandlerMatch ? resetHandlerMatch[0] : '';
-  eq('rebind source: sidebar.js RESET handler does NOT call applyNow()',
-    /applyNow\s*\(\)/.test(resetHandlerBlock), false);
+  eq('rebind source: sidebar.js TABLE_SWITCHED handler does NOT call applyNow()',
+    /applyNow\s*\(\)/.test(switchHandlerBlock), false);
 })();
 
 // =============================================================================
@@ -10632,7 +10641,7 @@ function fireMouseClick(buttonEl, fn) {
 //
 // IMPLEMENTATION BEHAVIOUR (found by adversarial test):
 // When table !== lastRightClickedTable, the click handler first reassigns
-// `lastRightClickedTable = table` (and sends RESET_SIDEBAR_TO_DEFAULTS), then
+// `lastRightClickedTable = table` (and sends TABLE_SWITCHED), then
 // the TABLE_TOGGLE_STATE guard re-checks — and now `table === lastRightClickedTable`
 // is TRUE, so TABLE_TOGGLE_STATE IS sent.
 //
@@ -10662,7 +10671,7 @@ function fireMouseClick(buttonEl, fn) {
 
   fireMouseClick(buttonA);
 
-  const resetMsgs   = sent.filter(m => m.action === 'RESET_SIDEBAR_TO_DEFAULTS');
+  const switchMsgs  = sent.filter(m => m.action === 'TABLE_SWITCHED');
   const toggleMsgs  = sent.filter(m => m.action === 'TABLE_TOGGLE_STATE');
   const lrc = lastRightClickedTable;
 
@@ -10674,9 +10683,9 @@ function fireMouseClick(buttonEl, fn) {
   eq('AC3 impl: clicking non-lastRightClickedTable reassigns lastRightClickedTable',
     lrc === tableA, true);
 
-  // Implementation sends RESET_SIDEBAR_TO_DEFAULTS for the table switch.
-  eq('AC3 impl: clicking non-lastRightClickedTable sends RESET_SIDEBAR_TO_DEFAULTS',
-    resetMsgs.length >= 1, true);
+  // Implementation sends TABLE_SWITCHED for the table switch.
+  eq('AC3 impl: clicking non-lastRightClickedTable sends TABLE_SWITCHED',
+    switchMsgs.length >= 1, true);
 
   // GAP (spec vs impl): spec says TABLE_TOGGLE_STATE must NOT be sent for a
   // non-matching table, but the implementation DOES send it (after reassignment).
@@ -12230,9 +12239,10 @@ function fireMouseClick(buttonEl, fn) {
 //
 // AC1 – init state: body gets no-table class, #status reads the prompt message.
 // AC2 – bound state: setTableBound(true) removes no-table; also check that
-//        PREVIEW_SAMPLES_CHANGED triggers fetchPreviewSamples (the only live-rebind
-//        path) — note this means the sidebar does NOT listen for a separate
-//        SET_TABLE_BOUND message; see gap note below.
+//        PREVIEW_SAMPLES_CHANGED triggers the settings pull whose chain ends
+//        in fetchPreviewSamples (the only live-rebind path) — note this means
+//        the sidebar does NOT listen for a separate SET_TABLE_BOUND message;
+//        see gap note below.
 // AC3 – old error string is gone from sidebar.js.
 // AC4 – sidebar.html CSS disables optionsSection/advancedSection when no-table.
 // ---------------------------------------------------------------------------
@@ -12265,16 +12275,16 @@ function fireMouseClick(buttonEl, fn) {
     /setTableBound\(response\.samples\s*!==\s*null\)/.test(sidebarSrc), true);
 
   // AC2 gap check: the sidebar handles PREVIEW_SAMPLES_CHANGED by calling
-  // fetchPreviewSamples(), which then calls setTableBound inside its callback.
-  // There is NO direct setTableBound call in the PREVIEW_SAMPLES_CHANGED handler,
-  // and no separate runtime message that calls setTableBound(true) synchronously.
-  // This means the live-rebind path (user right-clicks a new table while sidebar
-  // is open) works, but ONLY because content.js sends PREVIEW_SAMPLES_CHANGED
-  // which triggers a full fetchPreviewSamples round-trip. The sidebar has no
-  // push-style binding message. We assert the handler exists and calls
-  // fetchPreviewSamples, then flag the architectural gap as a note.
-  eq('no-table AC2: PREVIEW_SAMPLES_CHANGED handler calls fetchPreviewSamples',
-    /PREVIEW_SAMPLES_CHANGED[\s\S]{0,80}fetchPreviewSamples\(\)/.test(sidebarSrc), true);
+  // pullSettingsAndApplyToUI() (issue #251: every refresh re-reads the
+  // model's settings first; its chain ends in fetchPreviewSamples, which
+  // calls setTableBound inside its callback). There is NO direct
+  // setTableBound call in the PREVIEW_SAMPLES_CHANGED handler, and no
+  // separate runtime message that calls setTableBound(true) synchronously.
+  // The sidebar has no push-style binding message. We assert the handler
+  // exists and starts the pull chain, then flag the architectural gap as a
+  // note.
+  eq('no-table AC2: PREVIEW_SAMPLES_CHANGED handler calls pullSettingsAndApplyToUI',
+    /PREVIEW_SAMPLES_CHANGED[\s\S]{0,300}pullSettingsAndApplyToUI\(\)/.test(sidebarSrc), true);
 
   // GAP NOTE: The sidebar does not handle a dedicated "TABLE_BOUND" push message.
   // If content.js ever fails to send PREVIEW_SAMPLES_CHANGED after a new right-click
@@ -12352,7 +12362,6 @@ function fireMouseClick(buttonEl, fn) {
             enabledEl.checked = false;
             statusEl.textContent = NO_TABLE_STATUS_MSG;
           } else {
-            enabledEl.checked = DR_DEFAULTS.enabled !== false;
             if (statusEl.textContent === NO_TABLE_STATUS_MSG) {
               statusEl.textContent = '';
             }
@@ -12448,15 +12457,18 @@ function fireMouseClick(buttonEl, fn) {
         getUpdateDisabledCalls() >= 1, true);
     }
 
-    // Bind restores the toggle to the shared default (true), so the init
-    // sequence setTableBound(false) → setTableBound(true) does not leave the
-    // pill stuck off once a table resolves.
+    // Bind leaves the pill alone (issue #251): the settings apply that runs
+    // before the bind resolves — applySettingsToUI on a pull, or
+    // applyDefaultsToUI on the pull's fallback — is the pill's only writer
+    // for the bound state. A bind that reset the pill to the shipped default
+    // is what desynced the panel from the model.
     {
       const { enabledEl, setTableBound } = makeEnv(undefined, true);
-      setTableBound(false); // init: no table yet → pill off
-      setTableBound(true);  // table resolved → restore default
-      eq('no-table toggle: setTableBound(true) restores pill to default on bind',
-        enabledEl.checked, true);
+      setTableBound(false);      // init: no table yet → pill off
+      enabledEl.checked = false; // the model pull applied enabled:false
+      setTableBound(true);       // table resolved → bind must not touch it
+      eq('no-table toggle: setTableBound(true) leaves the pill to the pulled value on bind',
+        enabledEl.checked, false);
     }
 
     // Static guard: the real setTableBound flips enabledEl.checked off and runs
@@ -12474,6 +12486,11 @@ function fireMouseClick(buttonEl, fn) {
       /enabledEl\.checked\s*=\s*false/.test(setTableBoundFnBody), true);
     eq('no-table toggle: sidebar.js setTableBound calls updateDisabledState',
       /updateDisabledState\(\)/.test(setTableBoundFnBody), true);
+    // Issue #251: the bound branch must not reset the pill to the shipped
+    // default — the model (or the pull's explicit defaults fallback) is the
+    // pill's only source once a table is bound.
+    eq('no-table toggle: sidebar.js setTableBound bound branch no longer references DR_DEFAULTS (issue #251)',
+      /DR_DEFAULTS/.test(setTableBoundFnBody), false);
 
     // AC2 gap — ADVERSARIAL: verify that the sidebar does NOT have a runtime
     // message handler that directly calls setTableBound(true) when a table is
@@ -14645,9 +14662,14 @@ const LADDER_OPTS = {
       { action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' },
       { action: 'TABLE_TOGGLE_STATE', enabled: true },
     ],
+    // Issue #251 changed this cell's contract deliberately: the switch
+    // message was renamed to TABLE_SWITCHED (its sidebar handler pulls the
+    // model's settings instead of resetting to defaults), and the separate
+    // PREVIEW_SAMPLES_CHANGED send was dropped — the pull chain already ends
+    // in the preview fetch. The other three cells stay byte-identical to the
+    // frozen parent capture.
     'true:false': [
-      { action: 'RESET_SIDEBAR_TO_DEFAULTS' },
-      { action: 'PREVIEW_SAMPLES_CHANGED' },
+      { action: 'TABLE_SWITCHED' },
       { action: 'RANGE_OK' },
       { action: 'UPDATE_MENU_LABEL', title: 'Toggle readable data' },
       { action: 'TABLE_TOGGLE_STATE', enabled: true },
@@ -14665,8 +14687,7 @@ const LADDER_OPTS = {
   // sameTable=true reuses the SAME table object for both "who's currently
   // selected" and "who gets clicked" — the no-rebind cell of the matrix.
   // sameTable=false selects a different table than the one clicked — the
-  // rebind cell, which the guard must send RESET_SIDEBAR_TO_DEFAULTS +
-  // PREVIEW_SAMPLES_CHANGED for.
+  // rebind cell, which the guard must send TABLE_SWITCHED for.
   function runToggleClickFixture(mode, sidebarOpenValue, sameTable) {
     const clicked = makeToggleTable([
       [{ tag: 'td', text: 'H1' }, { tag: 'td', text: 'Col2' }],
@@ -15205,7 +15226,7 @@ const LADDER_OPTS = {
     // table is stuck showing simplified values, so the main toggle must
     // show ON (the truth) and stop accepting input, and the settings area
     // dims via body.table-locked. APPLY_OK, a table switch
-    // (RESET_SIDEBAR_TO_DEFAULTS), and unbinding (delivery failure →
+    // (TABLE_SWITCHED), and unbinding (delivery failure →
     // setTableBound(false)) each lift the lock. ---
     enabledEl.checked = false;
     enabledEl.disabled = false;
@@ -15224,8 +15245,8 @@ const LADDER_OPTS = {
       enabledEl.disabled, false);
 
     onMessageHandler({ action: 'APPLY_BLOCKED', count: 1 }, {}, () => {});
-    onMessageHandler({ action: 'RESET_SIDEBAR_TO_DEFAULTS' }, {}, () => {});
-    eq('sidebar lock: a table switch (RESET_SIDEBAR_TO_DEFAULTS) lifts the lock',
+    onMessageHandler({ action: 'TABLE_SWITCHED' }, {}, () => {});
+    eq('sidebar lock: a table switch (TABLE_SWITCHED) lifts the lock',
       bodyClasses.has('table-locked'), false);
     eq('sidebar lock: a table switch re-enables the main toggle',
       enabledEl.disabled, false);
@@ -15449,13 +15470,16 @@ const LADDER_OPTS = {
 // fetchPreviewSamples() chain end to end (same eval harness shape as
 // appModelSettings_settingsPublish_deliveryFeedback_behavioral above).
 //
-// The bug: pullSettingsAndApplyToUI applies the pulled settings (correctly
-// setting enabledEl.checked = false), then calls fetchPreviewSamples(), whose
-// response callback calls setTableBound(true) once GET_PREVIEW_SAMPLES
-// resolves with a bound table — and setTableBound's bound branch
-// unconditionally does `enabledEl.checked = DR_DEFAULTS.enabled !== false`,
-// which is true, clobbering the pulled false. The comment that used to sit
-// above pullSettingsAndApplyToUI only reasoned about the no-table case.
+// The bug (as found): pullSettingsAndApplyToUI applied the pulled settings
+// (correctly setting enabledEl.checked = false), then called
+// fetchPreviewSamples(), whose response callback called setTableBound(true)
+// once GET_PREVIEW_SAMPLES resolved with a bound table — and setTableBound's
+// bound branch unconditionally did `enabledEl.checked = DR_DEFAULTS.enabled
+// !== false`, which is true, clobbering the pulled false. Sprint 9 patched
+// it by threading the pulled settings through fetchPreviewSamples; issue
+// #251 then removed the bound branch's default write entirely, which made
+// the threading unnecessary. This test stays as the regression pin either
+// way: a pulled enabled:false must survive the reopen.
 // ---------------------------------------------------------------------------
 (function appModelSettings_pulledEnabledSurvivesReopenOnBoundTable() {
   const defaultsSrc = sourceByName('defaults.js');
@@ -15577,6 +15601,186 @@ const LADDER_OPTS = {
     global.document = savedDoc;
     global.chrome = savedChrome;
     global.window = savedWindow;
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// Issue #251: the sidebar mirrors the model's settings on any table switch.
+// A shared harness (same eval shape as the reopen-bound test above, plus an
+// onMessage capture and a rangeExpr capture) drives sidebar.js's real
+// onMessage handler. The model holds enabled:false and a non-default
+// rangeExpr; each scenario first drifts the controls away from the model —
+// exactly what the old code left behind — then delivers the message under
+// test and asserts the panel snapped back to the model.
+// ---------------------------------------------------------------------------
+function makeIssue251SidebarHarness() {
+  const defaultsSrc = sourceByName('defaults.js');
+  const roundingSrc = sourceByName('lib/dr-number/rounding.js');
+  const coreSrc = sourceByName('lib/dr-number/core.js');
+  if (defaultsSrc === null || roundingSrc === null || coreSrc === null || messagingCode === null) {
+    return null;
+  }
+
+  function makeEl() {
+    return {
+      addEventListener() {}, removeEventListener() {},
+      classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+      style: {}, value: '', checked: false, disabled: false, textContent: '', innerHTML: '',
+      appendChild() {}, querySelector() { return makeEl(); }, querySelectorAll() { return []; },
+      getBoundingClientRect() { return { top: 0, left: 0, width: 0, height: 0, bottom: 0, right: 0 }; },
+      matches() { return false; }, closest() { return null; }, dataset: {},
+      setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
+    };
+  }
+
+  const statusEl = makeEl();
+  const enabledEl = makeEl();
+  const rangeExprEl = makeEl();
+
+  const bodyClasses = new Set();
+  const captureBody = {
+    classList: {
+      add(cls) { bodyClasses.add(cls); },
+      remove(cls) { bodyClasses.delete(cls); },
+      contains(cls) { return bodyClasses.has(cls); },
+      toggle(cls, force) {
+        if (force === undefined) {
+          if (bodyClasses.has(cls)) bodyClasses.delete(cls); else bodyClasses.add(cls);
+        } else if (force) bodyClasses.add(cls); else bodyClasses.delete(cls);
+      },
+    },
+    addEventListener() {},
+    get offsetWidth() { return 0; },
+  };
+
+  const captureDoc = {
+    addEventListener() {},
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    body: captureBody,
+    getElementById(id) {
+      if (id === 'status') return statusEl;
+      if (id === 'enabled') return enabledEl;
+      if (id === 'rangeExpr') return rangeExprEl;
+      return makeEl();
+    },
+    createElement() { return makeEl(); },
+  };
+
+  // The model's settings differ from the shipped defaults on two controls,
+  // so a handler that pulls is distinguishable from one that resets: after
+  // any refresh the panel must show enabled:false and rangeExpr 'B2:E8'.
+  const modelSettings = Object.assign({}, DR_DEFAULTS, { enabled: false, rangeExpr: 'B2:E8' });
+  let onMessageHandler = null;
+  const captureChrome = {
+    runtime: {
+      onMessage: { addListener(fn) { onMessageHandler = fn; } },
+      sendMessage() {},
+      lastError: null,
+    },
+    tabs: {
+      query(q, cb) { cb([{ id: 42 }]); },
+      sendMessage(tabId, msg, cb) {
+        if (msg.action === 'GET_SETTINGS') {
+          cb({ settings: modelSettings });
+        } else if (msg.action === 'GET_PREVIEW_SAMPLES') {
+          cb({ samples: { top: [], bottom: [] }, maxMag: 0 });
+        } else {
+          cb({ ok: true });
+        }
+      },
+    },
+  };
+
+  const savedDoc = global.document;
+  const savedChrome = global.chrome;
+  const savedWindow = global.window;
+  global.document = captureDoc;
+  global.chrome = captureChrome;
+  global.window = { addEventListener() {}, close() {}, getComputedStyle: () => ({ display: 'block' }) };
+
+  let evalError = null;
+  try {
+    eval(
+      defaultsSrc + '\n' +
+      roundingSrc + '\n' +
+      coreSrc + '\n' +
+      messagingCode + '\n' +
+      fs.readFileSync(path.join(__dirname, 'sidebar.js'), 'utf8')
+    );
+  } catch (e) {
+    evalError = e;
+  }
+
+  return {
+    statusEl, enabledEl, rangeExprEl, bodyClasses, evalError,
+    dispatch(msg) { onMessageHandler(msg, {}, () => {}); },
+    hasHandler() { return typeof onMessageHandler === 'function'; },
+    restore() {
+      global.document = savedDoc;
+      global.chrome = savedChrome;
+      global.window = savedWindow;
+    },
+  };
+}
+
+(function issue251_tableSwitchMirrorsModelSettings() {
+  const h = makeIssue251SidebarHarness();
+  if (!h) {
+    eq('switch-pull: source files (defaults/rounding/core/messaging) present in manifest',
+      false, true);
+    return;
+  }
+  try {
+    eq('switch-pull: sidebar.js loaded with no stub gaps', h.evalError, null);
+    eq('switch-pull: sidebar onMessage handler was captured', h.hasHandler(), true);
+    if (h.evalError !== null || !h.hasHandler()) return;
+
+    // Drift the panel away from the model: the pill shows on (as the old
+    // defaults reset left it), the range expression is blank, and the
+    // previous table's apply left the panel locked.
+    h.enabledEl.checked = true;
+    h.rangeExprEl.value = '';
+    h.dispatch({ action: 'APPLY_BLOCKED', count: 1 });
+    eq('switch-pull: precondition — the previous table\'s APPLY_BLOCKED locked the panel',
+      h.bodyClasses.has('table-locked'), true);
+
+    // The switch message: lift the lock, re-read the model.
+    h.dispatch({ action: 'TABLE_SWITCHED' });
+    eq('switch-pull: a table switch lifts the lock',
+      h.bodyClasses.has('table-locked'), false);
+    eq('switch-pull: a table switch re-enables the main toggle',
+      h.enabledEl.disabled, false);
+    eq('switch-pull: the main toggle mirrors the model\'s enabled:false after a switch',
+      h.enabledEl.checked, false);
+    eq('switch-pull: the range expression mirrors the model after a switch (pull, not defaults reset)',
+      h.rangeExprEl.value, 'B2:E8');
+  } finally {
+    h.restore();
+  }
+})();
+
+(function issue251_previewRefreshMirrorsModelSettings() {
+  const h = makeIssue251SidebarHarness();
+  if (!h) {
+    eq('refresh-pull: source files (defaults/rounding/core/messaging) present in manifest',
+      false, true);
+    return;
+  }
+  try {
+    eq('refresh-pull: sidebar.js loaded with no stub gaps', h.evalError, null);
+    eq('refresh-pull: sidebar onMessage handler was captured', h.hasHandler(), true);
+    if (h.evalError !== null || !h.hasHandler()) return;
+
+    // Drift the pill on, then deliver the stale-view signal. The old bare
+    // preview fetch ended in setTableBound(true), which reset the pill to
+    // the shipped default (on) — the model says off.
+    h.enabledEl.checked = true;
+    h.dispatch({ action: 'PREVIEW_SAMPLES_CHANGED' });
+    eq('refresh-pull: the main toggle mirrors the model\'s enabled:false after a preview refresh',
+      h.enabledEl.checked, false);
+  } finally {
+    h.restore();
   }
 })();
 


### PR DESCRIPTION
Closes #251.

## Product

Switching tables while the settings panel was open threw away what the panel showed and replaced it with the shipped defaults. Right-clicking a different table reset the master on/off switch alone, so a user who had turned rounding off saw the switch flip to "on" while the page still behaved as "off" — the panel misled them about the product's state. Clicking a different table's pill reset every control, so a tuned coarseness or range expression looked lost, and the new table was rounded with the factory settings rather than the ones on screen. The settings themselves were never lost: the model kept them, and closing and reopening the panel brought them back.

Now one rule holds everywhere: the model is the source. On any table switch the panel re-reads the model, and the newly connected table is synced to the model — the same sync that already ran on panel reopen. The panel and the table it controls can no longer disagree.

## Changes

Two moves, one rule. First, the sidebar re-reads the model's settings on every switch and every stale-view refresh, and redraws every control from them; the switch message is renamed to `TABLE_SWITCHED` because it no longer resets anything, and binding no longer writes the master toggle, which made sprint 9's threading of pulled settings back through the preview fetch unnecessary. Second — added after an independent review of the first commit found the panel could mirror settings the table did not have — the switch also applies the model to the clicked table (`applySidebarRounding` with the model's settings, the same apply the `SIDEBAR_OPENED` reconnect runs) instead of blind-toggling it with defaults. A switch therefore sends no `TABLE_TOGGLE_STATE`; the panel redraws from the pull. With the sidebar closed, and on same-table clicks, the pill remains a plain toggle.

Two orderings make the lock lifecycle (#262) hold: `TABLE_SWITCHED` goes out before the switch apply, so the previous table's lock lifts before the new table's own `APPLY_BLOCKED` can land; and the settings pull skips the master-toggle write while the lock is displayed, so a pull resolving under it cannot contradict the forced-on state. Moving the refresh onto the pull also closes the reopen race where a reconnect refresh could reset a pulled "off" back to the default.

One affordance shifts with this: with the panel open, revealing a different table's originals now takes two clicks — the first connects and syncs the table, the second toggles it. With the panel closed the pill is unchanged.

Test pins that froze the old contracts are updated, and six new behavioral tests drive the real message handlers end to end: the panel snapping to the model after a switch and after a refresh, the model's offset reaching the clicked table's rounding pass, a model holding enabled:false leaving the clicked table unrounded, the lock surviving a pull that resolves under it, and the switch-onto-a-locked-table message order (lift, then re-lock).

Rejected alternatives, one line each: fixing only the right-click path left the two switch paths disagreeing; showing the table's rounded state in the master switch on a switch left the panel's other controls claiming a rounding the table did not have.

## Tested

- `node chrome-extension/tests.js` — 1,945 pass, 0 fail (baseline before the change: 1,920).
- Red phases verified: 19 assertions fail without the first commit, 7 without the second (the reviewer re-verified the 7 independently against the pre-fix sources).
- Independent code review (Opus): first pass blocked on two HIGH findings; both fixed in the second commit; re-review verdict APPROVE with the remaining notes folded into the third commit and a follow-up issue.
- `scripts/check-files.sh --staged` — clean.

## Manual tests

1. Open the panel on a table, turn rounding off, then right-click a second table: the switch stays off and neither table shows rounding.
2. With the panel open and a custom offset set, click a different table's pill: the new table rounds with that offset (not the factory one), and the panel keeps showing it.
3. With the panel open and rounding off, click a different table's pill: the table connects and stays unrounded — the pill no longer force-rounds while the panel says off.
4. Lock a table (reload with a rounded table so the apply blocks), then switch to another table: the lock clears; switch back to the stuck table: the lock re-arms.
5. Close and reopen the panel on a bound table with rounding off: the switch still shows off.

## Reviewer notes

- Behavior change to weigh: with the panel open, a pill click on a different table now means "connect and sync to the panel", not "toggle with defaults". With the panel closed nothing changed. Decided on #251; the review findings that forced it are quoted there.
- The master switch's double duty on same-table clicks (rounded-state vs. settings) is out of scope — #236 and #245 track it, and the two review findings it produces (a same-table pill toggle never writes the record's on/off; the lock's forced ON can leak into a save through the still-live sliders) are filed as #272.
