### PR TITLE
fix(extension): record an extracted cell as simplified only on a confirmed change

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1238,20 +1238,30 @@ function roundTable(table, options) {
           if (newNum !== m.numStr) patches.push({ index: m.index, numStr: m.numStr, newNum });
         }
         if (patches.length === 0) continue;
-        // Stash the pristine HTML, superscript ranges, and the surviving
-        // (link-filtered) match indices — measured against the pre-round
-        // text, BEFORE applyExtractedPatches shortens it — in the registry
-        // instead of four separate dataset attributes. collectNumericCells
-        // reads this record back instead of re-measuring the (now-rounded,
-        // differently-offset) live element against stored original text. See
-        // finalizeExtractedDecision and collectNumericCells for the read side.
-        DR_STORE.setTableOriginal(table, cell, {
+        // Measure the pristine HTML, superscript ranges, and the surviving
+        // (link-filtered) match indices against the pre-round text, BEFORE
+        // applyExtractedPatches shortens it — but store the record only after
+        // a patch confirms the cell changed. The registry record replaces
+        // four separate dataset attributes; collectNumericCells reads it back
+        // instead of re-measuring the (now-rounded, differently-offset) live
+        // element against stored original text. See finalizeExtractedDecision
+        // and collectNumericCells for the read side.
+        const originalRecord = {
           html: cell.innerHTML,
           value: originalValue,
           supRanges: getSuperscriptRanges(cell),
           linkFilteredIdx: info.matches.map((m) => m.index),
-        });
-        applyExtractedPatches(cell, patches);
+        };
+        const landed = applyExtractedPatches(cell, patches);
+        if (landed < patches.length) {
+          DR_LOG.warn('Dynamic Rounding: ' + (patches.length - landed) + ' of ' +
+            patches.length + ' extracted-cell patches did not land.');
+        }
+        // Record only a confirmed change: with every patch skipped the screen
+        // keeps its text, and storing the original, the hover text, or the
+        // marker would record a simplification that never happened.
+        if (landed === 0) continue;
+        DR_STORE.setTableOriginal(table, cell, originalRecord);
         cell.title = `Original: ${originalValue}`;
         cell.classList.add('dr-ext-rounded');
         appliedAny = true;

--- a/chrome-extension/lib/dr-table/detect.js
+++ b/chrome-extension/lib/dr-table/detect.js
@@ -687,11 +687,15 @@ function replaceTextPreservingHTML(cell, originalText, newText) {
  * by changes at higher positions. Only the specific text node containing each
  * number is touched; <sup>, <a>, and all other surrounding nodes are left intact.
  *
- * Fails silently (skips the patch) if the node cannot be found or if numStr is
- * not present at the expected position — same behaviour as the old fallback.
+ * A patch is skipped when its node cannot be found or numStr is not at the
+ * expected position. Returns the number of patches that landed: the caller
+ * records the cell as simplified only on a count above zero, because a
+ * skipped patch leaves the screen unchanged.
+ *
+ * @returns {number} how many patches landed
  */
 function applyExtractedPatches(cell, patches) {
-  if (!patches || patches.length === 0) return;
+  if (!patches || patches.length === 0) return 0;
   const walker = document.createTreeWalker(cell, NodeFilter.SHOW_TEXT, null, false);
   const nodePositions = [];
   let flatLen = 0;
@@ -701,6 +705,7 @@ function applyExtractedPatches(cell, patches) {
     flatLen += node.nodeValue.length;
   }
   const sorted = [...patches].sort((a, b) => b.index - a.index);
+  let landed = 0;
   for (const { index, numStr, newNum } of sorted) {
     const pos = nodePositions.find(
       p => p.start <= index && index < p.start + p.node.nodeValue.length
@@ -710,7 +715,9 @@ function applyExtractedPatches(cell, patches) {
     const v = pos.node.nodeValue;
     if (v.substring(i, i + numStr.length) !== numStr) continue;
     pos.node.nodeValue = v.substring(0, i) + newNum + v.substring(i + numStr.length);
+    landed++;
   }
+  return landed;
 }
 
 // --- Table/grid detection predicates ---

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -1698,6 +1698,114 @@ function withLinkCreateTreeWalker(fn) {
   });
 })();
 
+// --- 3c. A silently failed extracted patch records nothing (#301) ---
+//
+// The patch step skips silently when the number is not at its flat-text
+// position in the live nodes (the text moved between classification and
+// patching). The write path records a cell as simplified only when a patch
+// confirmed a change: no stored original, no hover text, no marker, no
+// simplified flag — and a log row states the failure so a capture shows it
+// instead of a false success.
+
+(function extractedPatchOptsFor() {
+  globalThis.EXTRACTED_PATCH_OPTS = {
+    enabled: true, simplifyMixedCells: true, simplifyDates: false, simplifyTimes: false,
+    simplifyFirstRow: true, simplifyFirstColumn: true,
+    simplifyMixedPercent: true, simplifyMixedCurrency: true,
+    offsetTop: -0.5, offsetOther: -0.5, numTop: 1,
+    rangeExpr: '',
+  };
+})();
+
+(function failedExtractedPatchRecordsNothing() {
+  // The walker's one text node does not hold the extracted number at its
+  // expected position, so every patch skips.
+  global.document.createTreeWalker = function () {
+    let done = false;
+    return {
+      nextNode: function () {
+        if (done) return null;
+        done = true;
+        return { nodeValue: 'Cost: [moved text] per month' };
+      },
+    };
+  };
+  const table = makeMockTable([[
+    { tag: 'td', text: 'Cost: 123,456 per month' },
+  ]]);
+  try {
+    roundTable(table, EXTRACTED_PATCH_OPTS);
+    const cell = table.rows[0].cells[0];
+    eq('patch-honesty: a cell whose patches all skip gets no marker',
+      cell.classList.contains('dr-ext-rounded'), false);
+    eq('patch-honesty: a cell whose patches all skip gets no hover text',
+      cell.title, '');
+    eq('patch-honesty: a cell whose patches all skip stores no original',
+      DR_STORE.getTableOriginalText(table, cell), undefined);
+    eq('patch-honesty: a table whose only change failed keeps form original',
+      DR_STORE.getTableAppliedFlag(table), 'original');
+    eq('patch-honesty: the failure leaves a warn row naming the patch step',
+      DR_LOG.snapshot().entries.some(
+        (row) => row.level === 'warn' && /extracted-cell patch/.test(row.text)),
+      true);
+  } finally {
+    delete global.document.createTreeWalker;
+    DR_STORE.unregisterTable(table);
+  }
+})();
+
+// Control: the same cell with its number where the patch expects it still
+// records in full — the honesty gate never blocks a confirmed change.
+(function landedExtractedPatchStillRecords() {
+  const table = makeMockTable([[
+    { tag: 'td', text: 'Cost: 123,456 per month' },
+  ]]);
+  try {
+    withCreateTreeWalker(function () {
+      roundTable(table, EXTRACTED_PATCH_OPTS);
+    });
+    const cell = table.rows[0].cells[0];
+    eq('patch-honesty: a landed patch changes the cell text',
+      cell.innerText.includes('123,456'), false);
+    eq('patch-honesty: a landed patch stamps the marker and hover text',
+      cell.classList.contains('dr-ext-rounded') &&
+        cell.title === 'Original: Cost: 123,456 per month',
+      true);
+    eq('patch-honesty: a landed patch stores the original',
+      DR_STORE.getTableOriginalText(table, cell), 'Cost: 123,456 per month');
+    eq('patch-honesty: a landed patch flips the form',
+      DR_STORE.getTableAppliedFlag(table), 'simplified');
+  } finally {
+    DR_STORE.unregisterTable(table);
+  }
+})();
+
+// The patch step reports what it did: the landed count is the write path's
+// only evidence that the screen changed.
+(function applyExtractedPatchesReturnsLandedCount() {
+  global.document.createTreeWalker = function () {
+    let done = false;
+    return {
+      nextNode: function () {
+        if (done) return null;
+        done = true;
+        return { nodeValue: 'A 100 B 200' };
+      },
+    };
+  };
+  try {
+    const landed = applyExtractedPatches({}, [
+      { index: 2, numStr: '100', newNum: '90' },
+      { index: 8, numStr: '999', newNum: '1,000' },
+    ]);
+    eq('patch-honesty: applyExtractedPatches returns the landed count', landed, 1);
+    eq('patch-honesty: an empty patch list lands zero patches',
+      applyExtractedPatches({}, []), 0);
+  } finally {
+    delete global.document.createTreeWalker;
+  }
+})();
+
 // --- 4. Spec-scope guards ---
 
 (function quoteScopeGuards() {


### PR DESCRIPTION
## Product

On some mixed-text cells the extension recorded a simplification that never reached the screen. The write path stored the original, stamped the hover text and the marker, and counted the cell toward the table's simplified state before the one step that can fail — patching the number inside the cell's text — and that step skips silently when the number is not where the earlier read said. The user saw an untreated table while the pillbox, the sidebar, and any capture taken on the table all claimed it was simplified; the stored "original" was byte-identical to what the cell showed.

The rule after this change: a cell is recorded as simplified only when its text confirmably changed. A cell whose patches all skip keeps no hover text, no marker, and no stored original, and a table whose every change failed reports itself raw. Every patch that does not land leaves a log row, so a capture taken on such a table shows the failure. No recovery step exists or is needed for past sessions: the false records lived only in page memory and end with the page.

This closes the defect your first real capture surfaced (#301).

## Doc impact

No doc impact.

## Tested

- Extension suite: 2,114 passed, 0 failed. Eleven new tests: a cell whose patches all skip records nothing and logs the failure; a landed patch still records in full (control); the patch step reports its landed count.
- Library suite: 256 passed, 0 failed. Doc examples: 67 passed, 0 failed.

## Manual tests

- [ ] On the page from the 2026-09-09 capture, apply rounding to the table that failed; the cells that do not change now carry no hover text, and a new capture records them with no stored original and a warn row naming the patch step.

## Reviewer notes

Closes #301.

The grid write path has an adjacent gap of the same honesty class (a per-cell write that can no-op silently while the table's flag still flips); it spans code this diff does not touch, so it goes to a follow-up issue rather than this branch.
