### PR TITLE
fix(extension): issues 303 and 304

### DIFF
--- a/chrome-extension/lib/dr-capture/render.js
+++ b/chrome-extension/lib/dr-capture/render.js
@@ -73,6 +73,7 @@ const CAPTURE_STYLES = [
   '.cap-table th, .cap-table td { border: 1px solid #bbb; padding: 4px 10px; text-align: right; }',
   '.cap-table th { background: #f2f2f2; }',
   '.cap-simplified { text-decoration: underline dotted #3d85c6; cursor: help; }',
+  '.cap-lost { color: #8a6d3b; font-style: italic; }',
   '.cap-locked, .cap-empty { color: #8a6d3b; background: #fcf8e3; padding: 6px 10px; border-radius: 4px; margin: 8px 0; }',
   '.cap-switch { display: flex; justify-content: space-between; margin: 2px 0; }',
   '.cap-switch b { font-weight: 600; }',
@@ -139,7 +140,11 @@ function captureFilenameFor(opts) {
 
 function renderCaptureHeader(state) {
   const meta = state.meta || {};
-  const glyph = CAPTURE_MARK_GLYPHS[state.mark] || '';
+  // Own-property guard: only the three mark words resolve a glyph. A bare
+  // lookup would resolve prototype property names too, and the glyph is
+  // interpolated as markup.
+  const glyph = Object.prototype.hasOwnProperty.call(CAPTURE_MARK_GLYPHS, state.mark)
+    ? CAPTURE_MARK_GLYPHS[state.mark] : '';
   const rows = [
     ['Page', displayValue(meta.url)],
     ['Title', displayValue(meta.title)],
@@ -165,9 +170,10 @@ function renderCaptureHeader(state) {
 // escaped text — never cloned markup. mode 'displayed' shows what the screen
 // showed; a simplified cell (its original differs from what it shows) gets
 // the original in its title, so hover reveals it the way the live page does.
-// mode 'originals' shows the originals themselves; a cell with no stored
-// original shows its displayed text, which for an unchanged cell IS the
-// original.
+// mode 'originals' shows the originals themselves. A cell with no stored
+// original splits on the rounded marker: with the marker the original is
+// lost and renders as that absence, never a substituted value; without it
+// the cell was never rounded, so its displayed text IS the original.
 function renderCapTable(table, mode) {
   const byRow = [];
   for (let i = 0; i < table.cells.length; i++) {
@@ -179,6 +185,9 @@ function renderCapTable(table, mode) {
     const cellsHtml = (rowCells || []).map(function (cell) {
       const tag = cell.role === 'th' ? 'th' : 'td';
       if (mode === 'originals') {
+        if (cell.original === null && cell.wearsMarker) {
+          return '<' + tag + ' class="cap-lost">original lost</' + tag + '>';
+        }
         const value = cell.original !== null ? cell.original : cell.text;
         return '<' + tag + '>' + escapeHtml(value) + '</' + tag + '>';
       }
@@ -203,6 +212,14 @@ function renderFocusedTable(state, lockedStatusText) {
   if (!table) {
     return '<p class="cap-empty">No table was bound when this capture was taken. ' +
       'The state below records everything the extension had.</p>';
+  }
+  // An error record holds a failure, not cells; rendering it through the
+  // table path would caption null counts over an empty table and read as a
+  // finding about the page. The failure is the finding.
+  if (table.kind === 'unknown') {
+    return '<p class="cap-empty">Serialization of this table failed: ' +
+      escapeHtml(table.error || '') +
+      '. The state below records everything the extension had.</p>';
   }
   const lockedHtml = table.locked
     ? '<p class="cap-locked">' + escapeHtml(lockedStatusText || '') + '</p>'
@@ -295,10 +312,16 @@ function renderSidebarLikeness(state, lockedStatusText) {
 }
 
 // Both contexts' log rows, labeled by provenance. An empty buffer is a
-// finding, so it renders as a sentence, never as a missing section.
+// finding, so it renders as a sentence, never as a missing section — and a
+// missing snapshot is a different finding: the state pull for that context
+// failed, so no buffer arrived at all.
 function renderCaptureLogs(state) {
   const log = state.log || {};
   const section = function (label, snap) {
+    if (!snap) {
+      return '<h3>' + escapeHtml(label) + '</h3>' +
+        '<p class="cap-empty">The page state pull failed; no log snapshot arrived.</p>';
+    }
     const rows = snap && Array.isArray(snap.entries) ? snap.entries : [];
     const dropped = snap && snap.dropped ? '<li>(' + escapeHtml(String(snap.dropped)) +
       ' earlier row(s) dropped past the cap)</li>' : '';

--- a/chrome-extension/lib/dr-capture/state.js
+++ b/chrome-extension/lib/dr-capture/state.js
@@ -72,6 +72,10 @@ function collectCaptureState(deps) {
           isOutside,
           text: cellObj.getDisplayedText(),
           original,
+          // Per cell, so the renderer can tell a lost original (marker,
+          // original: null) from a cell that was never rounded (no marker,
+          // original: null) without repeating the pairing logic.
+          wearsMarker,
         });
       }
     }

--- a/chrome-extension/lib/dr-table/detect.js
+++ b/chrome-extension/lib/dr-table/detect.js
@@ -397,16 +397,18 @@ class GridAdapter {
         tn.nodeValue = s;
         if (cellEl.classList) cellEl.classList.add(GRID_ROUNDED_CLASS);
       },
-      // The displayed text: what the screen shows right now — always the
-      // live text node, never the originals port. On a rounded grid cell
+      // The displayed text: what the screen shows right now — the cell's
+      // whole live text, never the originals port. On a rounded grid cell
       // getText() above answers with the ORIGINAL (the engine's contract:
       // classification must see pre-round text), so a consumer that needs
       // "as displayed" — the capture's state serializer — reads this one.
+      // The whole text, not findCellTextNode's one node: a cell that builds
+      // its text from several pieces (a number and a unit in separate
+      // nodes) displays all of them, matching the native read.
       // Declared after setText so the GR3b/GR6j source guards' fixed scan
       // window over _makeCellObj still covers the write path.
       getDisplayedText() {
-        const tn = findCellTextNode(cellEl);
-        return tn ? tn.nodeValue : (cellEl.textContent || '');
+        return cellEl.textContent || '';
       },
     };
   }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -17984,7 +17984,9 @@ function makeIssue251SidebarHarness() {
     nodeType: 1,
     childNodes: [{ nodeType: 3, nodeValue: text }],
     classList: { add() {}, contains() { return false; } },
-    textContent: text,
+    // Like the DOM: textContent derives from the child nodes, so a setText
+    // patch through nodeValue shows up in the whole-cell read.
+    get textContent() { return this.childNodes[0].nodeValue; },
   });
   const adapter = new GridAdapter({}, { originalsPort: makePort() });
 
@@ -18003,6 +18005,37 @@ function makeIssue251SidebarHarness() {
     typeof rounded.getDisplayedText === 'function'
       ? { engine: rounded.getText(), displayed: rounded.getDisplayedText() } : null,
     { engine: '98,765', displayed: '99,000' });
+})();
+
+// A grid cell that builds its text from several pieces — a number and a unit
+// in separate nodes — displays all of them. findCellTextNode answers with one
+// deepest text node (the write path's patch target); the displayed-text read
+// answers with the cell's whole text, matching the native read. Regression
+// for #303: "1,234<span>%</span>" recorded text: "%".
+(function captureDisplayedTextReadsWholeCell() {
+  const makePort = () => {
+    const m = new Map();
+    return { has: (k) => m.has(k), get: (k) => m.get(k), set: (k, v) => m.set(k, v) };
+  };
+  const adapter = new GridAdapter({}, { originalsPort: makePort() });
+  const textNode = (text) => ({ nodeType: 3, nodeValue: text });
+  const span = (text) => ({ nodeType: 1, childNodes: [textNode(text)] });
+  const makePiecedCellEl = (children, wholeText) => ({
+    nodeType: 1,
+    childNodes: children,
+    classList: { add() {}, contains() { return false; } },
+    textContent: wholeText,
+  });
+
+  const numberThenUnit = adapter._makeCellObj(
+    makePiecedCellEl([textNode('1,234'), span('%')], '1,234%'));
+  eq('capture-reads: a grid cell of number-then-unit pieces displays the whole text',
+    numberThenUnit.getDisplayedText(), '1,234%');
+
+  const unitThenNumber = adapter._makeCellObj(
+    makePiecedCellEl([span('$'), textNode('1,234')], '$1,234'));
+  eq('capture-reads: a grid cell of unit-then-number pieces displays the whole text',
+    unitThenNumber.getDisplayedText(), '$1,234');
 })();
 
 (function capturePlainOriginalTextRead() {
@@ -18117,9 +18150,11 @@ function makeIssue251SidebarHarness() {
       rowCount: 3, columnCount: 2,
     });
   eq('capture-state: a header cell serializes with role th',
-    recA.cells[0], { row: 0, col: 0, role: 'th', isOutside: false, text: 'Amount', original: null });
+    recA.cells[0],
+    { row: 0, col: 0, role: 'th', isOutside: false, text: 'Amount', original: null, wearsMarker: false });
   eq('capture-state: a simplified cell carries displayed text AND its original',
-    recA.cells[1], { row: 1, col: 0, role: 'td', isOutside: false, text: '99,000', original: '98,765' });
+    recA.cells[1],
+    { row: 1, col: 0, role: 'td', isOutside: false, text: '99,000', original: '98,765', wearsMarker: true });
   eq('capture-state: a cell with no stored original serializes original: null',
     recA.cells[2].original, null);
   eq('capture-state: an outside row keeps its flag',
@@ -18170,6 +18205,57 @@ function makeIssue251SidebarHarness() {
     { kind: 'unknown', cells: [], hasError: true });
   eq('capture-state: the tables after a throwing one still serialize in full',
     errState.tables[1].cells.length, 1);
+})();
+
+// The per-cell marker flag reaches the cell record (#304). The serializer
+// already reads the rounded marker to compute the locked pairing; the
+// renderer needs it per cell to tell a lost original (marker, original: null)
+// from a cell that was never rounded (no marker, original: null).
+(function captureStateCarriesMarkerFlag() {
+  if (typeof globalThis.collectCaptureState !== 'function') return;
+
+  const markerClassList = (marked) => ({ contains: (c) => marked && c === 'dr-ext-rounded' });
+  const makeCellEl = (marked) => ({ classList: markerClassList(marked) });
+
+  const marked = makeCellEl(true);
+  const unmarked = makeCellEl(false);
+  const lost = makeCellEl(true);
+  const table = { _rows: [{ cells: [
+    { el: marked, text: '99,000' },
+    { el: unmarked, text: 'Amount' },
+    { el: lost, text: '99,000' },
+  ] }] };
+  const store = {
+    getRegisteredTables: () => [table],
+    getSelectedTable: () => null,
+    getSettings: () => ({}),
+    getTableAppliedFlag: () => 'simplified',
+    getTableRoundOptions: () => null,
+    getTableMaxMagnitude: () => null,
+    getTableOriginalText: (t, cellEl) => (cellEl === marked ? '98,765' : undefined),
+  };
+  const adapterFor = () => ({
+    isVirtualized: () => false,
+    getRows: () => table._rows.map((row) => ({
+      isOutside: false,
+      getCells: () => row.cells.map((cell) => ({
+        el: cell.el,
+        tagName: 'TD',
+        getDisplayedText: () => cell.text,
+      })),
+    })),
+  });
+
+  const cells = collectCaptureState({ store, adapterFor }).tables[0].cells;
+  eq('capture-state: a marked cell record carries wearsMarker true beside its original',
+    { wearsMarker: cells[0].wearsMarker, original: cells[0].original },
+    { wearsMarker: true, original: '98,765' });
+  eq('capture-state: an unmarked cell record carries wearsMarker false',
+    { wearsMarker: cells[1].wearsMarker, original: cells[1].original },
+    { wearsMarker: false, original: null });
+  eq('capture-state: a lost original keeps the locked pairing readable per cell',
+    { wearsMarker: cells[2].wearsMarker, original: cells[2].original },
+    { wearsMarker: true, original: null });
 })();
 
 // --- content.js: the GET_CAPTURE_STATE wire action ---
@@ -18437,6 +18523,106 @@ function makeIssue251SidebarHarness() {
   eq('capture-render: a capture with no page url gets the no-source slug',
     filenameFor({ at: new Date(2026, 8, 9, 14, 5, 6), url: null }),
     'dr-capture-2026-09-09-no-source-140506.html');
+})();
+
+// --- lib/dr-capture: the renderer keeps the state's absences (#304) ---
+//
+// The state records three kinds of absence honestly; the page a human reads
+// must present each as an absence, never as something it is not: a lost
+// original never becomes a substituted value, an error record never becomes
+// an empty table, a missing log snapshot never becomes an empty buffer. The
+// glyph lookup resolves only the three mark words, so a hostile mark cannot
+// pull a prototype property into the document.
+(function captureRendererAbsenceHonesty() {
+  if (typeof globalThis.DR_CAPTURE !== 'object') return;
+  const buildCaptureDocument = DR_CAPTURE.buildCaptureDocument;
+  const LOCKED_TEXT = 'This table\'s original values are no longer available. Reload the page to change it.';
+
+  const makeState = (over) => Object.assign({
+    captureFormat: 1,
+    meta: { url: 'https://www.example.com/prices', title: 'Prices',
+      version: '2.1.50', platform: 'test-platform', at: '2026-09-09T18:00:00.000Z' },
+    mark: 'negative',
+    note: '',
+    settings: { enabled: true },
+    activeTableIndex: 0,
+    tables: [],
+    lensPreview: null,
+    sidebarView: null,
+    log: {
+      content: { entries: [], dropped: 0, limit: 50 },
+      sidebar: { entries: [], dropped: 0, limit: 50 },
+    },
+    page: { url: 'https://www.example.com/prices', title: 'Prices' },
+    fixtureSeed: null,
+  }, over || {});
+
+  // A locked table: the marker with no original behind it. The originals view
+  // renders the absence, never the displayed (rounded) value.
+  const locked = buildCaptureDocument({
+    state: makeState({
+      tables: [{
+        kind: 'native', appliedFlag: 'simplified', lastRoundOptions: null,
+        maxMagnitude: null, locked: true, rowCount: 1, columnCount: 2,
+        cells: [
+          { row: 0, col: 0, role: 'td', isOutside: false,
+            text: '99,000', original: null, wearsMarker: true },
+          { row: 0, col: 1, role: 'td', isOutside: false,
+            text: 'n/a', original: null, wearsMarker: false },
+        ],
+      }],
+    }),
+    lockedStatusText: LOCKED_TEXT,
+  });
+  // The originals table alone: from its heading to its closing tag. The JSON
+  // island later in the document carries the displayed value by design.
+  const originalsTable = (locked.split('with the originals')[1] || '').split('</table>')[0];
+  eq('capture-render: a lost original renders as lost, never as the displayed value',
+    /original lost/.test(originalsTable) && !originalsTable.includes('99,000'), true);
+  eq('capture-render: a never-rounded cell still shows its text in the originals view',
+    originalsTable.includes('n/a'), true);
+
+  // A focused error record: a failure notice, not an empty table.
+  const failed = buildCaptureDocument({
+    state: makeState({
+      tables: [{
+        kind: 'unknown', appliedFlag: null, lastRoundOptions: null,
+        maxMagnitude: null, locked: false, rowCount: null, columnCount: null,
+        cells: [], error: 'hostile walk',
+      }],
+    }),
+    lockedStatusText: LOCKED_TEXT,
+  });
+  const focusedHalf = failed.split('<h2>Registry')[0];
+  eq('capture-render: a focused error record renders as a failure notice with its error text',
+    /serialization[\s\S]{0,40}failed/i.test(focusedHalf) && focusedHalf.includes('hostile walk'),
+    true);
+  eq('capture-render: a focused error record renders no table and no null counts',
+    failed.includes('<table class="cap-table">') || failed.includes('null row(s)'), false);
+
+  // A missing log snapshot (the state pull failed) is distinct from an empty
+  // buffer: the sidebar half here IS an empty buffer and keeps its sentence.
+  const pullFailed = buildCaptureDocument({
+    state: makeState({
+      log: { content: null, sidebar: { entries: [], dropped: 0, limit: 50 } },
+    }),
+    lockedStatusText: LOCKED_TEXT,
+  });
+  eq('capture-render: a missing log snapshot renders as a failed state pull',
+    pullFailed.includes('state pull failed'), true);
+  eq('capture-render: an empty buffer keeps its own sentence beside a failed pull',
+    pullFailed.includes('Nothing was logged.'), true);
+
+  // The glyph lookup resolves only the three mark words: a prototype property
+  // name must not reach the document as a glyph.
+  const hostileMark = buildCaptureDocument({
+    state: makeState({ mark: 'constructor' }),
+    lockedStatusText: LOCKED_TEXT,
+  });
+  eq('capture-render: a mark outside the three words resolves no glyph',
+    hostileMark.includes('[native code]'), false);
+  eq('capture-render: the hostile mark word still renders escaped as text',
+    hostileMark.includes('<span>constructor</span>'), true);
 })();
 
 // --- sidebar: the capture section and its glue ---

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -129,6 +129,7 @@ One term per concept, across every platform and every document. Use the [Retired
 | finish | The explicit gesture that writes the capture file — the "Save capture" button. Nothing saves without that press. |
 | capture state | The plain-value record embedded in the capture: full registry detail for every table, the settings record, the lens preview samples, the sidebar view state, the log rows, the page and extension metadata, and the fixture seed. Carries a one-integer format version so a later tool can read old captures. |
 | log buffer | A per-context list of the last 50 log rows the extension recorded, with a count of rows dropped past the cap. Each row also goes to the console, so devtools output is unchanged. |
+| state pull | The one request the sidebar sends for the page-side half of a capture. A failed state pull still saves the capture: the sidebar half is present, and the page half renders as an absence. |
 | fixture seed | The focused table's raw markup, carried verbatim in the capture state — and escaped for reading in the visible file — so a regression fixture can be rebuilt from it. |
 
 ## Working terms


### PR DESCRIPTION
## Product

Issues 303 and 304

The rule after this change: the rendered page asserts only what the state records. A grid cell records its whole displayed text. A lost original renders as "original lost". A failed serialization renders as a failure notice carrying its error text. A failed state pull renders as that failure, apart from an empty log buffer, which keeps its own sentence.

## Doc impact

The vocabulary gains the state pull term. The extension README and the design doc already state the honesty rule this change makes hold, so neither needed an edit.

## Tested

- Extension suite: 2,116 passed, 0 failed. Thirteen new tests: the whole-cell grid read in both piece orders, the per-cell marker flag in the serialized state, and the four renderings — lost original, never-rounded cell, error record, failed state pull — plus the glyph guard.
- Library suite: 256 passed, 0 failed. Doc examples: 67 passed, 0 failed.

## Manual tests

- [ ] On a vendor grid whose cells hold a number and a unit in separate pieces, take a capture; the capture's table shows each cell's whole text.
- [ ] Apply rounding, reload the extension (locking the table), take a capture; the originals view shows "original lost" in the changed cells, never a value.
- [ ] Open the sidebar on a page the content script cannot reach and save a capture; the content-script log section says the state pull failed.

## Reviewer notes

Closes #303. Closes #304.

The never-rounded case stays: a cell with no marker and no stored original still shows its displayed text in the originals view, because for an unchanged cell that text is the original. #297 (hover text as best-effort originals for locked tables) is untouched by this change.
