### PR TITLE
fix(extension): count a grid's form from landed writes

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1075,11 +1075,21 @@ function roundTable(table, options) {
     const { results: cellTargets, maxMag } = computeGridRoundedValues(table, opts);
     DR_STORE.setTableMaxMagnitude(table, maxMag);
     let appliedAny = false;
+    let skippedWrites = 0;
     for (const { cellObj, targetValue } of cellTargets) {
       // null means "leave unchanged" — excluded, out-of-range, or no change needed.
       if (targetValue === null) continue;
-      cellObj.setText(targetValue);
-      appliedAny = true;
+      // setText reports whether the write landed; a cell with no text piece
+      // skips, and a skipped write never counts toward the form — the same
+      // rule as the extracted-cell path (#301, #315).
+      if (cellObj.setText(targetValue) === true) {
+        appliedAny = true;
+      } else {
+        skippedWrites++;
+      }
+    }
+    if (skippedWrites > 0) {
+      DR_LOG.warn('Dynamic Rounding: ' + skippedWrites + ' grid cell write(s) did not land.');
     }
     DR_STORE.setTableAppliedFlag(table, appliedAny ? 'simplified' : 'original');
     syncSwitchForTable(table);

--- a/chrome-extension/lib/dr-table/detect.js
+++ b/chrome-extension/lib/dr-table/detect.js
@@ -388,7 +388,9 @@ class GridAdapter {
       },
       setText(s) {
         const tn = findCellTextNode(cellEl);
-        if (tn === null) return; // no-op: cell has no text node to patch
+        // No text node to patch: the write skips, and the caller reads the
+        // false so a skipped write never counts toward the table's form.
+        if (tn === null) return false;
         // Store the original value once, through the port.
         if (!port.has(cellEl)) {
           port.set(cellEl, tn.nodeValue);
@@ -396,6 +398,7 @@ class GridAdapter {
         // Patch in place — NEVER replace the node (preserves React fiber identity).
         tn.nodeValue = s;
         if (cellEl.classList) cellEl.classList.add(GRID_ROUNDED_CLASS);
+        return true;
       },
       // The displayed text: what the screen shows right now — the cell's
       // whole live text, never the originals port. On a rounded grid cell

--- a/chrome-extension/tests.js
+++ b/chrome-extension/tests.js
@@ -8604,6 +8604,62 @@ function makeE2EGridWrapper(rowData) {
 })();
 
 // ---------------------------------------------------------------------------
+// Grid form honesty (#315): the per-cell write reports whether it landed,
+// and the table's form counts confirmed writes — the same rule as the
+// extracted-cell fix (#301). A grid cell can classify as roundable through
+// the whole-text fallback yet hold no text piece for the nodeValue write to
+// patch; such a write skips, and a skipped write must not flip the form.
+// ---------------------------------------------------------------------------
+
+(function gridSetTextReportsLanded() {
+  const makePort = () => {
+    const m = new Map();
+    return { has: (k) => m.has(k), get: (k) => m.get(k), set: (k, v) => m.set(k, v) };
+  };
+  const adapter = new GridAdapter({}, { originalsPort: makePort() });
+
+  const withNode = adapter._makeCellObj(makeGridCellWithTextNode('8584629'));
+  eq('grid-honesty: setText reports true when the write lands',
+    withNode.setText('8,500,000'), true);
+
+  const bareEl = makeElementNode('', []);
+  bareEl.textContent = '8584629';
+  const bare = adapter._makeCellObj(bareEl);
+  eq('grid-honesty: setText reports false when the cell has no text piece',
+    bare.setText('8,500,000'), false);
+  eq('grid-honesty: a skipped write adds no marker',
+    bareEl.classList.contains('dr-ext-rounded'), false);
+})();
+
+(function e2e_gridFormCountsConfirmedWrites() {
+  const grid = makeE2EGridWrapper([
+    ['8584629', '286'],
+  ]);
+  // Strip every cell's text pieces while keeping the text readable through
+  // the whole-text fallback: classification still computes targets, and the
+  // nodeValue write has nothing to patch — every write skips.
+  for (const cell of grid.cellEls) {
+    cell.textContent = cell.childNodes[0] ? cell.childNodes[0].nodeValue : '';
+    cell.childNodes = [];
+    cell.children = [];
+  }
+  try {
+    const opts = Object.assign({}, DR_DEFAULTS, { simplifyFirstRow: true, simplifyFirstColumn: true });
+    roundTable(grid.wrapperEl, opts);
+    eq('grid-honesty: a write with no text piece adds no marker through roundTable',
+      grid.cellEls[0].classList.contains('dr-ext-rounded'), false);
+    eq('grid-honesty: a grid whose every write skipped keeps form original',
+      DR_STORE.getTableAppliedFlag(grid.wrapperEl), 'original');
+    eq('grid-honesty: the skipped writes leave a warn row',
+      DR_LOG.snapshot().entries.some(
+        (row) => row.level === 'warn' && /grid cell write/.test(row.text)),
+      true);
+  } finally {
+    DR_STORE.unregisterTable(grid.wrapperEl);
+  }
+})();
+
+// ---------------------------------------------------------------------------
 // E2E-GR2: resetTable after roundTable — Text node restored in place, class
 // removed, drOriginal cleared, childNodes.length still unchanged.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Product

On a grid, the change to one cell can quietly do nothing: the cell classifies as roundable through its whole text, and the edit step then finds no text piece to change, so it skips. The skip was invisible — the code doing the edit reported nothing back — and the table's stored on/off state counted every attempt as a success. A grid where every edit skipped kept its raw values on screen while the pillbox and the sidebar switch showed the table as simplified, and a capture taken there recorded the same false state.

The per-cell records were already honest: the changed-cell mark and the saved original were only written on a real edit. Only the table-level state lied.

The rule after this change, the same one the mixed-text fix (#301) set: the table's on/off state counts only edits that actually changed a cell. A grid whose every edit skips stays "off", the controls show the truth, and the skipped edits are written to the extension's event log so a capture shows them. No recovery is needed for past sessions — the false state lived only in page memory and ended with the page.

## Doc impact

No doc impact.

## Tested

- Extension suite: 2,146 passed, 0 failed. Six new tests: the per-cell edit reports whether it landed, a skipped edit adds no mark, and a grid whose every edit skipped keeps its state off and logs the skips; a landed edit still counts (existing tests).
- Library suite: 256 passed, 0 failed. Doc examples: 67 passed, 0 failed.

## Manual tests

- [ ] None — the trigger needs a grid cell that reads as a number through its whole text while holding no directly editable text piece, which no known site reproduces on demand; the suite covers the shape synthetically.

## Reviewer notes

Closes #315.

The scroll-redraw pass needed no change: it already checks for a text piece before editing and never touches the table's on/off state.
