### PR TITLE
fix: wait for the PR checks before merging the version bump

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -131,12 +131,16 @@ jobs:
                 echo "The bump conflicts with main. Leaving the branch and $PR_URL in place."
                 exit 1
                 ;;
+              BEHIND)
+                echo "main advanced past the bump branch. Leaving the branch and $PR_URL in place."
+                exit 1
+                ;;
             esac
             echo "Merge state is $STATE (attempt $attempt of 40); checking again in 15 seconds."
             sleep 15
           done
           if [ -z "$READY" ]; then
-            echo "Checks did not pass within 10 minutes. Leaving the branch and $PR_URL in place."
+            echo "No merge-ready verdict within 10 minutes. Leaving the branch and $PR_URL in place."
             exit 1
           fi
           if ! gh pr merge "$PR_URL" --squash; then

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -115,9 +115,11 @@ jobs:
           # main requires the PR checks to pass, and they take a minute or two
           # from PR creation, so wait for GitHub's merge-state verdict before
           # merging. CLEAN, HAS_HOOKS, and UNSTABLE all mean the merge will be
-          # accepted. BLOCKED covers pending and failed checks alike, so a
-          # failed check waits out the deadline. On timeout, leave the PR and
-          # the branch for a human, as on any other refusal.
+          # accepted. DIRTY (a conflict) and BEHIND (main advanced past the
+          # bump) are terminal, so they end the run at once. BLOCKED covers
+          # pending and failed checks alike, so a failed check waits out the
+          # deadline. On timeout, leave the PR and the branch for a human, as
+          # on any other refusal.
           READY=""
           for attempt in $(seq 1 40); do
             STATE=$(gh pr view "$PR_URL" --json mergeStateStatus \

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -112,20 +112,34 @@ jobs:
             --body "Automated version bump triggered by merge of PR #${{ github.event.pull_request.number }}." \
             --base main \
             --head "$BUMP_BRANCH")
-          # Merge now rather than with --auto. The bump only edits version files on
-          # a branch cut from a green main, and no test reads the version, so there
-          # is nothing for the PR checks to prove. GitHub needs a moment to compute
-          # mergeability after the PR is created, hence the retry.
-          MERGED=""
-          for attempt in 1 2 3 4 5 6; do
-            if gh pr merge "$PR_URL" --squash; then
-              MERGED="yes"
-              break
-            fi
-            echo "Merge not accepted yet (attempt $attempt); retrying in 10 seconds."
-            sleep 10
+          # main requires the PR checks to pass, and they take a minute or two
+          # from PR creation, so wait for GitHub's merge-state verdict before
+          # merging. CLEAN, HAS_HOOKS, and UNSTABLE all mean the merge will be
+          # accepted. BLOCKED covers pending and failed checks alike, so a
+          # failed check waits out the deadline. On timeout, leave the PR and
+          # the branch for a human, as on any other refusal.
+          READY=""
+          for attempt in $(seq 1 40); do
+            STATE=$(gh pr view "$PR_URL" --json mergeStateStatus \
+              --jq .mergeStateStatus || echo UNKNOWN)
+            case "$STATE" in
+              CLEAN|HAS_HOOKS|UNSTABLE)
+                READY="yes"
+                break
+                ;;
+              DIRTY)
+                echo "The bump conflicts with main. Leaving the branch and $PR_URL in place."
+                exit 1
+                ;;
+            esac
+            echo "Merge state is $STATE (attempt $attempt of 40); checking again in 15 seconds."
+            sleep 15
           done
-          if [ -z "$MERGED" ]; then
+          if [ -z "$READY" ]; then
+            echo "Checks did not pass within 10 minutes. Leaving the branch and $PR_URL in place."
+            exit 1
+          fi
+          if ! gh pr merge "$PR_URL" --squash; then
             echo "Could not merge $PR_URL. Leaving the branch and the PR in place."
             exit 1
           fi


### PR DESCRIPTION
## Problem

After #276 merged, the bump workflow opened PR #278 and tried to merge it at once. main requires the `test` and `file-gate` checks, which finish about 80 seconds after PR creation. The workflow's merge loop retried six times over one minute and gave up seconds before the checks passed. Every future bump loses the same race. The old comment claimed the checks prove nothing for a version-only diff; the branch rules require them regardless.

## Change

In `.github/workflows/bump-version.yml`, replace the blind merge-retry loop with a poll on the PR's `mergeStateStatus`: wait up to ten minutes (40 polls, 15 seconds apart) until GitHub reports the merge will be accepted (`CLEAN`, `HAS_HOOKS`, or `UNSTABLE`), then merge and delete the branch as before. `DIRTY` (a conflict) fails at once. `BLOCKED` covers pending and failed checks alike, so a failed check waits out the deadline; the run then fails and leaves the PR and the branch for a human — the same fallback as today.

Rejected alternative: `gh pr merge --auto`. The workflow exits before the merge happens, so its branch-deletion step cannot run, and auto-delete does not fire for workflow-token merges (see #264/#265 cleanup).

## Cost

One step edited, +27/−13 lines. Worst case adds ten minutes of runner time when a check fails or hangs.

## Tested

- `bash -n` on the extracted step script passes.
- The workflow file parses as YAML.
- `scripts/check-files.sh --staged` passes.
- `MergeStateStatus` value meanings verified against GitHub's GraphQL introspection.

## Manual tests

- Merge any PR touching `python/` or `chrome-extension/`. The bump PR should open, merge itself within about two minutes, and leave no branch behind.
