### PR TITLE
chore(ci): the auto-versioning creates a branch that now auto-deletes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,9 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main
-        uses: actions/checkout@v4
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -28,8 +26,6 @@ jobs:
       - name: Detect which packages changed
         id: changes
         uses: dorny/paths-filter@v4
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           filters: |
             python:
@@ -78,6 +74,26 @@ jobs:
           print(f"chrome-extension/manifest.json: bumped to {mf['version']}")
           PY
 
+      - name: Verify the bumped version files still parse
+        if: steps.changes.outputs.python == 'true' || steps.changes.outputs.chrome == 'true'
+        run: |
+          python3 - <<'PY'
+          import json, pathlib, sys, tomllib
+          checks = (
+              ("chrome-extension/manifest.json", json.loads),
+              ("python/pyproject.toml", tomllib.loads),
+          )
+          for name, parse in checks:
+              path = pathlib.Path(name)
+              if not path.exists():
+                  continue
+              try:
+                  parse(path.read_text())
+              except Exception as exc:
+                  sys.exit(f"{name} no longer parses after the version bump: {exc}")
+              print(f"{name}: parses")
+          PY
+
       - name: Open version-bump PR if anything changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,4 +112,23 @@ jobs:
             --body "Automated version bump triggered by merge of PR #${{ github.event.pull_request.number }}." \
             --base main \
             --head "$BUMP_BRANCH")
-          gh pr merge "$PR_URL" --auto --squash
+          # Merge now rather than with --auto. The bump only edits version files on
+          # a branch cut from a green main, and no test reads the version, so there
+          # is nothing for the PR checks to prove. GitHub needs a moment to compute
+          # mergeability after the PR is created, hence the retry.
+          MERGED=""
+          for attempt in 1 2 3 4 5 6; do
+            if gh pr merge "$PR_URL" --squash; then
+              MERGED="yes"
+              break
+            fi
+            echo "Merge not accepted yet (attempt $attempt); retrying in 10 seconds."
+            sleep 10
+          done
+          if [ -z "$MERGED" ]; then
+            echo "Could not merge $PR_URL. Leaving the branch and the PR in place."
+            exit 1
+          fi
+          # Automatic head-branch deletion does not fire for merges made with the
+          # workflow token, so delete the bump branch here.
+          git push origin --delete "$BUMP_BRANCH"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
   file-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
   file-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version: '26'
       - name: Run ROUND_DYNAMIC (Google Sheets) tests
         run: node js/tests.js
       - name: Run chrome extension tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v5
         with:
           node-version: '24'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
       - name: Run ROUND_DYNAMIC (Google Sheets) tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Run ROUND_DYNAMIC (Google Sheets) tests
         run: node js/tests.js
       - name: Run chrome extension tests


### PR DESCRIPTION
## What changed

`bump-version.yml` merges the version PR itself with a squash and then deletes the bump branch, replacing `gh pr merge --auto --squash`. The merge retries for a minute; the delete runs only after a merge reports success, so a failed merge leaves both the PR and the branch in place.

A new step parses `chrome-extension/manifest.json` and `python/pyproject.toml` after the bump and before the commit. A broken file fails the job with the parse error and no PR is opened.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is removed from both steps that carried it. All three workflows move to `actions/checkout@v7`, which targets Node 24 on its own. `tests.yml` moves to `actions/setup-node@v7` and runs on Node 26.

## Why

Automatic head-branch deletion does not fire for merges made with the workflow token. `chore/version-bump-pr-261` and `chore/version-bump-pr-263` outlived their merges for two days, while every human-merged branch was deleted within two seconds. GitHub shows the same behaviour for app installation tokens in community discussion 63409, so the repository setting was never going to cover these. Deferred merging also means nothing of ours is running when the merge lands, so no later step can clean up. The delete has to sit beside the merge.

## Cost

The version PR merges without waiting for its checks. The bump branch is cut from a main that just passed and no test reads a version number, so the suite re-proved work from minutes earlier. It did cover one thing: `chrome-extension/tests.js` parses the manifest at start-up, so a malformed manifest would have failed there. The new parse step covers that case instantly and earlier in the chain.

No user-facing change.

## Expected behaviour

- [ ] The version PR opens, merges on its own, and its branch does not appear in the branch list afterwards.
- [ ] Version numbers advanced by one patch in both files.

## Rejected alternatives

To stop a retry: a scheduled prune of merged branches, and merging the version PR under a personal access token so deletion behaves like a human merge. Both were ruled out to avoid a janitor job and new credentials.
