### PR TITLE
fix(extension): capture follow-ups — pull guard, glyph pin, header line

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -770,13 +770,27 @@ function buildCaptureStateResponse() {
   const cellCounts = state.tables.map(function (t) { return t.cells.length; });
   DR_LOG.debug('Dynamic Rounding: capture state collected (' + state.tables.length +
     ' table(s), cells per table: [' + cellCounts.join(', ') + ']).');
+  // The serializer guards per table; this walk of the bound table is the one
+  // step after it that can throw, and an unguarded throw here would discard
+  // the whole page-side half — the serialized registry, the fixture seed,
+  // and the log rows. On a throw: null, a warn row (taken into the snapshot
+  // below), and the rest of the response stands.
+  let lensPreview = null;
+  if (selected) {
+    try {
+      lensPreview = extractPreviewSamples(selected);
+    } catch (e) {
+      DR_LOG.warn('Dynamic Rounding: lens preview extraction failed during capture (' +
+        String(e && e.message ? e.message : e) + ').');
+    }
+  }
   return Object.assign({
     page: {
       url: typeof location !== 'undefined' ? location.href : null,
       title: (typeof document !== 'undefined' && typeof document.title === 'string')
         ? document.title : null,
     },
-    lensPreview: selected ? extractPreviewSamples(selected) : null,
+    lensPreview: lensPreview,
     log: DR_LOG.snapshot(),
   }, state);
 }

--- a/chrome-extension/lib/dr-capture/render.js
+++ b/chrome-extension/lib/dr-capture/render.js
@@ -153,10 +153,16 @@ function renderCaptureHeader(state) {
   // The note is one free-text field; line breaks the user typed survive
   // through the pre-wrap rule on .cap-note.
   const noteRow = '<p><b>Remarks:</b> ' + escapeHtml(displayValue(state.note)) + '</p>';
+  // What the file holds, stated where the person about to attach it reads
+  // it: the script-free CSP makes the file safe to open, and this line
+  // covers the other half — the values it carries.
+  const holdsRow = '<p class="cap-band">This capture holds the page’s table contents, ' +
+    'its address and title, and browser details. Share it as you would share the page.</p>';
   return '<header>' +
     '<h1>DynamicRounding capture</h1>' +
     '<p class="cap-mark">' + glyph + ' <span>' + escapeHtml(displayValue(state.mark)) + '</span></p>' +
     '<dl>' + rows + '</dl>' +
+    holdsRow +
     '<section class="cap-note">' + noteRow + '</section>' +
     '</header>';
 }

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -96,6 +96,9 @@ globalThis.collectCaptureState = collectCaptureState;
 globalThis.buildCaptureStateResponse = buildCaptureStateResponse;
 // Expose the lib/dr-capture package bundle, mirroring DR_NUMBER above.
 globalThis.DR_CAPTURE = DR_CAPTURE;
+// Expose the renderer's glyph map so the glyph pin can compare it against
+// the sidebar's buttons.
+globalThis.CAPTURE_MARK_GLYPHS = CAPTURE_MARK_GLYPHS;
 // Expose toggle infrastructure for tests
 globalThis.tableToggles = tableToggles;
 globalThis.trackedTables = trackedTables;
@@ -18482,6 +18485,81 @@ function makeIssue251SidebarHarness() {
     /sidebar: DR_LOG\.snapshot\(\)/.test(sidebarJsSrc), true);
   eq('capture-ui: a failed state pull still saves and records the failure',
     /DR_LOG\.warn\([^)]*pull failed/.test(sidebarJsSrc), true);
+})();
+
+// --- capture follow-ups: the pull guard, the glyph pin, the header line ---
+
+// #305: the serializer guards per table; the response composer's
+// lens-preview step is the one step after it that walks the bound table.
+// Unguarded, a throw there discards the whole page-side half — the
+// serialized registry, the fixture seed, and the log rows.
+(function capturePullSurvivesThrowingPreview() {
+  if (typeof globalThis.buildCaptureStateResponse !== 'function') return;
+  const prevSelected = DR_STORE.getSelectedTable();
+  const throwing = {
+    get rows() { throw new Error('hostile preview walk'); },
+  };
+  DR_STORE.registerTable(throwing);
+  DR_STORE.setSelectedTable(throwing);
+  let response = null;
+  let threw = false;
+  try {
+    response = buildCaptureStateResponse();
+  } catch (e) {
+    threw = true;
+  } finally {
+    DR_STORE.setSelectedTable(prevSelected);
+    DR_STORE.unregisterTable(throwing);
+  }
+  eq('capture-wire: a throwing lens preview keeps the page-side half',
+    {
+      threw,
+      tablesIsArray: !!response && Array.isArray(response.tables),
+      lensPreview: response ? response.lensPreview : 'response lost',
+      hasLog: !!(response && response.log),
+    },
+    { threw: false, tablesIsArray: true, lensPreview: null, hasLog: true });
+  eq('capture-wire: the discarded lens preview leaves a warn row',
+    DR_LOG.snapshot().entries.some(
+      (row) => row.level === 'warn' && /lens preview/.test(row.text)),
+    true);
+})();
+
+// #308: the mark glyphs live in two machine copies — the sidebar's buttons
+// and the renderer's map — and one copy cannot read the other (static
+// markup against a content-script constant). This pin holds them together:
+// a glyph change that lands in one place fails here, naming the other.
+(function captureGlyphCopiesMatch() {
+  const sidebarHtmlSrc = fs.readFileSync(path.join(__dirname, 'sidebar.html'), 'utf8');
+  const buttonGlyphs = {};
+  const buttonRe = /data-mark="([a-z]+)"[^>]*>([^<]+)</g;
+  let m;
+  while ((m = buttonRe.exec(sidebarHtmlSrc)) !== null) {
+    buttonGlyphs[m[1]] = m[2].replace(/&#(\d+);/g,
+      (_, code) => String.fromCodePoint(Number(code)));
+  }
+  eq('capture-glyphs: the sidebar buttons and the renderer map carry the same three glyphs',
+    buttonGlyphs, CAPTURE_MARK_GLYPHS);
+})();
+
+// #310: the file says what it holds where the person about to attach it
+// reads it — the safe-to-attach claim covers script safety only.
+(function captureHeaderStatesContents() {
+  if (typeof globalThis.DR_CAPTURE !== 'object') return;
+  const html = DR_CAPTURE.buildCaptureDocument({
+    state: {
+      captureFormat: 1,
+      meta: { url: 'https://www.example.com/x', title: 'X', version: 'v', platform: 'p', at: 't' },
+      mark: 'positive', note: '', settings: {}, activeTableIndex: null,
+      tables: [], lensPreview: null, sidebarView: null,
+      log: { content: null, sidebar: null }, page: null, fixtureSeed: null,
+    },
+    lockedStatusText: '',
+  });
+  eq('capture-header: the header says what the file holds',
+    html.includes('table contents') &&
+      html.includes('Share it as you would share the page.'),
+    true);
 })();
 
 // --- content.js: the extension stands down on capture pages ---


### PR DESCRIPTION
## Product

Three follow-ups from the capture review, each small.

The page-side half of a capture — the serialized tables, the fixture seed, and the log rows — could be lost to one unguarded step. Every table serializes under its own guard, and then the lens-preview extraction ran with none; a page whose preview extraction throws is exactly the page whose capture arrived empty, indistinguishable from an unreachable page. The extraction now stands behind the same rule as the tables: on a throw the capture records the absence and a log row names the failure, and everything already collected stays.

The three mark glyphs exist in two machine copies — the buttons a user presses and the map the saved file prints from — and the button markup cannot read the renderer's constant. A suite pin now compares the two, so a glyph change that lands in one place fails the suite naming the other.

The capture file states it is safe to attach anywhere, and that claim covers script safety only. The header now says what the file holds — the table contents, the page address and title, and browser details — with the rule "share it as you would share the page", so the person about to attach a capture of a private page is warned by the file itself.

## Doc impact

No doc impact.

## Tested

- Extension suite: 2,107 passed, 0 failed. Four new tests: the page-side half survives a throwing preview extraction and logs it; the glyph copies match (verified failable by mutating one copy); the header line renders.
- Library suite: 256 passed, 0 failed. Doc examples: 67 passed, 0 failed.

## Manual tests

- [ ] Open a saved capture; the header carries the one-line statement of what the file holds.

## Reviewer notes

Closes #305. Closes #308. Closes #310.

For the glyphs, one machine copy was the preferred fix; the sidebar's buttons are static markup and cannot read the renderer's map without moving button construction into script, a larger change than the drift risk warrants. The pin is the issue's named alternative.
